### PR TITLE
Support to query for multiple signup groups

### DIFF
--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -27,16 +27,15 @@ class SignupGroupController extends Controller
         $response = [];
 
         if ($request->has('ids')) {
-            $groupIds = explode(',', $request->input('ids'));
+            $group_ids = explode(',', $request->input('ids'));
 
-            foreach ($groupIds as $groupId) {
-                $group = $this->getGroup($groupId);
+            foreach ($group_ids as $group_id) {
+                $group = $this->getGroup($group_id);
                 if (!empty($group)) {
                     $response[] = $group;
                 }
             }
-        }
-        else {
+        } else {
             throw new BadRequestHttpException("Missing ids query parameter.");
         }
 

--- a/app/Http/Middleware/CampaignResponseMiddleware.php
+++ b/app/Http/Middleware/CampaignResponseMiddleware.php
@@ -19,29 +19,13 @@ class CampaignResponseMiddleware {
 
         if (is_array($response->data)) {
             foreach ($response->data as $campaign) {
-                $this->fillCampaign($campaign);
+                Campaign::populateAllAttributes($campaign);
             }
         } elseif (is_object($response->data)) {
-            $this->fillCampaign($response->data);
+            Campaign::populateAllAttributes($response->data);
         }
 
         return response()->json($response, $statusCode, array(), JSON_UNESCAPED_SLASHES);
     }
 
-    /**
-     * For all Campaign attributes not hidden, where keys are unset, set those
-     * value to null.
-     *
-     * @param $campaign User campaign activity data
-     */
-    private function fillCampaign(&$campaign)
-    {
-        $tmp = new Campaign();
-
-        $attrsNotHidden = array_diff($tmp->getAttributes(), $tmp->getHidden());
-
-        foreach ($attrsNotHidden as $key => $value) {
-            $campaign->$key = isset($campaign->$key) ? $campaign->$key : null;
-        }
-    }
 }

--- a/app/Http/Middleware/UserResponseMiddleware.php
+++ b/app/Http/Middleware/UserResponseMiddleware.php
@@ -51,25 +51,8 @@ class UserResponseMiddleware {
         // Fill campaigns activity data too, if any
         if (!empty($user->campaigns) && is_array($user->campaigns)) {
             foreach ($user->campaigns as $campaign) {
-                $this->fillCampaign($campaign);
+                Campaign::populateAllAttributes($campaign);
             }
-        }
-    }
-
-    /**
-     * For all Campaign attributes not hidden, where keys are unset, set those
-     * value to null.
-     *
-     * @param $campaign User campaign activity data
-     */
-    private function fillCampaign(&$campaign)
-    {
-        $tmp = new Campaign();
-
-        $attrsNotHidden = array_diff($tmp->getAttributes(), $tmp->getHidden());
-
-        foreach ($attrsNotHidden as $key => $value) {
-            $campaign->$key = isset($campaign->$key) ? $campaign->$key : null;
         }
     }
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -47,6 +47,7 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth.api'], function () {
     });
 
     // Signup Groups.
+    Route::resource('signup-group', 'SignupGroupController');
     Route::get('signup-group/{id}', 'SignupGroupController@show');
 
     // Api Keys.

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -51,4 +51,27 @@ class Campaign extends Eloquent
         'signup_source' => null,
     ];
 
+    /**
+     * For all Campaign attributes not hidden, where keys are unset, set those
+     * value to null.
+     *
+     * @param $campaign User campaign activity data
+     */
+    public static function populateAllAttributes(&$campaign)
+    {
+        $tmp = new Campaign();
+
+        $attrs_not_hidden = array_diff($tmp->getAttributes(), $tmp->getHidden());
+
+        foreach ($attrs_not_hidden as $key => $value) {
+            if ($key == 'signup_group') {
+                $default_value = $campaign->signup_id;
+            } else {
+                $default_value = null;
+            }
+
+            $campaign->$key = isset($campaign->$key) ? $campaign->$key : $default_value;
+        }
+    }
+
 }


### PR DESCRIPTION
#### What's this PR do?

- Support for `GET /signup-group?ids=123,456,789`: Allows us to get multiple signup group info in a single call for app-side performance.
- (This one I feel less good about) If `signup_group` was saved as null or is not set, which is the case for signups done before PR #171, then it fills it in with the value of `signup_id`. This is logic that would otherwise have to happen client-side. So figured if done server-side, maybe it just stays in a single place. I'm pretty iffy on this one though, so if you give me one reason that I shouldn't do this, I'll yank it out of this PR.

#### Where should the reviewer start?

- **SignupGroupController.php**: The logic for getting signup group data was moved to private helper `getGroup` function. The `index()` function was added to account for the cases where we want to retrieve multiple group info. And both `index` and `show` essentially reuse the same logic in `getGroup` to do what they need to do.
- **Campaign.php** and __*ResponseMiddleware.php__: Logic for `fillCampaign` got moved to a singled location in the Campaign model - `populateAllAttributes()` - I'm open to a better name. Also adds the logic that responds with `signup_group = signup_id` if `signup_group` is not set.

#### What are the relevant tickets?
Closes #173

cc: @angaither @DFurnes @weerd 