### PR TITLE
Reportback Pushnotifications

### DIFF
--- a/app/Events/UserReportedBack.php
+++ b/app/Events/UserReportedBack.php
@@ -1,0 +1,25 @@
+<?php namespace Northstar\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Northstar\Models\User;
+use Northstar\Models\Campaign;
+
+class UserReportedBack extends Event {
+
+	use SerializesModels;
+
+	public $user;
+	public $campaign;
+
+	/**
+	 * Create a new event instance.
+	 *
+	 * @return void
+	 */
+	public function __construct(User $user, Campaign $campaign)
+	{
+		$this->user = $user;
+		$this->campaign = $campaign;
+	}
+
+}

--- a/app/Handlers/Events/SendReportbackPushNotification.php
+++ b/app/Handlers/Events/SendReportbackPushNotification.php
@@ -1,0 +1,55 @@
+<?php namespace Northstar\Handlers\Events;
+
+use Northstar\Events\UserReportedBack;
+use Northstar\Models\User;
+
+use Northstar\Services\Parse;
+
+
+class SendReportbackPushNotification {
+
+  /**
+   * Parse API wrapper.
+   * @var Parse
+   */
+  protected $parse;
+
+	/**
+	 * Create the event handler.
+	 *
+	 * @return void
+	 */
+  public function __construct(Parse $parse)
+  {
+    $this->parse = $parse;
+  }
+
+	/**
+	 * Handle the event.
+	 *
+	 * @param  UserReportedBack  $event
+	 * @return void
+	 */
+	public function handle(UserReportedBack $event)
+	{
+
+		$group = User::group($event->campaign->signup_id);
+
+	  if (count($group) > 0) {
+	    // Loop through the users in the group.
+	    foreach ($group as $user) {
+	      $drupal_id = $user->drupal_id;
+	      // Check that this user is not the user that triggered the event.
+	      if ($drupal_id !== $event->user->drupal_id) {
+	        // @TODO - This is placeholder content.
+	        $data = array("alert" => "A user in your group just reported back");
+
+	        // Send notifications to the users devices.
+	        if (!empty($user->parse_installation_ids)) {
+	          $this->parse->sendPushNotification($user->parse_installation_ids, $data);
+	        }
+	      }
+	    }
+	  }
+	}
+}

--- a/app/Handlers/Events/SendReportbackPushNotification.php
+++ b/app/Handlers/Events/SendReportbackPushNotification.php
@@ -14,42 +14,42 @@ class SendReportbackPushNotification {
    */
   protected $parse;
 
-	/**
-	 * Create the event handler.
-	 *
-	 * @return void
-	 */
+  /**
+   * Create the event handler.
+   *
+   * @return void
+   */
   public function __construct(Parse $parse)
   {
     $this->parse = $parse;
   }
 
-	/**
-	 * Handle the event.
-	 *
-	 * @param  UserReportedBack  $event
-	 * @return void
-	 */
-	public function handle(UserReportedBack $event)
-	{
+  /**
+   * Handle the event.
+   *
+   * @param  UserReportedBack  $event
+   * @return void
+   */
+  public function handle(UserReportedBack $event)
+  {
 
-		$group = User::group($event->campaign->signup_id);
+    $group = User::group($event->campaign->signup_id);
 
-	  if (count($group) > 0) {
-	    // Loop through the users in the group.
-	    foreach ($group as $user) {
-	      $drupal_id = $user->drupal_id;
-	      // Check that this user is not the user that triggered the event.
-	      if ($drupal_id !== $event->user->drupal_id) {
-	        // @TODO - This is placeholder content.
-	        $data = array("alert" => "A user in your group just reported back");
+    if (count($group) > 0) {
+      // Loop through the users in the group.
+      foreach ($group as $user) {
+        $drupal_id = $user->drupal_id;
+        // Check that this user is not the user that triggered the event.
+        if ($drupal_id !== $event->user->drupal_id) {
+          // @TODO - This is placeholder content.
+          $data = array("alert" => "A user in your group just reported back");
 
-	        // Send notifications to the users devices.
-	        if (!empty($user->parse_installation_ids)) {
-	          $this->parse->sendPushNotification($user->parse_installation_ids, $data);
-	        }
-	      }
-	    }
-	  }
-	}
+          // Send notifications to the users devices.
+          if (!empty($user->parse_installation_ids)) {
+            $this->parse->sendPushNotification($user->parse_installation_ids, $data);
+          }
+        }
+      }
+    }
+  }
 }

--- a/app/Handlers/Events/SendSignupPushNotification.php
+++ b/app/Handlers/Events/SendSignupPushNotification.php
@@ -30,14 +30,13 @@ class SendSignupPushNotification {
    */
   public function handle(UserSignedUp $event)
   {
-    // Get signup group.
-    $group = User::where('campaigns', 'elemMatch', ['signup_id' => (int)$event->campaign->signup_id])
-            ->orWhere('campaigns', 'elemMatch', ['signup_source' => $event->campaign->signup_id])->get();
+    $group = User::group($event->campaign->signup_id);
 
     if (count($group) > 0) {
       // Loop through the users in the group.
       foreach ($group as $user) {
         $drupal_id = $user->drupal_id;
+
         // Check that this user is not the user that triggered the event.
         if ($drupal_id !== $event->user->drupal_id) {
           // @TODO - This is placeholder content.

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Northstar\Events\UserSignedUp;
+use Northstar\Events\UserReportedBack;
 use Northstar\Models\Campaign;
 use Northstar\Models\User;
 use Northstar\Services\DrupalAPI;
@@ -169,6 +170,9 @@ class CampaignController extends Controller
 
         $campaign->reportback_id = $reportback_id;
         $campaign->save();
+
+        // Fire reportback event.
+        event(new UserReportedBack($user, $campaign));
 
         return $this->respond(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], $statusCode);
     }

--- a/app/Http/Controllers/KudosController.php
+++ b/app/Http/Controllers/KudosController.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Northstar\Services\DrupalAPI;
 use Northstar\Models\User;
+use Northstar\Events\UserGotKudo;
 
 
 class KudosController extends Controller

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -134,4 +134,14 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         return $user;
     }
 
+    /**
+     * Scope a query to get all of the users in a group.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeGroup($query, $signup_id)
+    {
+        // Get signup group.
+        return $query->where('campaigns', 'elemMatch', ['signup_id' => (int)$signup_id])->orWhere('campaigns', 'elemMatch', ['signup_source' => $signup_id])->get();
+    }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -18,6 +18,9 @@ class EventServiceProvider extends ServiceProvider
         'Northstar\Events\UserGotKudo' => [
             'Northstar\Handlers\Events\SendKudoPushNotification',
         ],
+        'Northstar\Events\UserReportedBack' => [
+            'Northstar\Handlers\Events\SendReportbackPushNotification',
+        ],
     ];
     /**
      * Register any other events for your application.


### PR DESCRIPTION
### What does this PR do?

This PR creates new Event/Handler classes for the reportback event, allowing us to fire an event when a user reports back. 

In the event handler, we look for the users group and send a notification to everyone else in the group. 

**Some organizational changes:**
- I moved the query that gets a user's group into a query scope function that accepts a sign up id, so we can easily reuse this query around the codebase.

- Found a issue in my set up of the Kudo event class, where the `KudosController` wasn't pulling in the event class so it wouldn't work. This PR fixes that.