### PR TITLE
Structuring login, logout, and user delete responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+app/storage
 /vendor
 /node_modules
 .env
 
 .DS_Store
+
+# PhpStorm
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-app/storage
 /vendor
 /node_modules
 .env

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -5,6 +5,7 @@ use Northstar\Models\Token;
 use Illuminate\Http\Request;
 use Hash;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class AuthController extends Controller
 {
@@ -32,7 +33,7 @@ class AuthController extends Controller
         }
 
         if (!($user instanceof User)) {
-            throw new HttpException(404, 'User is not registered.');
+            throw new NotFoundHttpException('User is not registered.');
         } elseif (Hash::check($input['password'], $user->password)) {
             $token = $user->login();
             $token->user = $user->toArray();
@@ -63,7 +64,7 @@ class AuthController extends Controller
         $user = Token::userFor($input_token);
 
         if (empty($token)) {
-            throw new HttpException(404, 'No active session found.');
+            throw new NotFoundHttpException('No active session found.');
         } elseif ($token->user_id !== $user->_id) {
             throw new HttpException(403, 'You do not own this token.');
         } elseif ($token->delete()) {

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -28,7 +28,8 @@ class CampaignController extends Controller
      * @param $term string - Term to search by (eg. mobile, drupal_id, id, etc)
      * @param $id   string - The value to search for
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
+     * @throws NotFoundHttpException
      */
     public function index($term, $id)
     {
@@ -36,11 +37,11 @@ class CampaignController extends Controller
         $user = User::where($term, $id)->first();
 
         if (!$user) {
-            throw new NotFoundHttpException('The resource does not exist');
+            throw new NotFoundHttpException('The resource does not exist.');
         }
 
         $campaigns = $user->campaigns;
-        return response()->json($campaigns, 200);
+        return $this->respond($campaigns);
     }
 
     /**
@@ -73,7 +74,8 @@ class CampaignController extends Controller
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
+     * @throws HttpException
      */
     public function signup($campaign_id, Request $request)
     {
@@ -111,7 +113,7 @@ class CampaignController extends Controller
             'created_at' => $campaign->created_at,
         );
 
-        return response()->json($response, 201);
+        return $this->respond($response, 201);
     }
 
 
@@ -123,7 +125,8 @@ class CampaignController extends Controller
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
      *
-     * @return \Illuminate\Http\Response
+     * @return Response
+     * @throws HttpException
      */
     public function reportback($campaign_id, Request $request)
     {
@@ -162,7 +165,7 @@ class CampaignController extends Controller
         $campaign->reportback_id = $reportback_id;
         $campaign->save();
 
-        return response()->json(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], $statusCode);
+        return $this->respond(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], $statusCode);
     }
 
 }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -28,7 +28,7 @@ class CampaignController extends Controller
      * @param $term string - Term to search by (eg. mobile, drupal_id, id, etc)
      * @param $id   string - The value to search for
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      * @throws NotFoundHttpException
      */
     public function index($term, $id)
@@ -51,6 +51,7 @@ class CampaignController extends Controller
      * @param int $campaign_id - Campaign ID
      *
      * @return \Illuminate\Http\Response
+     * @throws NotFoundHttpException
      */
     public function show($campaign_id)
     {
@@ -62,8 +63,7 @@ class CampaignController extends Controller
             throw new NotFoundHttpException('User has not signed up for this campaign.');
         }
 
-        // @TODO: Use $this->respond method introduced in #125
-        return $campaign;
+        return $this->respond($campaign);
     }
 
 
@@ -74,7 +74,7 @@ class CampaignController extends Controller
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      * @throws HttpException
      */
     public function signup($campaign_id, Request $request)
@@ -125,7 +125,7 @@ class CampaignController extends Controller
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      * @throws HttpException
      */
     public function reportback($campaign_id, Request $request)

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -9,4 +9,25 @@ abstract class Controller extends BaseController
 
     use DispatchesCommands, ValidatesRequests;
 
+    /**
+     * Method to standardize responses sent from child controllers.
+     *
+     * @param mixed $data - Data to send in the response
+     * @param int $code - Status code
+     * @param string $status - When $data is a message string, this is the name of the object enclosing the message
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function respond($data, $code = 200, $status = 'success') {
+        $response = [];
+        if (is_string($data)) {
+            $response[$status] = ['message' => $data];
+        } elseif (is_object($data) || is_array($data)) {
+            $response['data'] = $data;
+        } else {
+            $response = $data;
+        }
+
+        return response()->json($response, $code);
+    }
+
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -17,11 +17,13 @@ abstract class Controller extends BaseController
      * @param string $status - When $data is a message string, this is the name of the object enclosing the message
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function respond($data, $code = 200, $status = 'success') {
+    protected function respond($data, $code = 200, $status = 'success')
+    {
         $response = [];
         if (is_string($data)) {
             $response[$status] = ['message' => $data];
-        } elseif (is_object($data) || is_array($data)) {
+        } elseif ((is_object($data) && !is_a($data, 'Illuminate\Pagination\AbstractPaginator'))
+            || is_array($data)) {
             $response['data'] = $data;
         } else {
             $response = $data;

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Bus\DispatchesCommands;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Database\Eloquent;
+use Input;
 
 abstract class Controller extends BaseController
 {
@@ -22,14 +24,27 @@ abstract class Controller extends BaseController
         $response = [];
         if (is_string($data)) {
             $response[$status] = ['message' => $data];
-        } elseif ((is_object($data) && !is_a($data, 'Illuminate\Pagination\AbstractPaginator'))
-            || is_array($data)) {
+        } elseif (is_object($data) || is_array($data)) {
             $response['data'] = $data;
         } else {
             $response = $data;
         }
 
         return response()->json($response, $code);
+    }
+
+    /**
+     * Method to standardize paginated responses.
+     *
+     * @param $query - Eloquent query
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function respondPaginated($query) {
+        if (is_a($query, 'Illuminate\Database\Eloquent\Builder')) {
+            $limit = Input::get('limit') ?: 20;
+            $response = $query->paginate($limit);
+            return response()->json($response);
+        }
     }
 
 }

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -3,6 +3,8 @@
 use Northstar\Models\ApiKey;
 use Input;
 use Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class KeyController extends Controller
 {
@@ -16,7 +18,7 @@ class KeyController extends Controller
     public function index()
     {
         $keys = ApiKey::all();
-        return Response::json($keys, 200);
+        return $this->respond($keys);
     }
 
 
@@ -25,6 +27,7 @@ class KeyController extends Controller
      * POST /keys
      *
      * @return Response
+     * @throws HttpException
      */
     public function store()
     {
@@ -37,25 +40,27 @@ class KeyController extends Controller
             // Save new key.
             $key->save();
 
-            return Response::json($key, 200);
+            return $this->respond($key);
         }
-        return Response::json('Missing required information', 400);
+
+        throw new HttpException(400, 'Missing required information.');
     }
 
     /**
      * Display the specified resource.
      *
      * @return Response
+     * @throws NotFoundHttpException
      */
     public function show($id)
     {
         // Find the user.
         $key = Key::where('id', $id)->get();
         if (!$key->isEmpty()) {
-            return Response::json($key, 200);
+            return $this->respond($key);
         }
-        return Response::json('The resource does not exist', 404);
 
+        throw new NotFoundHttpException('The resource does not exist.');
     }
 
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -160,14 +160,20 @@ class UserController extends Controller
     public function destroy($id)
     {
         $user = User::where('_id', $id)->first();
+        $message = 'The resource does not exist';
+        $code = 404;
+        $status = 'error';
+
 
         if ($user instanceof User) {
             $user->delete();
 
-            return Response::json("No Content", 204);
+            $message = 'No Content';
+            $code = 204;
+            $status = 'success';
         }
 
-        return Response::json("The resource does not exist", 404);
+        return $this->respond($message, $code, $status);
     }
 
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -6,6 +6,7 @@ use Northstar\Models\User;
 use Input;
 use Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UserController extends Controller
 {
@@ -21,7 +22,7 @@ class UserController extends Controller
         //@TODO: set sensible limit here.
         $limit = Input::get('limit') ?: 20;
         $users = User::paginate($limit);
-        return Response::json($users, 200);
+        return $this->respond($users);
     }
 
 
@@ -89,9 +90,9 @@ class UserController extends Controller
             $token = $user->login();
             $user->session_token = $token->key;
 
-            return $user;
+            return $this->respond($user);
         } catch (\Exception $e) {
-            return Response::json($e, 401);
+            return $this->respond($e, 401);
         }
     }
 
@@ -104,16 +105,17 @@ class UserController extends Controller
      *  the actual value to search for
      *
      * @return Response
+     * @throws NotFoundHttpException
      */
     public function show($term, $id)
     {
         // Find the user.
         $user = User::where($term, $id)->get();
         if (!$user->isEmpty()) {
-            return Response::json($user, 200);
+            return $this->respond($user);
         }
-        return Response::json('The resource does not exist', 404);
 
+        throw new NotFoundHttpException('The resource does not exist.');
     }
 
 
@@ -123,6 +125,7 @@ class UserController extends Controller
      *
      * @param $id - User ID
      * @return Response
+     * @throws NotFoundHttpException
      */
     public function update($id)
     {
@@ -145,10 +148,10 @@ class UserController extends Controller
 
             $response = array('updated_at' => $user->updated_at);
 
-            return Response::json($response, 202);
+            return $this->respond($response, 202);
         }
 
-        return Response::json("The resource does not exist", 404);
+        throw new NotFoundHttpException('The resource does not exist.');
     }
 
     /**
@@ -157,7 +160,7 @@ class UserController extends Controller
      *
      * @param $id - User ID
      * @return Response
-     * @throws HttpException
+     * @throws NotFoundHttpException
      */
     public function destroy($id)
     {
@@ -168,7 +171,7 @@ class UserController extends Controller
 
             return $this->respond('No Content.', 204);
         } else {
-            throw new HttpException(404, 'The resource does not exist.');
+            throw new NotFoundHttpException('The resource does not exist.');
         }
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,6 +5,7 @@ use Northstar\Services\DrupalAPI;
 use Northstar\Models\User;
 use Input;
 use Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UserController extends Controller
 {
@@ -156,24 +157,19 @@ class UserController extends Controller
      *
      * @param $id - User ID
      * @return Response
+     * @throws HttpException
      */
     public function destroy($id)
     {
         $user = User::where('_id', $id)->first();
-        $message = 'The resource does not exist';
-        $code = 404;
-        $status = 'error';
-
 
         if ($user instanceof User) {
             $user->delete();
 
-            $message = 'No Content';
-            $code = 204;
-            $status = 'success';
+            return $this->respond('No Content.', 204);
+        } else {
+            throw new HttpException(404, 'The resource does not exist.');
         }
-
-        return $this->respond($message, $code, $status);
     }
 
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,7 +5,6 @@ use Northstar\Services\DrupalAPI;
 use Northstar\Models\User;
 use Input;
 use Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UserController extends Controller
@@ -19,10 +18,8 @@ class UserController extends Controller
      */
     public function index()
     {
-        //@TODO: set sensible limit here.
-        $limit = Input::get('limit') ?: 20;
-        $users = User::paginate($limit);
-        return $this->respond($users);
+        $query = User::query();
+        return $this->respondPaginated($query);
     }
 
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -51,11 +51,11 @@ class AuthTest extends TestCase
         $this->assertJson($content);
 
         // Response should include user ID & session token
-        $this->assertArrayHasKey('_id', $data);
-        $this->assertArrayHasKey('session_token', $data);
+        $this->assertArrayHasKey('_id', $data['data']);
+        $this->assertArrayHasKey('session_token', $data['data']);
 
         // Assert token exists in database
-        $tokenCount = Token::where('key', '=', $data['session_token'])->count();
+        $tokenCount = Token::where('key', '=', $data['data']['session_token'])->count();
         $this->assertEquals($tokenCount, 1);
     }
 

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -100,8 +100,8 @@ class CampaignTest extends TestCase
         $this->assertJson($content);
 
         // Response should return created at and sid columns
-        $this->assertArrayHasKey('created_at', $data);
-        $this->assertArrayHasKey('signup_id', $data);
+        $this->assertArrayHasKey('created_at', $data['data']);
+        $this->assertArrayHasKey('signup_id', $data['data']);
     }
 
     /**
@@ -133,9 +133,9 @@ class CampaignTest extends TestCase
         $this->assertJson($content);
 
         // Response should return created at and rbid columns
-        $this->assertArrayHasKey('reportback_id', $data);
-        $this->assertArrayHasKey('created_at', $data);
-        $this->assertEquals(100, $data['reportback_id']);
+        $this->assertArrayHasKey('reportback_id', $data['data']);
+        $this->assertArrayHasKey('created_at', $data['data']);
+        $this->assertEquals(100, $data['data']['reportback_id']);
     }
 
     /**
@@ -167,9 +167,9 @@ class CampaignTest extends TestCase
         $this->assertJson($content);
 
         // Response should return created at and rbid columns
-        $this->assertArrayHasKey('reportback_id', $data);
-        $this->assertArrayHasKey('created_at', $data);
-        $this->assertEquals(100, $data['reportback_id']);
+        $this->assertArrayHasKey('reportback_id', $data['data']);
+        $this->assertArrayHasKey('created_at', $data['data']);
+        $this->assertEquals(100, $data['data']['reportback_id']);
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -84,8 +84,8 @@ class UserTest extends TestCase
         $this->assertJson($content);
 
         // Response should return created at and id columns
-        $this->assertArrayHasKey('created_at', $data);
-        $this->assertArrayHasKey('_id', $data);
+        $this->assertArrayHasKey('created_at', $data['data']);
+        $this->assertArrayHasKey('_id', $data['data']);
     }
 
     /**
@@ -112,7 +112,7 @@ class UserTest extends TestCase
         $this->assertJson($content);
 
         // Response should return updated at and id columns
-        $this->assertArrayHasKey('updated_at', $data);
+        $this->assertArrayHasKey('updated_at', $data['data']);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
The intent here was to start standardizing the responses from Northstar. In particular, the focus was on a handful of responses that just replied back with a string as opposed to an object or array like some other responses did.

Responses affected:
- login
- logout
- user delete

Where a response would previously just reply back with a string, now it'll be structured like:
```
{
  status: {
    "message": "This is the error/success message"
  }
}
```

Where a response would've replied back with an object, now it'll assign it to a "data" field in an object. The only response affected by this PR right now is on a successful login.
```
{
  "data": <User object>
}
```

#### What are the relevant tickets?
#84

#### Questions
This is a breaking change for any client code that uses these endpoints right now. So for example, login on the mobile apps will be broken until they get updated to support the new structure. This is sorta why I held off on updating _all_ the responses.

That being said, should we just go ahead and update all of them right now? This might be more of a question for the iOS and Android devs.

cc: @DFurnes @aaronschachter 