### PR TITLE
Fixes drupal_id not being saved on user register

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -58,15 +58,8 @@ class UserController extends Controller
         }
         // Update or create the user from all the input.
         try {
-            foreach ($input as $key => $value) {
-                if ($key == 'interests') {
-                    // Remove spaces, split on commas.
-                    $interests = array_map('trim', explode(',', $value));
-                    $user->push('interests', $interests, true);
-                } elseif (!empty($value)) {
-                    $user->$key = $value;
-                }
-            }
+            $user->fill($input);
+
             // Do we need to forward this user to drupal?
             // If query string exists, make a drupal user.
             // @TODO: we can't create a Drupal user without an email. Do we just create an @mobile one like we had done previously?
@@ -81,7 +74,7 @@ class UserController extends Controller
                         try {
                             $drupal_id = $drupal->getUidByEmail($user->email);
                             $user->drupal_id = $drupal_id;
-                        } catch (Exception $e) {
+                        } catch (\Exception $e) {
                             // @TODO: still ok to just continue and allow the user to be saved?
                         }
                     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -69,16 +69,22 @@ class UserController extends Controller
             }
             // Do we need to forward this user to drupal?
             // If query string exists, make a drupal user.
+            // @TODO: we can't create a Drupal user without an email. Do we just create an @mobile one like we had done previously?
             if (Input::has('create_drupal_user') && !$user->drupal_id) {
                 try {
                     $drupal = new DrupalAPI;
                     $drupal_id = $drupal->register($user);
                     $user->drupal_id = $drupal_id;
                 } catch (Exception $e) {
-                    // @TODO: figure out what to do if a user isn't created.
-                    // This could be a failure for so many reasons
-                    // User is already registered/email taken
-                    // Or just a general failure - do we try again?
+                    // If user already exists, find the user to get the uid.
+                    if ($e->getCode() == 403) {
+                        try {
+                            $drupal_id = $drupal->getUidByEmail($user->email);
+                            $user->drupal_id = $drupal_id;
+                        } catch (Exception $e) {
+                            // @TODO: still ok to just continue and allow the user to be saved?
+                        }
+                    }
                 }
             }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -75,7 +75,7 @@ class UserController extends Controller
                     $drupal = new DrupalAPI;
                     $drupal_id = $drupal->register($user);
                     $user->drupal_id = $drupal_id;
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     // If user already exists, find the user to get the uid.
                     if ($e->getCode() == 403) {
                         try {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -83,6 +83,16 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     }
 
     /**
+     * Interests mutator converting comma-delimited string to an array
+     *
+     */
+    public function setInterestsAttribute($value)
+    {
+        $interests = array_map('trim', explode(',', $value));
+        $this->push('interests', $interests, true);
+    }
+
+    /**
      * Password mutator that hashes the password field
      *
      */

--- a/app/Services/DrupalAPI.php
+++ b/app/Services/DrupalAPI.php
@@ -115,7 +115,34 @@ class DrupalAPI
             'body' => json_encode($payload),
         ]);
 
-        return $response->uid;
+        $json = $response->json();
+        return $json['uid'];
+    }
+
+    /**
+     * Get a user uid by email.
+     * @see: https://github.com/DoSomething/dosomething/wiki/API#find-a-user
+     *
+     * @param String $email - Email of user to search for
+     * @return String - Drupal User ID
+     * @throws \Exception
+     */
+    public function getUidByEmail($email)
+    {
+        $response = $this->client->get('users?parameters[email]=' . urlencode($email), [
+            'cookies' => $this->getAuthenticationCookie(),
+            'headers' => [
+                'X-CSRF-Token' => $this->getAuthenticationToken()
+            ]
+        ]);
+
+        $json = $response->json();
+        if (sizeof($json) > 0) {
+            return $json[0]['uid'];
+        }
+        else {
+            throw new \Exception('Drupal user not found.', $response->getStatusCode());
+        }
     }
 
     /**

--- a/app/Services/DrupalAPI.php
+++ b/app/Services/DrupalAPI.php
@@ -129,11 +129,14 @@ class DrupalAPI
      */
     public function getUidByEmail($email)
     {
-        $response = $this->client->get('users?parameters[email]=' . urlencode($email), [
+        $response = $this->client->get('users', [
+            'query' => [
+                'parameters[email]' => $email,
+            ],
             'cookies' => $this->getAuthenticationCookie(),
             'headers' => [
-                'X-CSRF-Token' => $this->getAuthenticationToken()
-            ]
+                'X-CSRF-Token' => $this->getAuthenticationToken(),
+            ],
         ]);
 
         $json = $response->json();


### PR DESCRIPTION
#### What's this PR do?
The `drupal_id` wasn't getting saved on a register because the response needed to be json decoded first. This PR fixes that and also handles the case where a Northstar register fails because the user already exists on Drupal. In that case we send an authenticated request to get the user UID based on the user's email and then save that to the user's Northstar document.

#### Discussion
- We can't create a Drupal user without an email address. Previously on Drupal, we would just create a dummy one by appending `@mobile` ... is that what we do again? Is there a smarter solution we can implement now that we've got Northstar?
- Data in the GET params, like `create_drupal_user` are also getting added to the user doc. Can we make that not happen?

cc: @angaither @DFurnes 