### PR TITLE
Bug fixes

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -42,7 +42,7 @@ abstract class Controller extends BaseController
     protected function respondPaginated($query) {
         if (is_a($query, 'Illuminate\Database\Eloquent\Builder')) {
             $limit = Input::get('limit') ?: 20;
-            $response = $query->paginate($limit);
+            $response = $query->paginate((int)$limit);
             return response()->json($response);
         }
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -166,7 +166,7 @@ class UserController extends Controller
         if ($user instanceof User) {
             $user->delete();
 
-            return $this->respond('No Content.', 204);
+            return $this->respond('No Content.');
         } else {
             throw new NotFoundHttpException('The resource does not exist.');
         }


### PR DESCRIPTION
:bug: :beetle: 

- The `paginate` function on an `Eloquent\Builder` object requires the parameter to be a number. So I'm casting to an `int` there.
- Apparently `response()->json($response, $code)` doesn't play nice when `$response` is a string and `$code` is something that's not 200. Like, if I set it to 204, the response body would come back empty. So I'm just letting the `DELETE /users` return a 200.

cc: @angaither @DFurnes 