### PR TITLE
Fix broken middleware.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -25,7 +25,8 @@ class Kernel extends HttpKernel
      */
     protected $routeMiddleware = [
         'auth' => 'Northstar\Http\Middleware\Authenticate',
-        'auth.basic' => 'Illuminate\Auth\Middleware\AuthenticateWithBasicAuth',
+        'auth.token' => 'Northstar\Http\Middleware\AuthenticateToken',
+        'auth.api' => 'Northstar\Http\Middleware\AuthenticateAPI',
         'guest' => 'Northstar\Http\Middleware\RedirectIfAuthenticated',
     ];
 

--- a/app/Http/Middleware/AuthenticateAPI.php
+++ b/app/Http/Middleware/AuthenticateAPI.php
@@ -2,7 +2,7 @@
 
 use Northstar\Models\ApiKey;
 use Closure;
-use Request;
+use Response;
 
 class AuthenticateAPI
 {
@@ -16,8 +16,8 @@ class AuthenticateAPI
      */
     public function handle($request, Closure $next)
     {
-        $app_id = Request::header('X-DS-Application-Id');
-        $api_key = Request::header('X-DS-REST-API-Key');
+        $app_id = $request->header('X-DS-Application-Id');
+        $api_key = $request->header('X-DS-REST-API-Key');
 
         if (!ApiKey::where("app_id", '=', $app_id)->where("api_key", '=', $api_key)->exists()) {
             return Response::json("Unauthorized access.", 404);

--- a/app/Http/Middleware/AuthenticateToken.php
+++ b/app/Http/Middleware/AuthenticateToken.php
@@ -2,7 +2,7 @@
 
 use Northstar\Models\Token;
 use Closure;
-use Request;
+use Response;
 
 class AuthenticateToken
 {
@@ -16,7 +16,7 @@ class AuthenticateToken
      */
     public function handle($request, Closure $next)
     {
-        $token = Request::header('Session');
+        $token = $request->header('Session');
         if (!$token) {
             return Response::json("No token found.");
         }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -16,12 +16,12 @@ Route::get('/', function () {
 });
 
 // https://api.dosomething.org/v1/
-Route::group(array('prefix' => 'v1', 'before' => 'auth.api'), function () {
+Route::group(array('prefix' => 'v1', 'middleware' => 'auth.api'), function () {
     // Campaigns.
-    Route::group(array('before' => 'auth.token'), function () {
-        Route::post('campaigns/{id}/signup', 'CampaignController@signup');
-        Route::post('campaigns/{id}/reportback', 'CampaignController@reportback');
-        Route::put('campaigns/{id}/reportback', 'CampaignController@updateReportback');
+    Route::group(array('middleware' => 'auth.token'), function () {
+        Route::post('campaigns/{campaign_id}/signup', 'CampaignController@signup');
+        Route::post('campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
+        Route::put('campaigns/{campaign_id}/reportback', 'CampaignController@updateReportback');
     });
 
     // Sessions.

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -53,9 +53,8 @@ class UserTest extends TestCase
         $response = $this->call('GET', 'v1/users');
         $content = $response->getContent();
 
-        // The response should return 200
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertJson($content);
+        // The response should return 404
+        $this->assertEquals(404, $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
# Changes
 - Accidentally broke middleware in Laravel 5 upgrade, whoopsie. Fixed now. :cactus: 
 - Restored `/users/` test to check for `404`, since that now behaves as it was supposed to.

For review: @angaither @jonuy 