### PR TITLE
Fix for crash that came from trying to access an undefined property

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -65,7 +65,7 @@ class Campaign extends Eloquent
 
         foreach ($attrs_not_hidden as $key => $value) {
             if ($key == 'signup_group') {
-                $default_value = $campaign->signup_id;
+                $default_value = isset($campaign->signup_id) ? $campaign->signup_id : null;
             } else {
                 $default_value = null;
             }


### PR DESCRIPTION
#### What's this PR do?

Fixes crash that comes from attempting to access `signup_id` when it's undefined. Can particularly be seen from sending a GET request to the `/users` endpoint. Also fixes unit tests that failed due to the aforementioned bug (oops :bow:)