### PR TITLE
Added signup_group parameter for storing invite code

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -109,6 +109,8 @@ class CampaignController extends Controller
             $campaign->drupal_id = $campaign_id;
             $campaign->signup_id = $signup_id;
             $campaign->signup_source = $request->input('source');
+            // If group is specified, use that. Otherwise, use the signup_id.
+            $campaign->signup_group = $request->input('group') ?: $signup_id;
             $campaign = $user->campaigns()->save($campaign);
 
             // Fire sign up event.
@@ -116,6 +118,8 @@ class CampaignController extends Controller
 
             $response = array(
                 'signup_id' => $campaign->signup_id,
+                'signup_source' => $campaign->signup_source,
+                'signup_group' => $campaign->signup_group,
                 'created_at' => $campaign->created_at,
             );
 

--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -17,9 +17,9 @@ class SignupGroupController extends Controller
      */
     public function show($id)
     {
-        // signup_id is saved as a number and signup_source is saved as a string
+        // signup_id and signup_group are saved as numbers
         $group = User::where('campaigns', 'elemMatch', ['signup_id' => (int)$id])
-                        ->orWhere('campaigns', 'elemMatch', ['signup_source' => $id])->get();
+                        ->orWhere('campaigns', 'elemMatch', ['signup_group' => (int)$id])->get();
 
         if (count($group) == 0) {
             throw new NotFoundHttpException("No users found for the group ID.");
@@ -27,7 +27,7 @@ class SignupGroupController extends Controller
             // Get the campaign id associated with the signup group ID
             for ($i = 0; $i < count($group[0]->campaigns); $i++) {
                 $campaign = $group[0]->campaigns[$i];
-                if ($campaign->signup_id == $id || $campaign->signup_source == $id) {
+                if ($campaign->signup_id == $id || $campaign->signup_group == $id) {
                     $campaign_id = $campaign->drupal_id;
                     break;
                 }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -26,7 +26,8 @@ class Campaign extends Eloquent
     protected $casts = [
         'quantity' => 'integer',
         'reportback_id' => 'integer',
-        'signup_id' => 'integer'
+        'signup_id' => 'integer',
+        'signup_group' => 'integer',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -142,6 +142,6 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function scopeGroup($query, $signup_id)
     {
         // Get signup group.
-        return $query->where('campaigns', 'elemMatch', ['signup_id' => (int)$signup_id])->orWhere('campaigns', 'elemMatch', ['signup_source' => $signup_id])->get();
+        return $query->where('campaigns', 'elemMatch', ['signup_id' => (int)$signup_id])->orWhere('campaigns', 'elemMatch', ['signup_group' => (int)$signup_id])->get();
     }
 }

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -102,7 +102,8 @@ class UserTableSeeder extends Seeder
                     '_id' => '3f10c910251bcc636aa5477b',
                     'drupal_id' => 123,
                     'signup_id' => 102,
-                    'signup_source' => '100'
+                    'signup_source' => 'test',
+                    'signup_group' => 100
                 ]
             ]
         ]);


### PR DESCRIPTION
#### What's this PR do?
Previously we used `signup_source` to store both source info (like, this signup is from web or SMS, etc) or an invite code if the user was invited to sign up to the campaign by another. This was done out of a desire to not create a new column on the Drupal backend when we were thinking of storing this info there. But now that we're just storing it here in Northstar, let's just give it its own parameter.

In practice, for app devs signing up a user via an invite, this means that instead of sending the invite code in the `source` parameter, it'll need to be sent in the `group` parameter.

#### Where should the reviewer start?
- `CampaignController.php` - This is the bulk of the logic that needed to change. `signup_source` stays and can be used strictly for tracking source. `signup_group` is populated by either a `group` value provided in the request, or the user's own `signup_id`.
- `SignupGroupController.php` and `User.php` - Logic updated to look at `signup_group` to determine if users are in the same group.
- `Campaign.php` - `signup_group` is an integer, like `signup_id`
- `UserTableSeeder.php` - Updating test doc to make unit tests happy

#### Testing done?
Verified phpunit tests were working. Though one seems to be failing due to a separate issue (#158)

#### Things to do before the merge
Update documentation on the wiki: https://github.com/DoSomething/api/wiki/Mobile-App-Usage

#### What are the relevant tickets?
Closes #149