### PR TITLE
GET /signup-group fixes and reportback data

### DIFF
--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -8,6 +8,11 @@ class SignupGroupController extends Controller
 {
     protected $drupal;
 
+    public function __construct(DrupalAPI $drupal)
+    {
+        $this->drupal = $drupal;
+    }
+
     /**
      * Display the users who share the specified signup group id.
      * GET /signup-group/:id
@@ -36,9 +41,6 @@ class SignupGroupController extends Controller
             }
         }
 
-        // Drupal API client
-        $drupal = new DrupalAPI;
-
         foreach ($group as &$user) {
             if (isset($user->campaigns)) {
                 for ($i = 0; $i < count($user->campaigns); $i++) {
@@ -50,7 +52,7 @@ class SignupGroupController extends Controller
 
                     if (isset($user->campaigns[$i]->reportback_id)) {
                         // get reportback data from drupal
-                        $rbResponse = $drupal->reportbackContent($user->campaigns[$i]->reportback_id);
+                        $rbResponse = $this->drupal->reportbackContent($user->campaigns[$i]->reportback_id);
                         $user->campaigns[$i]->reportback_data = $rbResponse['data'];
                     }
                 }

--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -1,10 +1,12 @@
 <?php namespace Northstar\Http\Controllers;
 
 use Northstar\Models\User;
+use Northstar\Services\DrupalAPI;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SignupGroupController extends Controller
 {
+    protected $drupal;
 
     /**
      * Display the users who share the specified signup group id.
@@ -18,28 +20,49 @@ class SignupGroupController extends Controller
     public function show($id)
     {
         // signup_id and signup_group are saved as numbers
-        $group = User::where('campaigns', 'elemMatch', ['signup_id' => (int)$id])
-                        ->orWhere('campaigns', 'elemMatch', ['signup_group' => (int)$id])->get();
+        $group = User::where('campaigns', 'elemMatch', ['signup_id' => $id])
+                        ->orWhere('campaigns', 'elemMatch', ['signup_group' => $id])->get();
 
         if (count($group) == 0) {
             throw new NotFoundHttpException("No users found for the group ID.");
-        } else {
-            // Get the campaign id associated with the signup group ID
-            for ($i = 0; $i < count($group[0]->campaigns); $i++) {
-                $campaign = $group[0]->campaigns[$i];
-                if ($campaign->signup_id == $id || $campaign->signup_group == $id) {
-                    $campaign_id = $campaign->drupal_id;
-                    break;
+        }
+
+        // Get the campaign id associated with the signup group ID
+        for ($i = 0; $i < count($group[0]->campaigns); $i++) {
+            $campaign = $group[0]->campaigns[$i];
+            if ($campaign->signup_id == $id || $campaign->signup_group == $id) {
+                $campaign_id = $campaign->drupal_id;
+                break;
+            }
+        }
+
+        // Drupal API client
+        $drupal = new DrupalAPI;
+
+        foreach ($group as &$user) {
+            if (isset($user->campaigns)) {
+                for ($i = 0; $i < count($user->campaigns); $i++) {
+                    // Cull campaigns that aren't associated with this group
+                    if ($user->campaigns[$i]->drupal_id != $campaign_id) {
+                        unset($user->campaigns[$i]);
+                        continue;
+                    }
+
+                    if (isset($user->campaigns[$i]->reportback_id)) {
+                        // get reportback data from drupal
+                        $rbResponse = $drupal->reportbackContent($user->campaigns[$i]->reportback_id);
+                        $user->campaigns[$i]->reportback_data = $rbResponse['data'];
+                    }
                 }
             }
-
-            $response = [
-                'campaign_id' => $campaign_id,
-                'users' => $group
-            ];
-
-            return $this->respond($response);
         }
+
+        $response = [
+            'campaign_id' => $campaign_id,
+            'users' => $group
+        ];
+
+        return $this->respond($response);
     }
 
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -35,14 +35,15 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     Route::post('logout', 'AuthController@logout');
 
     // Users.
-    Route::group(['middleware' => 'user'], function() {
+    Route::group(['middleware' => 'user'], function () {
         Route::resource('users', 'UserController');
         Route::get('users/{term}/{id}', 'UserController@show');
         Route::post('users/{id}/avatar', 'AvatarController@store');
+    });
 
-        Route::group(['middleware' => 'campaign'], function () {
-            Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
-        });
+    // User campaign activity.
+    Route::group(['middleware' => 'campaign'], function () {
+        Route::get('users/{term}/{id}/campaigns', 'CampaignController@index');
     });
 
     // Signup Groups.

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -56,7 +56,7 @@ class UserTableSeeder extends Seeder
                 [
                     '_id' => '5480c950bffebc651c8b456e',
                     'drupal_id' => 123,
-                    'signup_id' => 100,
+                    'signup_id' => '100',
                     'signup_source' => 'android'
                 ]
             ]
@@ -82,7 +82,7 @@ class UserTableSeeder extends Seeder
                 [
                     '_id' => '3f10c910251bcc636aa5477a',
                     'drupal_id' => 123,
-                    'signup_id' => 101,
+                    'signup_id' => '101',
                     'signup_source' => 'ios',
                     'reportback_id' => 125
                 ]
@@ -101,9 +101,9 @@ class UserTableSeeder extends Seeder
                 [
                     '_id' => '3f10c910251bcc636aa5477b',
                     'drupal_id' => 123,
-                    'signup_id' => 102,
+                    'signup_id' => '102',
                     'signup_source' => 'test',
-                    'signup_group' => 100
+                    'signup_group' => '100'
                 ]
             ]
         ]);


### PR DESCRIPTION
#### What's this PR do?

- Gets reportback data from Drupal for each user in a group who has reported back on the campaign associated with the group.
- Fix where `GET users/{term}/{id}/campaigns` was incorrectly being pushed through the `user` middleware.

#### Where should the reviewer start?
I think it's sorta straightforward? But let me know if there are any questions. I'll just pick out a couple of the more interesting changes:

-  I think I was wrong about the need to cast these ids in the query:
```
$group = User::where('campaigns', 'elemMatch', ['signup_id' => $id])
                       ->orWhere('campaigns', 'elemMatch', ['signup_group' => $id])->get();
```
  The casting only seems to happen in responses, but the data saved in the backend still ends up being a string because that's how we get it back from Drupal.
- Culling campaigns out of the response that aren't associated with the group. I was thinking it'd be weird if someone reported back for 10 campaigns, but only one of the campaign objects returned had the full reportback data. Or on the flip side, that it'd be unnecessary to get the reportback for all the other campaigns.
```
if ($user->campaigns[$i]->drupal_id != $campaign_id)
```

#### What are the relevant tickets?
Closes #163