### PR TITLE
Make it sparse

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -36,7 +36,7 @@ class UserController extends \BaseController {
         //@TODO: is there a better way to get this to the mutator?
         Session::flash('country', $input['country']);
         foreach($input as $key => $value) {
-          if(isset($value)) {
+          if(empty($value)) {
             $user->$key = $value;
           }
         }

--- a/app/database/migrations/2014_11_21_164546_create_users_table.php
+++ b/app/database/migrations/2014_11_21_164546_create_users_table.php
@@ -20,10 +20,10 @@ class CreateUsersTable extends Migration {
 		    $collection->text('mobile');
 
 			/* Email address - forced to lowercase */
-		    $collection->unique('email');
+		    $collection->sparse('email');
 
 		    /* Mobile phone number */
-		    $collection->text('mobile');
+		    $collection->sparse('mobile');
 
 		    /* Password */
 		    $collection->text('password');


### PR DESCRIPTION
The `email` and `mobile` fields should be sparse, not unique. 
This will allow people to have null, or no email/mobile set and still be 'unique'

Refs dosomething/voting-app#274

@jonuy 