### PR TITLE
PUT reportbacks

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -101,6 +101,7 @@ class CampaignController extends Controller
     /**
      * Store a newly created campaign report back in storage.
      * POST /campaigns/:campaign_id/reportback
+     * PUT  /campaigns/:campaign_id/reportback
      *
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
@@ -139,19 +140,6 @@ class CampaignController extends Controller
         $campaign->save();
 
         return response()->json(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], 201);
-    }
-
-    /**
-     * Update a campaign report back in storage.
-     * PUT /campaigns/:campaign_id/reportback
-     *
-     * @return Response
-     */
-    public function updateReportback($campaign_id)
-    {
-        throw new HttpException(501, 'Not yet implemented.');
-
-        // ...
     }
 
 }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -136,10 +136,16 @@ class CampaignController extends Controller
         // Create a reportback via the Drupal API, and store reportback ID in Northstar
         $reportback_id = $this->drupal->campaignReportback($user->drupal_id, $campaign_id, $request->all());
 
+        // Set status code based on whether `reportback_id` field already exists or not
+        $statusCode = 201;
+        if($campaign->reportback_id) {
+            $statusCode = 200;
+        }
+
         $campaign->reportback_id = $reportback_id;
         $campaign->save();
 
-        return response()->json(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], 201);
+        return response()->json(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], $statusCode);
     }
 
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -21,7 +21,7 @@ Route::group(array('prefix' => 'v1', 'middleware' => 'auth.api'), function () {
     Route::group(array('middleware' => 'auth.token'), function () {
         Route::post('campaigns/{campaign_id}/signup', 'CampaignController@signup');
         Route::post('campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
-        Route::put('campaigns/{campaign_id}/reportback', 'CampaignController@updateReportback');
+        Route::put('campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
     });
 
     // Sessions.

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -60,6 +60,32 @@ class UserTableSeeder extends Seeder
             ]
         ]);
 
+        // Reported back user
+        User::create([
+            '_id' => 'bf1039b0271bcc636aa5477a',
+            'email' => 'test2@dosomething.org',
+            'mobile' => '5554445555',
+            'password' => 'secret',
+            'drupal_id' => 123457,
+            'addr_street1' => '123',
+            'addr_street2' => '456',
+            'addr_city' => 'Paris',
+            'addr_state' => 'Florida',
+            'addr_zip' => '555555',
+            'country' => 'US',
+            'birthdate' => '12/17/91',
+            'first_name' => 'First',
+            'last_name' => 'Last',
+            'campaigns' => [
+                [
+                    '_id' => '3f10c910251bcc636aa5477a',
+                    'drupal_id' => 123,
+                    'signup_id' => 101,
+                    'reportback_id' => 125
+                ]
+            ]
+        ]);
+
         User::create(array(
             'email' => 'info@dosomething.org',
             'mobile' => '5556669999',

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -10,6 +10,7 @@ class CampaignTest extends TestCase
 
     protected $server;
     protected $signedUpServer;
+    protected $reportedBackServer;
 
     /**
      * Migrate database and set up HTTP headers
@@ -39,6 +40,14 @@ class CampaignTest extends TestCase
             'HTTP_X-DS-Application-Id' => '456',
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
             'HTTP_Session' => User::find('5480c950bffebc651c8b456f')->login()->key
+        );
+
+        $this->reportedBackServer = array(
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
+            'HTTP_X-DS-Application-Id' => '456',
+            'HTTP_X-DS-REST-API-Key' => 'abc4324',
+            'HTTP_Session' => User::find('bf1039b0271bcc636aa5477a')->login()->key
         );
 
         // Mock Drupal API class
@@ -96,14 +105,13 @@ class CampaignTest extends TestCase
     }
 
     /**
-     * Test for submiting a campaign report back.
+     * Test for submitting a new campaign report back.
      * POST /campaigns/:nid/reportback
      *
      * @return void
      */
     public function testSubmitCampaignReportback()
     {
-
         $payload = [
             'quantity' => 10,
             'why_participated' => 'I love helping others',
@@ -131,48 +139,59 @@ class CampaignTest extends TestCase
     }
 
     /**
-     * Test for successful update of a campaign report back.
+     * Test for successful update of an existing campaign report back.
      * PUT /campaigns/:nid/reportback
      *
      * @return void
      */
     public function testUpdateCampaignReportback200()
     {
-        // @TODO Implement this route!
-        $rb = array(
-            'rbid' => 10,
-            'quantity' => '1'
-        );
+        $payload = [
+            'quantity' => 10,
+            'why_participated' => 'I love helping others',
+            'file' => 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCA',
+            'caption' => 'Here I am helping others.'
+        ];
 
-        $response = $this->call('PUT', 'v1/campaigns/100/reportback', [], [], [], $this->server, json_encode($rb));
+        // Mock successful response from Drupal API
+        $this->drupalMock->shouldReceive('campaignReportback')->once()->andReturn(100);
+
+        $response = $this->call('PUT', 'v1/campaigns/123/reportback', [], [], [], $this->reportedBackServer, json_encode($payload));
         $content = $response->getContent();
+        $data = json_decode($content, true);
 
-        // Response should return a 200
-        $this->assertEquals(501, $response->getStatusCode());
+        // The response should return a 201 Created status code
+        $this->assertEquals(201, $response->getStatusCode());
 
         // Response should be valid JSON
         $this->assertJson($content);
+
+        // Response should return created at and rbid columns
+        $this->assertArrayHasKey('reportback_id', $data);
+        $this->assertArrayHasKey('created_at', $data);
+        $this->assertEquals(100, $data['reportback_id']);
     }
 
     /**
-     * Test for update of a non-existent campaign report back.
+     * Test for creating a reportback when signup does not exist.
      * PUT /campaigns/:nid/reportback
      *
      * @return void
      */
     public function testUpdateCampaignReportback401()
     {
-        // @TODO Implement this route!
-        $rb = array(
-            'rbid' => 11,
-            'quantity' => '1'
-        );
+        $payload = [
+            'quantity' => 10,
+            'why_participated' => 'I love helping others',
+            'file' => 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCA',
+            'caption' => 'Here I am helping others.'
+        ];
 
-        $response = $this->call('PUT', 'v1/campaigns/100/reportback', [], [], [], $this->server, json_encode($rb));
+        $response = $this->call('POST', 'v1/campaigns/123/reportback', [], [], [], $this->server, json_encode($payload));
         $content = $response->getContent();
 
         // Response should return a 501
-        $this->assertEquals(501, $response->getStatusCode());
+        $this->assertEquals(401, $response->getStatusCode());
 
         // Response should be valid JSON
         $this->assertJson($content);

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -160,8 +160,8 @@ class CampaignTest extends TestCase
         $content = $response->getContent();
         $data = json_decode($content, true);
 
-        // The response should return a 201 Created status code
-        $this->assertEquals(201, $response->getStatusCode());
+        // The response should return a 200 Success status code
+        $this->assertEquals(200, $response->getStatusCode());
 
         // Response should be valid JSON
         $this->assertJson($content);


### PR DESCRIPTION
# Changes
 - Route PUT to same reportback method, and update corresponding tests.

Routing them both to the same method because none of the logic was different between the two. The _only_ difference is the status code returned – all validation, Drupal API calls, database queries, etc. are shared between the two endpoints.

This PR also (finally) closes #62.

For review: @angaither @jonuy 