### PR TITLE
Fixes failing phpunit and runscope tests

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -36,7 +36,7 @@ class UserController extends \BaseController {
         //@TODO: is there a better way to get this to the mutator?
         Session::flash('country', $input['country']);
         foreach($input as $key => $value) {
-          if(empty($value)) {
+          if(!empty($value)) {
             $user->$key = $value;
           }
         }

--- a/app/tests/CampaignTest.php
+++ b/app/tests/CampaignTest.php
@@ -31,9 +31,8 @@ class CampaignTest extends TestCase {
    * @return void
    */
   public function testGetCampaignsFromUser()
-  {   
-    $parameters = array('email' => 'test@dosomething.org',);
-    $response = $this->call('GET', '1/users/campaigns', $parameters, array(), $this->server);
+  {
+    $response = $this->call('GET', '1/users/email/test@dosomething.org/campaigns', array(), array(), $this->server);
     $content = $response->getContent();
 
     // The response should return a 200 OK status code

--- a/app/tests/UserTest.php
+++ b/app/tests/UserTest.php
@@ -31,9 +31,8 @@ class UserTest extends TestCase {
    * @return void
   */
   public function testGetDataFromUser()
-  {   
-    $parameters = array('email' => 'test@dosomething.org',);
-    $response = $this->call('GET', '1/users', $parameters, array(), $this->server);
+  {
+    $response = $this->call('GET', '1/users/email/test@dosomething.org', array(), array(), $this->server);
     $content = $response->getContent();
 
     // The response should return a 200 OK status code


### PR DESCRIPTION
#### What's this PR do?
Fixes failing phpunit and runscope tests

#### Where should the reviewer start?
- `UserController.php`: previous logic would only save values that were null
- `CampaignTest.php` and `UserTest.php`: route to GET user data was previously modified to `/users/{term}/{id}`. This updates the tests to match that.

#### How should this be manually tested?
- `$ vendor/bin/phpunit`
- and Runscope tests should pass

@angaither 