### PR TITLE
Added a step after deploy to trigger runscope tests

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -30,3 +30,6 @@ deploy:
           token: $HIPCHAT_TOKEN
           room-id: $HIPCHAT_ROOM_ID
           from-name: wercker
+      - script:
+          name: Run Runscope tests
+          code: curl $RUNSCOPE_TRIGGER_URL


### PR DESCRIPTION
There's a bucket of tests that are setup in Runscope to test Northstar on production. These tests act as additional validation of deployed code.

The curl request alone is enough to trigger the tests, and the `RUNSCOPE_TRIGGER_URL` has been setup in wercker.

cc: @blisteringherb 