### PR TITLE
Mock Drupal API for signup & reportback tests.

### DIFF
--- a/app/Northstar/Http/Controllers/CampaignController.php
+++ b/app/Northstar/Http/Controllers/CampaignController.php
@@ -15,9 +15,9 @@ class CampaignController extends BaseController {
    */
   protected $drupal;
 
-  public function __construct()
+  public function __construct(DrupalAPI $drupal)
   {
-    $this->drupal = new DrupalAPI;
+    $this->drupal = $drupal;
   }
 
   /**

--- a/app/database/seeds/DatabaseSeeder.php
+++ b/app/database/seeds/DatabaseSeeder.php
@@ -33,8 +33,10 @@ class UserTableSeeder extends Seeder {
     // @TODO: Why is this being called... it's called for each unit test.
     // Without this line, the unit tests fail.
     DB::table('users')->delete();
-    User::create(array(
-      '_id' => '5480c950bffebc651c8b456f',
+
+    // Non-signed up user
+    User::create([
+      '_id' => '5430e850dt8hbc541c37tt3d',
       'email' => 'test@dosomething.org',
       'mobile' => '5555555555',
       'password' => 'secret',
@@ -48,15 +50,33 @@ class UserTableSeeder extends Seeder {
       'birthdate' => '12/17/91',
       'first_name' => 'First',
       'last_name' => 'Last',
-      'campaigns' => array(
-        array(
-          'nid' => 100,
-          'rbid' => 10,
-          'quantity' => 100,
-          '_id' => '5480c950bffebc651c8b456e'
-        )
-      )
-    ));
+    ]);
+
+    // Signed up user
+    User::create([
+      '_id' => '5480c950bffebc651c8b456f',
+      'email' => 'test2@dosomething.org',
+      'mobile' => '5554445555',
+      'password' => 'secret',
+      'drupal_id' => 123457,
+      'addr_street1' => '123',
+      'addr_street2' => '456',
+      'addr_city' => 'Paris',
+      'addr_state' => 'Florida',
+      'addr_zip' => '555555',
+      'country' => 'US',
+      'birthdate' => '12/17/91',
+      'first_name' => 'First',
+      'last_name' => 'Last',
+      'campaigns' => [
+        [
+          '_id' => '5480c950bffebc651c8b456e',
+          'drupal_id' => 123,
+          'signup_id' => 100
+        ]
+      ]
+    ]);
+
     User::create(array(
       'email' => 'info@dosomething.org',
       'mobile' => '5556669999',
@@ -72,6 +92,7 @@ class UserTableSeeder extends Seeder {
       'first_name' => 'John',
       'last_name' => 'Doe'
     ));
+
     User::create(array(
       '_id' =>'5480c950bffebc651c8b4570',
       'email' => 'delete-test@ds.org',

--- a/app/tests/CampaignTest.php
+++ b/app/tests/CampaignTest.php
@@ -1,6 +1,14 @@
 <?php
 
+use Northstar\Models\User;
+use Northstar\Models\Campaign;
+
 class CampaignTest extends TestCase {
+
+  protected $drupalMock;
+
+  protected $server;
+  protected $signedUpServer;
 
   /**
    * Migrate database and set up HTTP headers
@@ -10,17 +18,31 @@ class CampaignTest extends TestCase {
   public function setUp()
   {
     parent::setUp();
+
+    // Enable route filters on tests
     Route::enableFilters();
 
+    // Migrate & seed database
     Artisan::call('migrate');
     $this->seed();
 
+    // Prepare server headers
     $this->server = array(
       'CONTENT_TYPE' => 'application/json',
       'HTTP_X-DS-Application-Id' => '456',
       'HTTP_X-DS-REST-API-Key' => 'abc4324',
-      'HTTP_Session' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz0='
+      'HTTP_Session' => User::find('5430e850dt8hbc541c37tt3d')->login()->key
     );
+
+    $this->signedUpServer = array(
+      'CONTENT_TYPE' => 'application/json',
+      'HTTP_X-DS-Application-Id' => '456',
+      'HTTP_X-DS-REST-API-Key' => 'abc4324',
+      'HTTP_Session' => User::find('5480c950bffebc651c8b456f')->login()->key
+    );
+
+    // Mock Drupal API class
+    $this->drupalMock = $this->mock('Northstar\Services\DrupalAPI');
   }
 
 
@@ -51,25 +73,26 @@ class CampaignTest extends TestCase {
    */
   public function testSubmitCampaignSignup()
   {
-      // @TODO: Test has external dependency... need to mock DrupalAPI!
-//    $payload = [
-//      'user' => '5480c950bffebc651c8b456f',  // Test user ID
-//      'source' => 'test'
-//    ];
-//
-//    $response = $this->call('POST', 'v1/campaigns/123/signup', [], [], $this->server, json_encode($payload));
-//    $content = $response->getContent();
-//    $data = json_decode($content, true);
-//
-//    // The response should return a 201 Created status code
-//    $this->assertEquals(201, $response->getStatusCode());
-//
-//    // Response should be valid JSON
-//    $this->assertJson($content);
-//
-//    // Response should return created at and sid columns
-//    $this->assertArrayHasKey('created_at', $data);
-//    $this->assertArrayHasKey('signup_id', $data);
+    $payload = [
+      'source' => 'test'
+    ];
+
+    // Mock successful response from Drupal API
+    $this->drupalMock->shouldReceive('campaignSignup')->once()->andReturn(100);
+
+    $response = $this->call('POST', 'v1/campaigns/123/signup', [], [], $this->server, json_encode($payload));
+    $content = $response->getContent();
+    $data = json_decode($content, true);
+
+    // The response should return a 201 Created status code
+    $this->assertEquals(201, $response->getStatusCode());
+
+    // Response should be valid JSON
+    $this->assertJson($content);
+
+    // Response should return created at and sid columns
+    $this->assertArrayHasKey('created_at', $data);
+    $this->assertArrayHasKey('signup_id', $data);
   }
 
   /**
@@ -80,28 +103,31 @@ class CampaignTest extends TestCase {
    */
   public function testSubmitCampaignReportback()
   {
-    // @TODO: Test has external dependency... need to mock DrupalAPI!
-//    // Campaign reportback data
-//    $rb = array(
-//      'rbid' => 100,
-//      'quantity' => 10,
-//      'why_participated' => 'I love helping others',
-//      'file_url' => 'http://example.test/example.png'
-//    );
-//
-//    $response = $this->call('POST', 'v1/campaigns/123/reportback', array(), array(), $this->server, json_encode($rb));
-//    $content = $response->getContent();
-//    $data = json_decode($content, true);
-//
-//    // The response should return a 201 Created status code
-//    $this->assertEquals(501, $response->getStatusCode());
-//
-//    // Response should be valid JSON
-//    $this->assertJson($content);
-//
-//    // Response should return created at and rbid columns
-//    $this->assertArrayHasKey('created_at', $data);
-//    $this->assertArrayHasKey('rbid', $data);
+
+    $payload = [
+      'quantity' => 10,
+      'why_participated' => 'I love helping others',
+      'file' => 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCA',
+      'caption' => 'Here I am helping others.'
+    ];
+
+    // Mock successful response from Drupal API
+    $this->drupalMock->shouldReceive('campaignReportback')->once()->andReturn(100);
+
+    $response = $this->call('POST', 'v1/campaigns/123/reportback', [], [], $this->signedUpServer, json_encode($payload));
+    $content = $response->getContent();
+    $data = json_decode($content, true);
+
+    // The response should return a 201 Created status code
+    $this->assertEquals(201, $response->getStatusCode());
+
+    // Response should be valid JSON
+    $this->assertJson($content);
+
+    // Response should return created at and rbid columns
+    $this->assertArrayHasKey('reportback_id', $data);
+    $this->assertArrayHasKey('created_at', $data);
+    $this->assertEquals(100, $data['reportback_id']);
   }
 
   /**
@@ -111,20 +137,20 @@ class CampaignTest extends TestCase {
    * @return void
    */
   public function testUpdateCampaignReportback200() {
-    // @TODO: Test has external dependency... need to mock DrupalAPI!
-//    $rb = array(
-//      'rbid' => 10,
-//      'quantity' => '1'
-//    );
-//
-//    $response = $this->call('PUT', 'v1/campaigns/100/reportback', array(), array(), $this->server, json_encode($rb));
-//    $content = $response->getContent();
-//
-//    // Response should return a 200
-//    $this->assertEquals(501, $response->getStatusCode());
-//
-//    // Response should be valid JSON
-//    $this->assertJson($content);
+    // @TODO Implement this route!
+    $rb = array(
+      'rbid' => 10,
+      'quantity' => '1'
+    );
+
+    $response = $this->call('PUT', 'v1/campaigns/100/reportback', array(), array(), $this->server, json_encode($rb));
+    $content = $response->getContent();
+
+    // Response should return a 200
+    $this->assertEquals(501, $response->getStatusCode());
+
+    // Response should be valid JSON
+    $this->assertJson($content);
   }
 
   /**
@@ -134,19 +160,19 @@ class CampaignTest extends TestCase {
    * @return void
    */
   public function testUpdateCampaignReportback401() {
-    // @TODO: Test has external dependency... need to mock DrupalAPI!
-//    $rb = array(
-//      'rbid' => 11,
-//      'quantity' => '1'
-//    );
-//
-//    $response = $this->call('PUT', 'v1/campaigns/100/reportback', array(), array(), $this->server, json_encode($rb));
-//    $content = $response->getContent();
-//
-//    // Response should return a 401
-//    $this->assertEquals(501, $response->getStatusCode());
-//
-//    // Response should be valid JSON
-//    $this->assertJson($content);
+    // @TODO Implement this route!
+    $rb = array(
+      'rbid' => 11,
+      'quantity' => '1'
+    );
+
+    $response = $this->call('PUT', 'v1/campaigns/100/reportback', array(), array(), $this->server, json_encode($rb));
+    $content = $response->getContent();
+
+    // Response should return a 501
+    $this->assertEquals(501, $response->getStatusCode());
+
+    // Response should be valid JSON
+    $this->assertJson($content);
   }
 }

--- a/app/tests/TestCase.php
+++ b/app/tests/TestCase.php
@@ -16,4 +16,19 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase {
 		return require __DIR__.'/../../bootstrap/start.php';
 	}
 
+  /**
+   * Mock a class, and register with the IoC container.
+   *
+   * @param $class String - Class name to mock
+   * @return \Mockery\MockInterface
+   */
+  public function mock($class)
+  {
+    $mock = Mockery::mock($class);
+
+    $this->app->instance($class, $mock);
+
+    return $mock;
+  }
+
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
 		"phpunit/phpunit": "4.0.*",
 		"guzzlehttp/guzzle": "~5.2"
 	},
+  "require-dev": {
+    "fzaninotto/faker": "~1.4",
+    "mockery/mockery": "^0.9.4"
+  },
 	"autoload": {
 		"classmap": [
 			"app/commands",
@@ -37,8 +41,5 @@
 	"config": {
 		"preferred-install": "dist"
 	},
-	"minimum-stability": "stable",
-	"require-dev": {
-		"fzaninotto/faker": "~1.4"
-	}
+	"minimum-stability": "stable"
 }


### PR DESCRIPTION
# Changes
 - Test coverage restored & green! :traffic_light: Added tests for updated signup & reportback endpoints.
 - Mocks `DrupalAPI` class, so unit tests do not have external dependency on another app.

For review: @angaither @jonuy 