### PR TITLE
Campaign signup endpoint

### DIFF
--- a/app/Northstar/Services/Drupal.php
+++ b/app/Northstar/Services/Drupal.php
@@ -47,7 +47,7 @@ class DrupalAPI {
         'body' => json_encode($user),
         ]);
       return $response->json();
-    } catch (Exception $e) {
+    } catch (\Exception $e) {
       // whatever.
       return;
     }

--- a/app/Northstar/Services/Drupal.php
+++ b/app/Northstar/Services/Drupal.php
@@ -1,27 +1,26 @@
 <?php namespace Northstar\Services\Drupal;
 
+use GuzzleHttp\Client;
+use Config;
+
 class DrupalAPI {
 
   protected $client;
 
   public function __construct()
   {
-    $base_url = \Config::get('services.drupal.url');
-    if (\App::environment('local')) {
-      $base_url .=  ":" . \Config::get('services.drupal.port');
-    }
-    $base_url .= '/api';
-    $version = \Config::get('services.drupal.version');
-    $client = new \GuzzleHttp\Client([
-      'base_url' => [$base_url . '/{version}/', ['version' => $version]],
-      'defaults' => array(
+    $base_url = Config::get('services.drupal.url');
+    $version = Config::get('services.drupal.version');
+
+    $this->client = new Client([
+      'base_url' => [$base_url . '/api/{version}/', ['version' => $version]],
+      'defaults' => [
         'headers' => [
           'Content-Type' => 'application/json',
           'Accept' => 'application/json'
-          ]
-        ),
+        ]
+      ],
     ]);
-    $this->client = $client;
   }
 
   public function campaigns($id = NULL)

--- a/app/Northstar/Services/Drupal.php
+++ b/app/Northstar/Services/Drupal.php
@@ -52,4 +52,28 @@ class DrupalAPI {
       return;
     }
   }
+
+  /**
+   * Create a new campaign signup on the Drupal site.
+   * @param $drupal_id    String - UID of user on the Drupal site
+   * @param $campaign_id  String - NID of campaign on the Drupal site
+   * @param $source       String - Sign up source (e.g. web, iPhone, etc.)
+   *
+   * @return String - Signup ID
+   */
+  public function campaignSignup($drupal_id, $campaign_id, $source)
+  {
+    $payload = [
+      'uid' => $drupal_id,
+      'source' => $source
+    ];
+
+    $response = $this->client->post('campaigns/' . $campaign_id . '/signup', [
+      'body' => json_encode($payload)
+    ]);
+
+    dd($response);
+
+    return $response->sid;
+  }
 }

--- a/app/Northstar/Services/Drupal.php
+++ b/app/Northstar/Services/Drupal.php
@@ -68,11 +68,10 @@ class DrupalAPI {
       'source' => $source
     ];
 
+    // @TODO: This request must be authenticated as the relevant user.
     $response = $this->client->post('campaigns/' . $campaign_id . '/signup', [
       'body' => json_encode($payload)
     ]);
-
-    dd($response);
 
     return $response->sid;
   }

--- a/app/config/local/services.php
+++ b/app/config/local/services.php
@@ -12,12 +12,11 @@
   |
   */
 
-return array(
+return [
 
-  'drupal' => array(
-    'url' => 'http://dev.dosomething.org',
+  'drupal' => [
+    'url' => 'http://dev.dosomething.org:8888',
     'version' => 'v1',
-    'port' => '8888',
-  ),
+  ],
 
-);
+];

--- a/app/controllers/CampaignController.php
+++ b/app/controllers/CampaignController.php
@@ -3,17 +3,6 @@
 class CampaignController extends \BaseController {
 
   /**
-   * Display a listing of the resource.
-   * GET users/campaigns
-   *
-   * @return Response
-  */
-  public function index()
-  {
-
-  }
-
-  /**
    * Returns a user's campaigns
    *
    * @param $term - string

--- a/app/controllers/CampaignController.php
+++ b/app/controllers/CampaignController.php
@@ -57,7 +57,6 @@ class CampaignController extends \BaseController {
     // Validate request
     $validator = Validator::make($request, [
       'campaign_id' => ['required', 'integer'],
-      'user' => ['sometimes', 'exists:users,_id'],
       'source' => ['required']
     ]);
 
@@ -65,14 +64,8 @@ class CampaignController extends \BaseController {
       return Response::json($validator->messages(), 401);
     }
 
-    // If given a Northstar user ID, get that user. Otherwise, use
-    // the currently authenticated Northstar user.
-    if($request['user']) {
-      $user = User::find($request['user']);
-    } else {
-      $token = Request::header('Session');
-      $user = Token::userFor($token);
-    }
+    // Get the currently authenticated Northstar user.
+    $user = User::current();
 
     // Check if campaign signup already exists.
     $campaign = $user->campaigns()->where('nid', $campaign_id)->first();

--- a/app/controllers/CampaignController.php
+++ b/app/controllers/CampaignController.php
@@ -50,6 +50,9 @@ class CampaignController extends \BaseController {
    */
   public function signup($campaign_id)
   {
+    // @TODO: Not yet fully implemented, return error for now.
+    return Response::json('Not yet implemented.', 501);
+
     // Build request object
     $request = Input::all();
     $request['campaign_id'] = $campaign_id;

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -117,6 +117,7 @@ class UserController extends \BaseController {
    * Update the specified resource in storage.
    * PUT /users
    *
+   * @param $id - User ID
    * @return Response
    */
   public function update($id)
@@ -151,6 +152,7 @@ class UserController extends \BaseController {
    * Delete a user resource.
    * DELETE /users/:id
    *
+   * @param $id - User ID
    * @return Response
    */
   public function destroy($id)
@@ -206,8 +208,8 @@ class UserController extends \BaseController {
   }
 
   /**
-   *  Logout a user: remove the specified active token from the database
-   *  @param user User
+   * Logout a user by removing the currently authenticated user token from the database.
+   * @return Response
    */
   public function logout()
   {

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -6,6 +6,11 @@ use Illuminate\Auth\Reminders\RemindableTrait;
 use Illuminate\Auth\Reminders\RemindableInterface;
 use Jenssegers\Mongodb\Model as Eloquent;
 
+/**
+ * Class User
+ *
+ * @method static where()
+ */
 class User extends Eloquent implements UserInterface, RemindableInterface {
 
   use UserTrait, RemindableTrait;
@@ -128,7 +133,9 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
   /**
    * Determines validation rules for user registration and authentication
    *
-   * @var array
+   * @param $data - User data to be validated
+   * @param bool $auth - Whether validation should use authentication ruleset
+   * @return bool - Success/failure of validation
    */
   public function validate($data, $auth = false)
   {
@@ -168,6 +175,19 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
     $token->save();
 
     return $token;
+  }
+
+  /**
+   * Get the currently authenticated user from the session token.
+   *
+   * @return User
+   */
+  public static function current()
+  {
+    $token = Request::header('Session');
+    $user = Token::userFor($token);
+
+    return $user;
   }
 
 }

--- a/app/tests/CampaignTest.php
+++ b/app/tests/CampaignTest.php
@@ -51,10 +51,12 @@ class CampaignTest extends TestCase {
    */
   public function testSubmitCampaignSignup()
   {   
-    // Campaign sid
-    $sid = array('sid' => '235');
+    $payload = [
+      'user' => '5480c950bffebc651c8b456f',  // Test user ID
+      'source' => 'test'
+    ];
 
-    $response = $this->call('POST', 'v1/campaigns/123/signup', array(), array(), $this->server, json_encode($sid));
+    $response = $this->call('POST', 'v1/campaigns/123/signup', [], [], $this->server, json_encode($payload));
     $content = $response->getContent();
     $data = json_decode($content, true);
 

--- a/app/tests/UserTest.php
+++ b/app/tests/UserTest.php
@@ -76,8 +76,8 @@ class UserTest extends TestCase {
     $content = $response->getContent();
     $data = json_decode($content, true);
 
-    // The response should return a 201 Created status code
-    $this->assertEquals(201, $response->getStatusCode());
+    // The response should return a 200 Okay status code
+    $this->assertEquals(200, $response->getStatusCode());
 
     // Response should be valid JSON
     $this->assertJson($content);


### PR DESCRIPTION
Initial attempt at a `/campaigns/{id}/signup` endpoint. :construction: 

### Open Questions
 - How does Northstar authenticate to the Drupal API? Where do we handle permissions for things?
 - We're checking for an existing `Campaign` resource on Northstar, but some users may have signed up directly through Drupal. Is it bad that there are two error conditions for the same thing?
 - Is it unexpected/weird to have different behavior based on presence of the `user` parameter? I wonder if it makes more sense to have that always/never required.

/cc @angaither @jonuy 