### PR TITLE
Duplicate signup returns campaign object instead of 401

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -99,7 +99,7 @@ class CampaignController extends Controller
 
         if ($campaign) {
             // Campaign already signed up for. Return existing campaign object.
-            $response = $campaign;
+            return $this->respond($campaign, 200);
         } else {
             // Create a Drupal signup via Drupal API, and store signup ID in Northstar.
             $signup_id = $this->drupal->campaignSignup($user->drupal_id, $campaign_id, $request->input('source'));
@@ -118,9 +118,9 @@ class CampaignController extends Controller
                 'signup_id' => $campaign->signup_id,
                 'created_at' => $campaign->created_at,
             );
-        }
 
-        return $this->respond($response, 201);
+            return $this->respond($response, 201);
+        }
     }
 
 

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -98,26 +98,27 @@ class CampaignController extends Controller
         $campaign = $user->campaigns()->where('drupal_id', $campaign_id)->first();
 
         if ($campaign) {
-            throw new HttpException(401, 'Campaign signup already exists.');
+            // Campaign already signed up for. Return existing campaign object.
+            $response = $campaign;
+        } else {
+            // Create a Drupal signup via Drupal API, and store signup ID in Northstar.
+            $signup_id = $this->drupal->campaignSignup($user->drupal_id, $campaign_id, $request->input('source'));
+
+            // Save reference to the signup on the user object.
+            $campaign = new Campaign;
+            $campaign->drupal_id = $campaign_id;
+            $campaign->signup_id = $signup_id;
+            $campaign->signup_source = $request->input('source');
+            $campaign = $user->campaigns()->save($campaign);
+
+            // Fire sign up event.
+            event(new UserSignedUp($user, $campaign));
+
+            $response = array(
+                'signup_id' => $campaign->signup_id,
+                'created_at' => $campaign->created_at,
+            );
         }
-
-        // Create a Drupal signup via Drupal API, and store signup ID in Northstar.
-        $signup_id = $this->drupal->campaignSignup($user->drupal_id, $campaign_id, $request->input('source'));
-
-        // Save reference to the signup on the user object.
-        $campaign = new Campaign;
-        $campaign->drupal_id = $campaign_id;
-        $campaign->signup_id = $signup_id;
-        $campaign->signup_source = $request->input('source');
-        $campaign = $user->campaigns()->save($campaign);
-
-        // Fire sign up event.
-        event(new UserSignedUp($user, $campaign));
-
-        $response = array(
-            'signup_id' => $campaign->signup_id,
-            'created_at' => $campaign->created_at,
-        );
 
         return $this->respond($response, 201);
     }

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -57,7 +57,7 @@ class CampaignTest extends TestCase
 
     /**
      * Test for retrieving a user's campaigns
-     * GET /users/campaigns
+     * GET /users/:term/:id/campaigns
      *
      * @return void
      */
@@ -76,7 +76,7 @@ class CampaignTest extends TestCase
 
     /**
      * Test for submiting a campaign signup
-     * POST /campaigns/:nid/signup
+     * POST /user/campaigns/:nid/signup
      *
      * @return void
      */
@@ -105,8 +105,29 @@ class CampaignTest extends TestCase
     }
 
     /**
+     * Test for submitting a duplicate campaign signup
+     * POST /user/campaigns/:nid/signup
+     *
+     * @return void
+     */
+    public function testDuplicateCampaignSignup()
+    {
+        $payload = ['source' => 'test'];
+
+        $response = $this->call('POST', 'v1/user/campaigns/123/signup', [], [], [], $this->signedUpServer, json_encode($payload));
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+
+        // Verify a 200 status code
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Verify the signup_id is the same as what was already there
+        $this->assertEquals(100, $data['data']['signup_id']);
+    }
+
+    /**
      * Test for submitting a new campaign report back.
-     * POST /campaigns/:nid/reportback
+     * POST /user/campaigns/:nid/reportback
      *
      * @return void
      */
@@ -140,7 +161,7 @@ class CampaignTest extends TestCase
 
     /**
      * Test for successful update of an existing campaign report back.
-     * PUT /campaigns/:nid/reportback
+     * PUT /user/campaigns/:nid/reportback
      *
      * @return void
      */
@@ -174,7 +195,7 @@ class CampaignTest extends TestCase
 
     /**
      * Test for creating a reportback when signup does not exist.
-     * PUT /campaigns/:nid/reportback
+     * PUT /user/campaigns/:nid/reportback
      *
      * @return void
      */


### PR DESCRIPTION
#### What's this PR do?
On a duplicate signup, instead of responding with a 401 and an error code, respond with the existing campaign object. And while creating a new signup will still respond with a 201, on duplicates we'll respond with a 200.

This also adds a unit test to check the duplicate scenario.

#### Where should the reviewer start?
- `CampaignController.php`: The only real new thing happening here is:
```
if ($campaign) {
  // Campaign already signed up for. Return existing campaign object.
  return $this->respond($campaign, 200);
} else {
  ...
```
  Everything else from before is just getting thrown inside the `else` block.

- `CampaignTest.php`: The new test takes advantage of the `$this->signedUpServer` which was configured with a user who had already signed up for campaign `123`.

#### What are the relevant tickets?
Closes #157 