### PR TITLE
401 status code on invalid or missing token

### DIFF
--- a/app/Http/Middleware/AuthenticateToken.php
+++ b/app/Http/Middleware/AuthenticateToken.php
@@ -3,6 +3,7 @@
 use Northstar\Models\Token;
 use Closure;
 use Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class AuthenticateToken
 {
@@ -13,16 +14,17 @@ class AuthenticateToken
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure $next
      * @return mixed
+     * @throws HttpException
      */
     public function handle($request, Closure $next)
     {
         $token = $request->header('Session');
         if (!$token) {
-            return Response::json("No token found.");
+            throw new HttpException(401, 'No token found.');
         }
 
         if (!Token::where('key', '=', $token)->exists()) {
-            return Response::json("Token mismatched.");
+            throw new HttpException(401, 'Token mismatched.');
         }
 
         return $next($request);

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -32,6 +32,19 @@ class AuthTest extends TestCase
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
             'HTTP_Session' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz1='
         );
+
+        $this->serverMissingToken = array(
+            'HTTP_Accept' => 'application/json',
+            'HTTP_X-DS-Application-Id' => '456',
+            'HTTP_X-DS-REST-API-Key' => 'abc4324',
+        );
+
+        $this->serverFakeToken = array(
+            'HTTP_Accept' => 'application/json',
+            'HTTP_X-DS-Application-Id' => '456',
+            'HTTP_X-DS-REST-API-Key' => 'abc4324',
+            'HTTP_Session' => 'thisisafaketoken',
+        );
     }
 
     /**
@@ -109,5 +122,25 @@ class AuthTest extends TestCase
         $user = json_decode($getContent, true);
 
         $this->assertEquals(0, count($user['data'][0]['parse_installation_ids']));
+    }
+
+    /**
+     * Tests that a proper error is thrown when a route requiring an auth token
+     * is given no token.
+     */
+    public function testMissingToken() {
+        $response = $this->call('GET', 'v1/user/campaigns/123', [], [], [], $this->serverMissingToken);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    /**
+     * Tests that a proper error is thrown when a route requiring an auth token
+     * is given a fake token.
+     */
+    public function testFakeToken() {
+        $response = $this->call('GET', 'v1/user/campaigns/123', [], [], [], $this->serverFakeToken);
+
+        $this->assertEquals(401, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
#### What's this PR do?
When an auth token is either invalid or missing, we now return a 401 status code instead of a 200.

This also adds unit tests to check both of those cases.

#### Where should the reviewer start?
- `AuthenticateToken.php`: By throwing `HttpException`s, we allow the exception handler to deal with the response in its structured way. This is also how we've been handling other non-200 types of errors elsewhere.
- `AuthTest.php`: Hello unit tests.

#### What are the relevant tickets?
Closes  #156 