### PR TITLE
Signup groups

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -106,6 +106,7 @@ class CampaignController extends Controller
         $campaign = new Campaign;
         $campaign->drupal_id = $campaign_id;
         $campaign->signup_id = $signup_id;
+        $campaign->signup_source = $request->input('source');
         $campaign = $user->campaigns()->save($campaign);
 
         $response = array(

--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -23,9 +23,22 @@ class SignupGroupController extends Controller
 
         if (count($group) == 0) {
             throw new NotFoundHttpException("No users found for the group ID.");
-        }
-        else {
-            return $this->respond($group);
+        } else {
+            // Get the campaign id associated with the signup group ID
+            for ($i = 0; $i < count($group[0]->campaigns); $i++) {
+                $campaign = $group[0]->campaigns[$i];
+                if ($campaign->signup_id == $id || $campaign->signup_source == $id) {
+                    $campaign_id = $campaign->drupal_id;
+                    break;
+                }
+            }
+
+            $response = [
+                'campaign_id' => $campaign_id,
+                'users' => $group
+            ];
+
+            return $this->respond($response);
         }
     }
 

--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -1,0 +1,32 @@
+<?php namespace Northstar\Http\Controllers;
+
+use Northstar\Models\User;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class SignupGroupController extends Controller
+{
+
+    /**
+     * Display the users who share the specified signup group id.
+     * GET /signup-group/:id
+     *
+     * @param int $id - Signup Group ID
+     *
+     * @return \Illuminate\Http\Response
+     * @throws NotFoundHttpException
+     */
+    public function show($id)
+    {
+        // signup_id is saved as a number and signup_source is saved as a string
+        $group = User::where('campaigns', 'elemMatch', ['signup_id' => (int)$id])
+                        ->orWhere('campaigns', 'elemMatch', ['signup_source' => $id])->get();
+
+        if (count($group) == 0) {
+            throw new NotFoundHttpException("No users found for the group ID.");
+        }
+        else {
+            return $this->respond($group);
+        }
+    }
+
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -34,6 +34,9 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
     Route::get('users/{term}/{id}', 'UserController@show');
 
+    // Signup Groups.
+    Route::get('signup-group/{id}', 'SignupGroupController@show');
+
     // Api Keys.
     Route::resource('keys', 'KeyController');
 });

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -21,9 +21,9 @@ class UserTableSeeder extends Seeder
         User::create([
             '_id' => '5430e850dt8hbc541c37tt3d',
             'email' => 'test@dosomething.org',
-            'mobile' => '5555555555',
+            'mobile' => '5555550100',
             'password' => 'secret',
-            'drupal_id' => 123456,
+            'drupal_id' => 100001,
             'addr_street1' => '123',
             'addr_street2' => '456',
             'addr_city' => 'Paris',
@@ -38,10 +38,10 @@ class UserTableSeeder extends Seeder
         // Signed up user
         User::create([
             '_id' => '5480c950bffebc651c8b456f',
-            'email' => 'test2@dosomething.org',
-            'mobile' => '5554445555',
+            'email' => 'test1@dosomething.org',
+            'mobile' => '5555550101',
             'password' => 'secret',
-            'drupal_id' => 123457,
+            'drupal_id' => 100002,
             'addr_street1' => '123',
             'addr_street2' => '456',
             'addr_city' => 'Paris',
@@ -55,7 +55,8 @@ class UserTableSeeder extends Seeder
                 [
                     '_id' => '5480c950bffebc651c8b456e',
                     'drupal_id' => 123,
-                    'signup_id' => 100
+                    'signup_id' => 100,
+                    'signup_source' => 'android'
                 ]
             ]
         ]);
@@ -64,9 +65,9 @@ class UserTableSeeder extends Seeder
         User::create([
             '_id' => 'bf1039b0271bcc636aa5477a',
             'email' => 'test2@dosomething.org',
-            'mobile' => '5554445555',
+            'mobile' => '5555550102',
             'password' => 'secret',
-            'drupal_id' => 123457,
+            'drupal_id' => 100003,
             'addr_street1' => '123',
             'addr_street2' => '456',
             'addr_city' => 'Paris',
@@ -81,14 +82,33 @@ class UserTableSeeder extends Seeder
                     '_id' => '3f10c910251bcc636aa5477a',
                     'drupal_id' => 123,
                     'signup_id' => 101,
+                    'signup_source' => 'ios',
                     'reportback_id' => 125
+                ]
+            ]
+        ]);
+
+        // User invited to campaign
+        User::create([
+            '_id' => 'bf1039b0271bcc636aa5477b',
+            'email' => 'test3@dosomething.org',
+            'mobile' => '5555550102',
+            'password' => 'secret',
+            'drupal_id' => 100004,
+            'birthdate' => '12/17/91',
+            'campaigns' => [
+                [
+                    '_id' => '3f10c910251bcc636aa5477b',
+                    'drupal_id' => 123,
+                    'signup_id' => 102,
+                    'signup_source' => '100'
                 ]
             ]
         ]);
 
         User::create(array(
             'email' => 'info@dosomething.org',
-            'mobile' => '5556669999',
+            'mobile' => '5555550104',
             'password' => 'secret',
             'drupal_id' => 456788,
             'addr_street1' => '456',

--- a/tests/SignupGroupTest.php
+++ b/tests/SignupGroupTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class SignupGroupTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Migrate & seed database
+        Artisan::call('migrate');
+        $this->seed();
+
+        // Prepare server headers
+        $this->server = array(
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
+            'HTTP_X-DS-Application-Id' => '456',
+            'HTTP_X-DS-REST-API-Key' => 'abc4324'
+        );
+    }
+
+    public function testShow()
+    {
+        $response = $this->call('GET', 'v1/signup-group/100', [], [], [], $this->server);
+        $content = json_decode($response->getContent(), true);
+        $data = $content['data'];
+
+        // Verify it's the two users we expect it to be.
+        $usersFound = 0;
+        for ($i = 0; $i < count($data['users']); $i++) {
+            $email = $data['users'][$i]['email'];
+            if ($email == 'test1@dosomething.org' || $email == 'test3@dosomething.org') {
+                $usersFound++;
+            }
+        }
+
+        $this->assertEquals(2, $usersFound);
+
+        // Campaign ID should be 123.
+        $this->assertEquals(123, $data['campaign_id']);
+    }
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -125,7 +125,7 @@ class UserTest extends TestCase
     {
         $response = $this->call('DELETE', 'v1/users/5480c950bffebc651c8b4570', [], [], [], $this->server, array());
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Saves `source` param on signup to `signup_source`
- Adds the endpoint `GET /signup-group/:group_id`.

  It returns the users where the `:group_id` is equal to their own `signup_id` or `signup_source`. This gives us the users who have been invited to and joined a campaign with an invite code.

  If no users are found, it returns a 404.
- Adds test for `GET /signup-group`
- Fixes `DELETE /users` test
- Changes mobile numbers seeded in the DB since those combinations can actually be real numbers.

#### What are the relevant tickets?
Closes #98 
Closes #99

cc: @angaither @DFurnes @aaronschachter 