### PR TITLE
Customized push notification for reportback event

### DIFF
--- a/app/Handlers/Events/SendReportbackPushNotification.php
+++ b/app/Handlers/Events/SendReportbackPushNotification.php
@@ -8,48 +8,46 @@ use Northstar\Services\Parse;
 
 class SendReportbackPushNotification {
 
-  /**
-   * Parse API wrapper.
-   * @var Parse
-   */
-  protected $parse;
+    /**
+     * Parse API wrapper.
+     * @var Parse
+     */
+    protected $parse;
 
-  /**
-   * Create the event handler.
-   *
-   * @return void
-   */
-  public function __construct(Parse $parse)
-  {
-    $this->parse = $parse;
-  }
-
-  /**
-   * Handle the event.
-   *
-   * @param  UserReportedBack  $event
-   * @return void
-   */
-  public function handle(UserReportedBack $event)
-  {
-
-    $group = User::group($event->campaign->signup_id);
-
-    if (count($group) > 0) {
-      // Loop through the users in the group.
-      foreach ($group as $user) {
-        $drupal_id = $user->drupal_id;
-        // Check that this user is not the user that triggered the event.
-        if ($drupal_id !== $event->user->drupal_id) {
-          // @TODO - This is placeholder content.
-          $data = array("alert" => "A user in your group just reported back");
-
-          // Send notifications to the users devices.
-          if (!empty($user->parse_installation_ids)) {
-            $this->parse->sendPushNotification($user->parse_installation_ids, $data);
-          }
-        }
-      }
+    /**
+     * Create the event handler.
+     *
+     * @return void
+     */
+    public function __construct(Parse $parse)
+    {
+        $this->parse = $parse;
     }
-  }
+
+    /**
+     * Handle the event.
+     *
+     * @param  UserReportedBack  $event
+     * @return void
+     */
+    public function handle(UserReportedBack $event)
+    {
+
+        $group = User::group($event->campaign->signup_id);
+
+        if (count($group) > 0) {
+            // Loop through the users in the group.
+            foreach ($group as $user) {
+                $drupal_id = $user->drupal_id;
+                // Check that this user is not the user that triggered the event.
+                if ($drupal_id !== $event->user->drupal_id && !empty($user->parse_installation_ids)) {
+                    // @TODO - This is placeholder content.
+                    $data = array("alert" => "A user in your group just reported back");
+
+                    // Send notifications to the user's devices.
+                    $this->parse->sendPushNotification($user->parse_installation_ids, $data);
+                }
+            }
+        }
+    }
 }

--- a/app/Handlers/Events/SendReportbackPushNotification.php
+++ b/app/Handlers/Events/SendReportbackPushNotification.php
@@ -39,7 +39,11 @@ class SendReportbackPushNotification {
      */
     public function handle(UserReportedBack $event)
     {
-        $group = User::group($event->campaign->signup_group);
+        if (!empty($event->campaign->signup_group)) {
+            $group = User::group($event->campaign->signup_group);
+        } else {
+            $group = [];
+        }
 
         // If group count is only 1, safe to assume the 1 user is the one who reported back
         if (count($group) <= 1) {

--- a/app/Handlers/Events/SendReportbackPushNotification.php
+++ b/app/Handlers/Events/SendReportbackPushNotification.php
@@ -87,16 +87,16 @@ class SendReportbackPushNotification {
                     'extras' => [
                         'completion' => [
                             'message' => $message,
-                        ],
-                        'group' => [
-                            'data' => [
-                                'campaign_id' => $event->campaign->drupal_id,
-                                'users' => $group,
-                            ]
-                        ],
-                        'reportback_items' => [
-                            'total' => 1,
-                            'data' => [$latest_item],
+                            'group' => [
+                                'data' => [
+                                    'campaign_id' => $event->campaign->drupal_id,
+                                    'users' => $group,
+                                ]
+                            ],
+                            'reportback_items' => [
+                                'total' => 1,
+                                'data' => [$latest_item],
+                            ],
                         ],
                     ],
                 ];

--- a/app/Handlers/Events/SendReportbackPushNotification.php
+++ b/app/Handlers/Events/SendReportbackPushNotification.php
@@ -2,7 +2,7 @@
 
 use Northstar\Events\UserReportedBack;
 use Northstar\Models\User;
-
+use Northstar\Services\DrupalAPI;
 use Northstar\Services\Parse;
 
 
@@ -15,13 +15,20 @@ class SendReportbackPushNotification {
     protected $parse;
 
     /**
+     * Drupal API wrapper
+     * @var DrupalAPI
+     */
+    protected $drupal;
+
+    /**
      * Create the event handler.
      *
      * @return void
      */
-    public function __construct(Parse $parse)
+    public function __construct(Parse $parse, DrupalAPI $drupal)
     {
         $this->parse = $parse;
+        $this->drupal = $drupal;
     }
 
     /**
@@ -32,21 +39,50 @@ class SendReportbackPushNotification {
      */
     public function handle(UserReportedBack $event)
     {
+        $group = User::group($event->campaign->signup_group);
 
-        $group = User::group($event->campaign->signup_id);
+        // If group count is only 1, safe to assume the 1 user is the one who reported back
+        if (count($group) <= 1) {
+            return;
+        }
 
-        if (count($group) > 0) {
-            // Loop through the users in the group.
-            foreach ($group as $user) {
-                $drupal_id = $user->drupal_id;
-                // Check that this user is not the user that triggered the event.
-                if ($drupal_id !== $event->user->drupal_id && !empty($user->parse_installation_ids)) {
-                    // @TODO - This is placeholder content.
-                    $data = array("alert" => "A user in your group just reported back");
+        // Get reportback content
+        $reportback_response = $this->drupal->reportbackContent($event->campaign->reportback_id);
 
-                    // Send notifications to the user's devices.
-                    $this->parse->sendPushNotification($user->parse_installation_ids, $data);
-                }
+        // Assuming the last item in this array is the latest reportback submitted
+        $reportback_items = $reportback_response['data']['reportback_items']['data']['total'];
+        $latest_item = $reportback_response['data']['reportback_items']['data'][$reportback_items - 1];
+
+        // Loop through the users in the group.
+        foreach ($group as $user) {
+            $drupal_id = $user->drupal_id;
+            // Check that this user is not the user that triggered the event.
+            if ($drupal_id !== $event->user->drupal_id && !empty($user->parse_installation_ids)) {
+                // @TODO The user id and campaign id need to be turned into user name and campaign name
+                $message = $event->user->drupal_id . ' shared a photo in your ' . $event->campaign->drupal_id . ' group.';
+
+                // @TODO group.data.users doesn't include detailed reportback info for each user, is that ok?
+                $data = [
+                    'alert' => $message,
+                    'extras' => [
+                        'completion' => [
+                            'message' => $message,
+                        ],
+                        'group' => [
+                            'data' => [
+                                'campaign_id' => $event->campaign->drupal_id,
+                                'users' => $group,
+                            ]
+                        ],
+                        'reportback_items' => [
+                            'total' => 1,
+                            'data' => [$latest_item],
+                        ],
+                    ],
+                ];
+
+                // Send notifications to the user's devices.
+                $this->parse->sendPushNotification($user->parse_installation_ids, $data);
             }
         }
     }

--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -67,8 +67,7 @@ class SignupGroupController extends Controller
     private function getGroup($id)
     {
         // signup_id and signup_group are saved as numbers
-        $group = User::where('campaigns', 'elemMatch', ['signup_id' => $id])
-            ->orWhere('campaigns', 'elemMatch', ['signup_group' => $id])->get();
+        $group = User::group($id);
 
         // Get the campaign id associated with the signup group ID
         $campaign_id = null;

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -25,9 +25,6 @@ class Campaign extends Eloquent
      */
     protected $casts = [
         'quantity' => 'integer',
-        'reportback_id' => 'integer',
-        'signup_id' => 'integer',
-        'signup_group' => 'integer',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -49,7 +49,6 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      * @var array
      */
     protected $casts = [
-        'drupal_id' => 'integer',
         'cgg_id' => 'integer'
     ];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -139,9 +139,10 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeGroup($query, $signup_id)
+    public function scopeGroup($query, $id)
     {
         // Get signup group.
-        return $query->where('campaigns', 'elemMatch', ['signup_id' => (int)$signup_id])->orWhere('campaigns', 'elemMatch', ['signup_group' => (int)$signup_id])->get();
+        return $query->where('campaigns', 'elemMatch', ['signup_id' => $id])
+            ->orWhere('campaigns', 'elemMatch', ['signup_group' => $id])->get();
     }
 }

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -133,6 +133,8 @@ class UserTableSeeder extends Seeder
         User::create(array(
             '_id' => 'bf1039b0271bcc636aa5477e',
             'drupal_id' => '100006',
+            'first_name' => 'Push',
+            'last_name' => 'User',
             'parse_installation_ids' => 'parse-101',
             'campaigns' => [
                 [

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -23,7 +23,7 @@ class UserTableSeeder extends Seeder
             'email' => 'test@dosomething.org',
             'mobile' => '5555550100',
             'password' => 'secret',
-            'drupal_id' => 100001,
+            'drupal_id' => '100001',
             'addr_street1' => '123',
             'addr_street2' => '456',
             'addr_city' => 'Paris',
@@ -41,7 +41,7 @@ class UserTableSeeder extends Seeder
             'email' => 'test1@dosomething.org',
             'mobile' => '5555550101',
             'password' => 'secret',
-            'drupal_id' => 100002,
+            'drupal_id' => '100002',
             'addr_street1' => '123',
             'addr_street2' => '456',
             'addr_city' => 'Paris',
@@ -55,9 +55,9 @@ class UserTableSeeder extends Seeder
             'campaigns' => [
                 [
                     '_id' => '5480c950bffebc651c8b456e',
-                    'drupal_id' => 123,
+                    'drupal_id' => '123',
                     'signup_id' => '100',
-                    'signup_source' => 'android'
+                    'signup_source' => 'android',
                 ]
             ]
         ]);
@@ -68,7 +68,7 @@ class UserTableSeeder extends Seeder
             'email' => 'test2@dosomething.org',
             'mobile' => '5555550102',
             'password' => 'secret',
-            'drupal_id' => 100003,
+            'drupal_id' => '100003',
             'addr_street1' => '123',
             'addr_street2' => '456',
             'addr_city' => 'Paris',
@@ -81,10 +81,10 @@ class UserTableSeeder extends Seeder
             'campaigns' => [
                 [
                     '_id' => '3f10c910251bcc636aa5477a',
-                    'drupal_id' => 123,
+                    'drupal_id' => '123',
                     'signup_id' => '101',
                     'signup_source' => 'ios',
-                    'reportback_id' => 125
+                    'reportback_id' => '125'
                 ]
             ]
         ]);
@@ -95,15 +95,15 @@ class UserTableSeeder extends Seeder
             'email' => 'test3@dosomething.org',
             'mobile' => '5555550102',
             'password' => 'secret',
-            'drupal_id' => 100004,
+            'drupal_id' => '100004',
             'birthdate' => '12/17/91',
             'campaigns' => [
                 [
                     '_id' => '3f10c910251bcc636aa5477b',
-                    'drupal_id' => 123,
+                    'drupal_id' => '123',
                     'signup_id' => '102',
                     'signup_source' => 'test',
-                    'signup_group' => '100'
+                    'signup_group' => '100',
                 ]
             ]
         ]);
@@ -114,11 +114,42 @@ class UserTableSeeder extends Seeder
             'parse_installation_ids' => 'parse-abc123'
         ));
 
+        // User 1 for push notification tests
+        User::create(array(
+            '_id' => 'bf1039b0271bcc636aa5477d',
+            'drupal_id' => '100005',
+            'parse_installation_ids' => 'parse-100',
+            'campaigns' => [
+                [
+                    'drupal_id' => '123',
+                    'signup_id' => '200',
+                    'signup_source' => 'test',
+                    'signup_group' => '200',
+                ]
+            ]
+        ));
+
+        // User 2 for push notification tests
+        User::create(array(
+            '_id' => 'bf1039b0271bcc636aa5477e',
+            'drupal_id' => '100006',
+            'parse_installation_ids' => 'parse-101',
+            'campaigns' => [
+                [
+                    'drupal_id' => '123',
+                    'signup_id' => '201',
+                    'signup_source' => 'test',
+                    'signup_group' => '200',
+                    'reportback_id' => '1000',
+                ]
+            ]
+        ));
+
         User::create(array(
             'email' => 'info@dosomething.org',
             'mobile' => '5555550104',
             'password' => 'secret',
-            'drupal_id' => 456788,
+            'drupal_id' => '456788',
             'addr_street1' => '456',
             'addr_street2' => '33',
             'addr_city' => 'Example',

--- a/tests/PushNotificationTest.php
+++ b/tests/PushNotificationTest.php
@@ -5,7 +5,8 @@ use Northstar\Handlers\Events\SendReportbackPushNotification;
 use Northstar\Models\User;
 use Northstar\Models\Campaign;
 
-class PushNotificationTest extends TestCase {
+class PushNotificationTest extends TestCase
+{
 
     public function setUp()
     {
@@ -53,8 +54,11 @@ class PushNotificationTest extends TestCase {
                             'created_at' => '1234567890',
                             'status' => 'approved'
                         ],
-                    ]
-                ]
+                    ],
+                ],
+                'campaign' => [
+                    'title' => 'Test Campaign',
+                ],
             ]
         ];
 
@@ -75,6 +79,7 @@ class PushNotificationTest extends TestCase {
         $this->assertArrayHasKey('extras', $push_data);
         $this->assertArrayHasKey('completion', $push_data['extras']);
         $completion = $push_data['extras']['completion'];
+        $this->assertEquals($push_data['alert'], 'Push U. shared a photo in your Test Campaign group.');
         $this->assertEquals($push_data['alert'], $completion['message']);
         $this->assertArrayHasKey('message', $completion);
         $this->assertArrayHasKey('group', $completion);
@@ -84,4 +89,5 @@ class PushNotificationTest extends TestCase {
         $this->assertCount(1, $completion['reportback_items']['data']);
         $this->assertEquals($campaign->reportback_id, $completion['reportback_items']['data'][0]['id']);
     }
+
 }

--- a/tests/PushNotificationTest.php
+++ b/tests/PushNotificationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Northstar\Events\UserReportedBack;
+use Northstar\Handlers\Events\SendReportbackPushNotification;
+use Northstar\Models\User;
+use Northstar\Models\Campaign;
+
+class PushNotificationTest extends TestCase {
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Migrate & seed database
+        Artisan::call('migrate');
+        $this->seed();
+
+        $this->drupalMock = $this->mock('Northstar\Services\DrupalAPI');
+        $this->parseMock = $this->mock('Northstar\Services\Parse');
+    }
+
+    /**
+     * Test for verifying the push data compiled before it's sent to the Parse
+     * client.
+     */
+    public function testReportbackPushData()
+    {
+        // Simulated user who just reported back
+        $user = new User();
+        $user->drupal_id = '100006';
+
+        // Simulated campaign info for user who just reported back
+        $campaign = new Campaign();
+        $campaign->signup_group = '200';
+        $campaign->reportback_id = '1000';
+        $campaign->drupal_id = '123';
+        $event = new UserReportedBack($user, $campaign);
+
+        // Response from server for the reportback just submitted by the user above
+        $reportback_response = [
+            'data' => [
+                'reportback_items' => [
+                    'total' => 1,
+                    'data' => [
+                        [
+                            'id' => '1000',
+                            'caption' => 'Test caption 1000.',
+                            'uri' => 'http://www.example.com/reportback-items/1000',
+                            'media' => [
+                                'uri' => 'http://www.example.com/reportback-items/1001.jpg',
+                                'type' => 'image'
+                            ],
+                            'created_at' => '1234567890',
+                            'status' => 'approved'
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $this->drupalMock->shouldReceive('reportbackContent')->once()->andReturn($reportback_response);
+        $notification = new SendReportbackPushNotification($this->parseMock, $this->drupalMock);
+
+        $pushes = $notification->createPushData($event);
+
+        // Seeded table should be setup so that there's one other user in group
+        // '200'. That user should be receiving a push notification.
+        $this->assertCount(1, $pushes);
+        $this->assertCount(1, $pushes[0]['installation_ids']);
+        $this->assertEquals('parse-100', $pushes[0]['installation_ids'][0]);
+
+        // Verify structure of the push data.
+        $push_data = $pushes[0]['data'];
+        $this->assertArrayHasKey('alert', $push_data);
+        $this->assertArrayHasKey('extras', $push_data);
+        $this->assertArrayHasKey('completion', $push_data['extras']);
+        $completion = $push_data['extras']['completion'];
+        $this->assertEquals($push_data['alert'], $completion['message']);
+        $this->assertArrayHasKey('message', $completion);
+        $this->assertArrayHasKey('group', $completion);
+        $this->assertArrayHasKey('reportback_items', $completion);
+
+        // Verify reportback_item in push data matches the one in the event.
+        $this->assertCount(1, $completion['reportback_items']['data']);
+        $this->assertEquals($campaign->reportback_id, $completion['reportback_items']['data'][0]['id']);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Packs additional info into the Parse pushes so that apps can deal with them appropriately.
- The message is customized to include username and campaign name
- Group info and reportback item data also included so the receiver of the push notification can know what the reportback item is and what group it's a part of

Includes a new unit test to verify the structure of the data we're sending to Parse.

#### Where should the reviewer start?
- Most of the magic happens in `SendReportbackPushNotification::createPushData`. We get the username, campaign name and who to send pushes to here. The function will return array that we can then loop through to send pushes to the individual users who need it.
- **PushNotificationTest.php**: Unit test to verify the data coming out of `createPushData`
- **SignupGroupController.php**: this was just a realization that there was another scope function already doing this same logic
- **User.php** and **Campaign.php**: primary thing to note here is the removal of properties that are getting casted to ints. See the **Potential problem** section below for more info.

#### How should this be manually tested?
Running the PHPUnit tests would be cool if you wanna do taht.

#### How was this tested?
- Unit tests
- Plus local/staging tests that sent data to Parse. You can see that the data sent looks like we expect it to here: https://www.parse.com/apps/lets-do-this--6/push_notifications/TnW42fCIOj

#### What are the relevant tickets?
Closes #178 

#### Potential problem
`drupal_id`, `reportback_id`, `signup_id` and `signup_group`. I've removed the integer casting we were doing on these. Drupal returns these values as strings and so instead of juggling between two different data types, seems to make sense to just keep them as strings.

This will probably temporarily break at least the Android app that expects these values to be returned as ints. @aaronschachter will it similarly cause problems on the iOS side?

Does this seem like the right thing to do?

#### Potential todo
If the above is ok, then:
- updating documentation to indicate `drupal_id`, `reportback_id`, `signup_id` and `signup_group` are strings
- updating relevant app code to support that
cc: @angaither 