### PR TITLE
Add route to retrieve campaign details.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -28,9 +28,9 @@ class CampaignController extends Controller
      * @param $term string - Term to search by (eg. mobile, drupal_id, id, etc)
      * @param $id   string - The value to search for
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
-    public function show($term, $id)
+    public function index($term, $id)
     {
         // Find the user.
         $user = User::where($term, $id)->first();
@@ -43,6 +43,28 @@ class CampaignController extends Controller
         return response()->json($campaigns, 200);
     }
 
+    /**
+     * Display the specified campaign.
+     * GET /campaigns/:campaign_id
+     *
+     * @param int $campaign_id - Campaign ID
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function show($campaign_id)
+    {
+        $user = User::current();
+
+        $campaign = $user->campaigns()->where('drupal_id', $campaign_id)->first();
+
+        if(!$campaign) {
+            throw new NotFoundHttpException('User has not signed up for this campaign.');
+        }
+
+        // @TODO: Use $this->respond method introduced in #125
+        return $campaign;
+    }
+
 
     /**
      * Sign user up for a given campaign.
@@ -51,7 +73,7 @@ class CampaignController extends Controller
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function signup($campaign_id, Request $request)
     {
@@ -101,7 +123,7 @@ class CampaignController extends Controller
      * @param $campaign_id - Drupal campaign node ID
      * @param Request $request
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function reportback($campaign_id, Request $request)
     {

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -57,7 +57,7 @@ class CampaignController extends Controller
 
         $campaign = $user->campaigns()->where('drupal_id', $campaign_id)->first();
 
-        if(!$campaign) {
+        if (!$campaign) {
             throw new NotFoundHttpException('User has not signed up for this campaign.');
         }
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -12,13 +12,14 @@
 */
 
 Route::get('/', function () {
-    return Redirect::to('https://github.com/DoSomething/api');
+    return redirect()->to('https://github.com/DoSomething/api');
 });
 
 // https://api.dosomething.org/v1/
-Route::group(array('prefix' => 'v1', 'middleware' => 'auth.api'), function () {
+Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     // Campaigns.
-    Route::group(array('middleware' => 'auth.token'), function () {
+    Route::group(['middleware' => 'auth.token'], function () {
+        Route::get('campaigns/{campaign_id}', 'CampaignController@show');
         Route::post('campaigns/{campaign_id}/signup', 'CampaignController@signup');
         Route::post('campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
         Route::put('campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
@@ -30,7 +31,7 @@ Route::group(array('prefix' => 'v1', 'middleware' => 'auth.api'), function () {
 
     // Users.
     Route::resource('users', 'UserController');
-    Route::get('users/{term}/{id}/campaigns', 'CampaignController@show');
+    Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
     Route::get('users/{term}/{id}', 'UserController@show');
 
     // Api Keys.


### PR DESCRIPTION
# Changes
 - Adds a route to show campaign details. References #98.

I renamed the previous `show` method to `index`, since it's listing a bunch of campaigns, and implemented this as a `campaign` route rather than a signup object, since that's the REST noun we're using to store this data. Totally up for discussion if anyone thinks there's a better way of handling.

For review: @angaither @jonuy 