### PR TITLE
Save Parse IDs to the user doc

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -68,6 +68,13 @@ class AuthController extends Controller
         } elseif ($token->user_id !== $user->_id) {
             throw new HttpException(403, 'You do not own this token.');
         } elseif ($token->delete()) {
+            // Remove Parse installation ID. Disables push notifications.
+            if ($request->has('parse_installation_ids')) {
+                $removeId = $request->get('parse_installation_ids');
+                $user->pull('parse_installation_ids', $removeId);
+                $user->save();
+            }
+
             return $this->respond('User logged out successfully.');
         } else {
             throw new HttpException(400, 'User could not log out. Please try again.');

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -70,7 +70,7 @@ class AuthController extends Controller
         } elseif ($token->delete()) {
             // Remove Parse installation ID. Disables push notifications.
             if ($request->has('parse_installation_ids')) {
-                $removeId = $request->get('parse_installation_ids');
+                $removeId = $request->parse_installation_ids;
                 $user->pull('parse_installation_ids', $removeId);
                 $user->save();
             }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,7 +25,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             'race', 'religion',
             'college_name', 'degree_type', 'major_name', 'hs_gradyear', 'hs_name', 'sat_math', 'sat_verbal', 'sat_writing',
             'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip', 'country',
-            'cgg_id', 'drupal_id', 'agg_id', 'source'
+            'cgg_id', 'drupal_id', 'agg_id', 'source',
+            'parse_installation_ids'
         ];
 
     /**
@@ -77,6 +78,15 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     {
         $interests = array_map('trim', explode(',', $value));
         $this->push('interests', $interests, true);
+    }
+
+    /**
+     * Mutator saves Parse installation ids as an array
+     */
+    public function setParseInstallationIdsAttribute($value)
+    {
+        $ids = array_map('trim', explode(',', $value));
+        $this->push('parse_installation_ids', $ids, true);
     }
 
     /**

--- a/database/seeds/TokenTableSeeder.php
+++ b/database/seeds/TokenTableSeeder.php
@@ -19,6 +19,11 @@ class TokenTableSeeder extends Seeder
             'key' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz0=',
             'user_id' => '5480c950bffebc651c8b456f'
         ));
+
+        Token::create(array(
+            'key' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz1=',
+            'user_id' => 'bf1039b0271bcc636aa5477c'
+        ));
     }
 
 }

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -106,6 +106,12 @@ class UserTableSeeder extends Seeder
             ]
         ]);
 
+        // Parse user to be logged out
+        User::create(array(
+            '_id' => 'bf1039b0271bcc636aa5477c',
+            'parse_installation_ids' => 'parse-abc123'
+        ));
+
         User::create(array(
             'email' => 'info@dosomething.org',
             'mobile' => '5555550104',

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -98,7 +98,8 @@ class UserTest extends TestCase
     {
         // Create a new user object
         $user = array(
-            'email' => 'newemail@dosomething.org'
+            'email' => 'newemail@dosomething.org',
+            'parse_installation_ids' => 'parse-abc123',
         );
 
         $response = $this->call('PUT', 'v1/users/5480c950bffebc651c8b456f', [], [], [], $this->server, json_encode($user));
@@ -113,6 +114,14 @@ class UserTest extends TestCase
 
         // Response should return updated at and id columns
         $this->assertArrayHasKey('updated_at', $data['data']);
+
+        // Verify user data got updated
+        $getResponse = $this->call('GET', 'v1/users/_id/5480c950bffebc651c8b456f', [], [], [], $this->server);
+        $getContent = $getResponse->getContent();
+        $updatedUser = json_decode($getContent, true);
+
+        $this->assertEquals('newemail@dosomething.org', $updatedUser['data'][0]['email']);
+        $this->assertEquals('parse-abc123', $updatedUser['data'][0]['parse_installation_ids'][0]);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Parse will be used to handle push notifications for our app on both Android and iOS. In preparation of Northstar or other services to send notifications to users, we need to know each user's Parse installation ID. This PR:

- Allows the ids to be saved as an array under `parse_installation_ids` in case there are multiple devices per user
- Removes the id on logout if specified. This can effectively ensure a user won't be notified on that device.
- Unit tests

#### Where should the reviewer start?

##### User.php
Adds `parse_installation_ids` to the fillable array and a mutator to convert it from a comma-separated string to be saved as an array on the DB.

##### AuthController.php
If `parse_installation_ids` is included in the logout request, we remove that ID from the user doc.

#### What are the relevant tickets?
Closes #101 

cc: @DFurnes @sbsmith86 