### PR TITLE
Adding support for mongo replica sets

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,6 +53,7 @@ return [
             'username' => getenv('DB_USERNAME') ? getenv('DB_USERNAME') : '',
             'password' => getenv('DB_PASSWORD') ? getenv('DB_PASSWORD') : '',
             'database' => getenv('DB_NAME') ? getenv('DB_NAME') : 'userapi',
+            'options'  => array('replicaSet' => getenv('DB_REPL_SET_NAME') ? getenv('DB_REPL_SET_NAME') : 'rs0'),
         ),
 
     ],


### PR DESCRIPTION
The current settings work fine if the settings are pointed directly to the primary node in the Mongo replica set, but they'll break otherwise.  I've added the additional replica set parameter in 'options' to make sure that the app can always connect to the primary.  I also updated the hostnames in the settings on the server to reflect these changes.

@jonuy @angaither 