### PR TITLE
Including password in register call to Drupal

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -64,10 +64,10 @@ class UserController extends Controller
             // Do we need to forward this user to drupal?
             // If query string exists, make a drupal user.
             // @TODO: we can't create a Drupal user without an email. Do we just create an @mobile one like we had done previously?
-            if (Input::has('create_drupal_user') && !$user->drupal_id) {
+            if (Input::has('create_drupal_user') && Input::has('password') && !$user->drupal_id) {
                 try {
                     $drupal = new DrupalAPI;
-                    $drupal_id = $drupal->register($user);
+                    $drupal_id = $drupal->register($user, Input::get('password'));
                     $user->drupal_id = $drupal_id;
                 } catch (\Exception $e) {
                     // If user already exists, find the user to get the uid.

--- a/app/Services/DrupalAPI.php
+++ b/app/Services/DrupalAPI.php
@@ -100,16 +100,18 @@ class DrupalAPI
      * @see: https://github.com/DoSomething/dosomething/wiki/API#create-a-user
      *
      * @param \User $user - User to be registered on Drupal site
+     * @param String $password - Password to register with
      *
      * @return int - Created Drupal user UID
      */
-    public function register($user)
+    public function register($user, $password)
     {
         $payload = $user->toArray();
 
         // Format user object for consumption by Drupal API.
         $payload['birthdate'] = date('Y-m-d', strtotime($user->birthdate));
         $payload['user_registration_source'] = $user->source;
+        $payload['password'] = $password;
 
         $response = $this->client->post('users', [
             'body' => json_encode($payload),


### PR DESCRIPTION
Drupal users were getting created without a password being included. So I found that when I registered through Northstar, I wouldn't be able to login to the Drupal site. This passes that password on to the Drupal register call.

cc: @angaither @DFurnes 