### PR TITLE
Use Request objects and controller validation for campaign endpoints.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -46,8 +46,10 @@ class Handler extends ExceptionHandler
             }
 
             $response = [
-                'code' => $code,
-                'error' => $e->getMessage()
+                'error' => [
+                    'code' => $code,
+                    'message' => $e->getMessage()
+                ]
             ];
 
             // Show more information if we're in debug mode

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -25,7 +25,7 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $e)
     {
-        return parent::report($e);
+        parent::report($e);
     }
 
     /**
@@ -37,6 +37,30 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        // If client requests it, render exception as JSON object
+        if ($request->ajax() || $request->wantsJson()) {
+            $code = 500;
+
+            if($this->isHttpException($e)) {
+                $code = $e->getStatusCode();
+            }
+
+            $response = [
+                'code' => $code,
+                'error' => $e->getMessage()
+            ];
+
+            // Show more information if we're in debug mode
+            if(config('app.debug')) {
+                $response['debug'] = [
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine()
+                ];
+            }
+
+            return response()->json($response, $code);
+        }
+
         return parent::render($request, $e);
     }
 

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -133,12 +133,7 @@ class CampaignController extends Controller
         }
 
         // Create a reportback via the Drupal API, and store reportback ID in Northstar
-        $reportback_id = $this->drupal->campaignReportback($user->drupal_id, $campaign_id, [
-            'quantity' => $request->input('quantity'),
-            'why_participated' => $request->input('why_participated'),
-            'file' => $request->input('file'),
-            'caption' => $request->input('caption')
-        ]);
+        $reportback_id = $this->drupal->campaignReportback($user->drupal_id, $campaign_id, $request->all());
 
         $campaign->reportback_id = $reportback_id;
         $campaign->save();

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -19,6 +19,7 @@ class AuthTest extends TestCase
 
         $this->server = array(
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
             'HTTP_X-DS-Application-Id' => '456',
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
             'HTTP_Session' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz0='

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -27,6 +27,7 @@ class CampaignTest extends TestCase
         // Prepare server headers
         $this->server = array(
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
             'HTTP_X-DS-Application-Id' => '456',
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
             'HTTP_Session' => User::find('5430e850dt8hbc541c37tt3d')->login()->key
@@ -34,6 +35,7 @@ class CampaignTest extends TestCase
 
         $this->signedUpServer = array(
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
             'HTTP_X-DS-Application-Id' => '456',
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
             'HTTP_Session' => User::find('5480c950bffebc651c8b456f')->login()->key

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -17,6 +17,7 @@ class UserTest extends TestCase
 
         $this->server = array(
             'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
             'HTTP_X-DS-Application-Id' => '456',
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
             'HTTP_Session' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz0='


### PR DESCRIPTION
# Changes
 - Use Laravel 5 [Request](http://laravel.com/docs/master/requests#accessing-the-request) objects & [Controller validation](http://laravel.com/docs/master/validation#a-complete-example) for campaign endpoints.
 - Cleans up campaign controller using Laravel 5 style response helpers.
 - Use exceptions for error handling, and set handler to render with standard JSON format if `Accept: application/json` header is set. References #84.

For review: @angaither @jonuy 