### PR TITLE
Forward user registration events to droops.

### DIFF
--- a/app/Northstar/Services/Drupal.php
+++ b/app/Northstar/Services/Drupal.php
@@ -42,6 +42,7 @@ class DrupalAPI {
   public function register($user)
   {
     $user->birthdate = date('Y-m-d', strtotime($user->birthdate));
+    $user->user_registration_source = $user->source;
     $response = $this->client->post('users', [
       'body' => json_encode($user),
       ]);

--- a/app/Northstar/Services/Drupal.php
+++ b/app/Northstar/Services/Drupal.php
@@ -35,4 +35,17 @@ class DrupalAPI {
     }
     return $response->json();
   }
+
+  /**
+   * Forward registration to drupal.
+   */
+  public function register($user)
+  {
+    $user->birthdate = date('Y-m-d', strtotime($user->birthdate));
+    $response = $this->client->post('users', [
+      'body' => json_encode($user),
+      ]);
+    return $response->json();
+
+  }
 }

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -30,9 +30,11 @@ class UserController extends \BaseController {
     $input = Input::all();
 
     // Does this user exist already?
-    $user = User::where('email', '=', $check['email'])
-                    ->orWhere('mobile', '=', $check['mobile'])
-                    ->first();
+    if (Input::has('email')) {
+      $user = User::where('email', '=', $check['email'])->first();
+    } elseif (Input::has('mobile')) {
+      $user = User::where('mobile', '=', $check['mobile'])->first();
+    }
 
     // If there is no user found, create a new one.
     if (!$user) {
@@ -57,8 +59,7 @@ class UserController extends \BaseController {
         if ($key == 'interests'){
           $interests = array_map('trim', explode(',', $value));
           $user->push('interests', $interests, true);
-        }
-        elseif (!empty($value)) {
+        } elseif (!empty($value)) {
           $user->$key = $value;
         }
       }

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -62,6 +62,20 @@ class UserController extends \BaseController {
           $user->$key = $value;
         }
       }
+      // Do we need to forward this user to drupal?
+      if ($user->email && !$user->drupal_id) {
+        try {
+          $drupal = new Northstar\Services\Drupal\DrupalAPI;
+          $response = $drupal->register($user);
+          $user->drupal_id = $response['uid'];
+          return Response::json($response, 200);
+        } catch (Exception $e) {
+          // @TODO: figure out what to do if a user isn't created.
+          // This could be a failure for so many reasons
+          // User is already registered/email taken
+          // Or just a general failure - do we try again?
+        }
+      }
 
       $user->save();
 


### PR DESCRIPTION
This forwards all users who have emails but no drupal id into the drooops

Unclear how we handle drupal registration failures right now....

Fixes #61