### PR TITLE
Returning null values for user and campaigns properties not set

### DIFF
--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -40,7 +40,7 @@ class AvatarController extends Controller
         $user->save();
 
         // Respond to user with success and photo URL
-        return $this->respond(['url' => $filename]);
+        return $this->respond($user);
     }
 }
 

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -111,10 +111,10 @@ class CampaignController extends Controller
         // Check if campaign signup already exists.
         $campaign = $user->campaigns()->where('drupal_id', $campaign_id)->first();
 
+        $statusCode = 200;
         if ($campaign) {
-            // Campaign already signed up for. Return existing campaign object.
-            return $this->respond($campaign, 200);
-        } else {
+            $statusCode = 201;
+
             // Create a Drupal signup via Drupal API, and store signup ID in Northstar.
             $signup_id = $this->drupal->campaignSignup($user->drupal_id, $campaign_id, $request->input('source'));
 
@@ -129,16 +129,9 @@ class CampaignController extends Controller
 
             // Fire sign up event.
             event(new UserSignedUp($user, $campaign));
-
-            $response = array(
-                'signup_id' => $campaign->signup_id,
-                'signup_source' => $campaign->signup_source,
-                'signup_group' => $campaign->signup_group,
-                'created_at' => $campaign->created_at,
-            );
-
-            return $this->respond($response, 201);
         }
+
+        return $this->respond($campaign, $statusCode);
     }
 
     /**

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -112,7 +112,7 @@ class CampaignController extends Controller
         $campaign = $user->campaigns()->where('drupal_id', $campaign_id)->first();
 
         $statusCode = 200;
-        if ($campaign) {
+        if (!$campaign) {
             $statusCode = 201;
 
             // Create a Drupal signup via Drupal API, and store signup ID in Northstar.

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -29,6 +29,7 @@ class Kernel extends HttpKernel
         'auth.api' => 'Northstar\Http\Middleware\AuthenticateAPI',
         'guest' => 'Northstar\Http\Middleware\RedirectIfAuthenticated',
         'user' => 'Northstar\Http\Middleware\UserResponseMiddleware',
+        'campaign' => 'Northstar\Http\Middleware\CampaignResponseMiddleware',
     ];
 
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends HttpKernel
         'auth.token' => 'Northstar\Http\Middleware\AuthenticateToken',
         'auth.api' => 'Northstar\Http\Middleware\AuthenticateAPI',
         'guest' => 'Northstar\Http\Middleware\RedirectIfAuthenticated',
+        'user' => 'Northstar\Http\Middleware\UserResponseMiddleware',
     ];
 
 }

--- a/app/Http/Middleware/CampaignResponseMiddleware.php
+++ b/app/Http/Middleware/CampaignResponseMiddleware.php
@@ -10,17 +10,22 @@ class CampaignResponseMiddleware {
     public function handle($request, Closure $next)
     {
         $response = $next($request);
+        if (!is_object($response)) {
+            return $response;
+        }
+
+        $statusCode = $response->getStatusCode();
         $response = $response->getData();
 
         if (is_array($response->data)) {
             foreach ($response->data as $campaign) {
-                self::fillCampaign($campaign);
+                $this->fillCampaign($campaign);
             }
         } elseif (is_object($response->data)) {
-            self::fillCampaign($response->data);
+            $this->fillCampaign($response->data);
         }
 
-        return json_encode($response);
+        return response()->json($response, $statusCode, array(), JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/app/Http/Middleware/CampaignResponseMiddleware.php
+++ b/app/Http/Middleware/CampaignResponseMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use Closure;
+use Northstar\Models\Campaign;
+
+class CampaignResponseMiddleware {
+
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        $response = $response->getData();
+
+        if (is_array($response->data)) {
+            foreach ($response->data as $campaign) {
+                self::fillCampaign($campaign);
+            }
+        } elseif (is_object($response->data)) {
+            self::fillCampaign($response->data);
+        }
+
+        return json_encode($response);
+    }
+
+    /**
+     * For all Campaign attributes not hidden, where keys are unset, set those
+     * value to null.
+     *
+     * @param $campaign User campaign activity data
+     */
+    private function fillCampaign(&$campaign)
+    {
+        $tmp = new Campaign();
+
+        $attrsNotHidden = array_diff($tmp->getAttributes(), $tmp->getHidden());
+
+        foreach ($attrsNotHidden as $key => $value) {
+            $campaign->$key = isset($campaign->$key) ? $campaign->$key : null;
+        }
+    }
+}

--- a/app/Http/Middleware/UserResponseMiddleware.php
+++ b/app/Http/Middleware/UserResponseMiddleware.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use Northstar\Models\User;
+use Closure;
+
+class UserResponseMiddleware {
+
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        $response = $response->getData();
+
+        // Ensure user objects have all fillable properties set with
+        if (is_array($response->data)) {
+            foreach ($response->data as $user) {
+                self::fillWithNullValues($user);
+            }
+        }
+        else if (is_object($response->data)) {
+            self::fillWithNullValues($response->data);
+        }
+
+        return json_encode($response);
+    }
+
+    /**
+     * For any fillable User properties that are not hidden, set values to keys
+     * that are unset to null.
+     *
+     * @param $user User object
+     */
+    private function fillWithNullValues(&$user)
+    {
+        $tmp = new User();
+
+        $fillableNotHidden = array_diff($tmp->getFillable(), $tmp->getHidden());
+
+        foreach ($fillableNotHidden as $key) {
+            $user->$key = isset($user->$key) ?: null;
+        }
+    }
+
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -19,12 +19,15 @@ Route::get('/', function () {
 Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     // Campaigns.
     Route::group(['middleware' => 'auth.token'], function () {
-        Route::get('user/campaigns/{campaign_id}', 'CampaignController@show');
-        Route::post('user/campaigns/{campaign_id}/signup', 'CampaignController@signup');
-        Route::post('user/campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
-        Route::put('user/campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
         Route::post('kudos', 'KudosController@store');
         Route::delete('kudos', 'KudosController@delete');
+
+        Route::group(['middleware' => 'campaign'], function () {
+            Route::get('user/campaigns/{campaign_id}', 'CampaignController@show');
+            Route::post('user/campaigns/{campaign_id}/signup', 'CampaignController@signup');
+            Route::post('user/campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
+            Route::put('user/campaigns/{campaign_id}/reportback', 'CampaignController@reportback');
+        });
     });
 
     // Sessions.
@@ -34,9 +37,12 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     // Users.
     Route::group(['middleware' => 'user'], function() {
         Route::resource('users', 'UserController');
-        Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
         Route::get('users/{term}/{id}', 'UserController@show');
         Route::post('users/{id}/avatar', 'AvatarController@store');
+
+        Route::group(['middleware' => 'campaign'], function () {
+            Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
+        });
     });
 
     // Signup Groups.

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -32,10 +32,12 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     Route::post('logout', 'AuthController@logout');
 
     // Users.
-    Route::resource('users', 'UserController');
-    Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
-    Route::get('users/{term}/{id}', 'UserController@show');
-    Route::post('users/{id}/avatar', 'AvatarController@store');
+    Route::group(['middleware' => 'user'], function() {
+        Route::resource('users', 'UserController');
+        Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
+        Route::get('users/{term}/{id}', 'UserController@show');
+        Route::post('users/{id}/avatar', 'AvatarController@store');
+    });
 
     // Signup Groups.
     Route::get('signup-group/{id}', 'SignupGroupController@show');

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -38,4 +38,17 @@ class Campaign extends Eloquent
      */
     protected $dates = ['created_at', 'updated_at'];
 
+    /**
+     * Setting default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'drupal_id' => null,
+        'reportback_id' => null,
+        'signup_group' => null,
+        'signup_id' => null,
+        'signup_source' => null,
+    ];
+
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,15 +19,15 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
     use Authenticatable, CanResetPassword;
 
-    protected $fillable =
-        ['email', 'mobile', 'password', 'drupal_password',
-            'first_name', 'last_name', 'birthdate', 'photo', 'interests',
-            'race', 'religion',
-            'school_id' ,'college_name', 'degree_type', 'major_name', 'hs_gradyear', 'hs_name', 'sat_math', 'sat_verbal', 'sat_writing',
-            'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip', 'country',
-            'cgg_id', 'drupal_id', 'agg_id', 'source',
-            'parse_installation_ids'
-        ];
+    protected $fillable = [
+        'email', 'mobile', 'password', 'drupal_password',
+        'first_name', 'last_name', 'birthdate', 'photo', 'interests',
+        'race', 'religion',
+        'school_id' ,'college_name', 'degree_type', 'major_name', 'hs_gradyear', 'hs_name', 'sat_math', 'sat_verbal', 'sat_writing',
+        'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip', 'country',
+        'cgg_id', 'drupal_id', 'agg_id', 'source',
+        'parse_installation_ids'
+    ];
 
     /**
      * The database collection used by the model.
@@ -41,7 +41,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      *
      * @var array
      */
-    protected $hidden = ['password'];
+    protected $hidden = ['drupal_password', 'password'];
 
     /**
      * The attributes that should be casted to native types.


### PR DESCRIPTION
Sorta feels hacky? But other than modifying all documents already in the db to store null values for properties, there doesn't seem to be a better way to handle this other than with middleware.

#### What's this PR do?

Modifies the responses that include user and campaign objects to return all possible properties for them even if they're not set. Values default to null.

This is all the result of discussion that happened here: https://github.com/DoSomething/northstar/issues/153

Endpoints affected:

- `GET user/campaigns/{campaign_id}`
- `POST user/campaigns/{campaign_id}/signup`
- `POST user/campaigns/{campaign_id}/reportback`
- `PUT user/campaigns/{campaign_id}/reportback`
- `GET users/{term}/{id}`
- `POST users/{id}/avatar`
- `GET users/{term}/{id}/campaigns`

#### Where should the reviewer start?
The majority of the changes are in the new middleware files. Basically it's intercepting the response before it goes back to the user and fills in User and Campaign properties with null values for keys that aren't set.

#### Any background context?
https://github.com/DoSomething/northstar/issues/153

#### What are the relevant tickets?
Closes #155