### PR TITLE
Push Notifications: Signup and Kudos data

### DIFF
--- a/app/Events/UserGotKudo.php
+++ b/app/Events/UserGotKudo.php
@@ -1,22 +1,21 @@
 <?php namespace Northstar\Events;
 
 use Illuminate\Queue\SerializesModels;
-use Northstar\Models\User;
 
 class UserGotKudo extends Event {
 
 	use SerializesModels;
 
-	public $user;
+	public $reportback_item_id;
 
 	/**
 	 * Create a new event instance.
 	 *
 	 * @return void
 	 */
-	public function __construct(User $user)
+	public function __construct($reportback_item_id)
 	{
-		$this->user = $user;
+		$this->reportback_item_id = $reportback_item_id;
 	}
 
 }

--- a/app/Handlers/Events/SendKudoPushNotification.php
+++ b/app/Handlers/Events/SendKudoPushNotification.php
@@ -55,7 +55,6 @@ class SendKudoPushNotification {
      */
     public function createPushData(UserGotKudo $event)
     {
-
         // Get reportback item content that recieved the kudo.
         $reportback_response = $this->drupal->reportbackItemContent($event->reportback_item_id);
 

--- a/app/Handlers/Events/SendKudoPushNotification.php
+++ b/app/Handlers/Events/SendKudoPushNotification.php
@@ -2,43 +2,92 @@
 
 use Northstar\Events\UserGotKudo;
 use Northstar\Models\User;
-
+use Northstar\Services\DrupalAPI;
 use Northstar\Services\Parse;
+
 
 class SendKudoPushNotification {
 
-  /**
-   * Parse API wrapper.
-   * @var Parse
-   */
-  protected $parse;
+    /**
+    * Parse API wrapper.
+    * @var Parse
+    */
+    protected $parse;
 
-  /**
-   * Create the event handler.
-   *
-   * @return void
-   */
-  public function __construct(Parse $parse)
-  {
-    $this->parse = $parse;
-  }
+    /**
+     * Drupal API wrapper
+     * @var DrupalAPI
+     */
+    protected $drupal;
 
-
-	/**
-	 * Handle the event.
-	 *
-	 * @param  UserGotKudo  $event
-	 * @return void
-	 */
-	public function handle(UserGotKudo $event)
-	{
-    // @TODO - This is placeholder content.
-    $data = array("alert" => "You just got a kudo");
-
-    // Send notifications to the users devices.
-    if (!empty($user->parse_installation_ids)) {
-      $this->parse->sendPushNotification($user->parse_installation_ids, $data);
+    /**
+    * Create the event handler.
+    *
+    * @return void
+    */
+    public function __construct(Parse $parse, DrupalAPI $drupal)
+    {
+        $this->parse = $parse;
+        $this->drupal = $drupal;
     }
-	}
 
+    /**
+     * Handle the event.
+     *
+     * @param  UserGotKudo $event
+     * @return void
+     */
+    public function handle(UserGotKudo $event)
+    {
+        $pushes = $this->createPushData($event);
+        foreach ($pushes as $push) {
+            // Send notifications to the user's devices.
+            $this->parse->sendPushNotification($push['installation_ids'], $push['data']);
+        }
+    }
+
+
+    /**
+     * Compile push data per user to send to Parse.
+     *
+     * @param UserGotKudo $event
+     * @return array
+     */
+    public function createPushData(UserGotKudo $event)
+    {
+
+        // Get reportback item content that recieved the kudo.
+        $reportback_response = $this->drupal->reportbackItemContent($event->reportback_item_id);
+
+        // Get the user who owns that reportback item.
+        $user = User::where('drupal_id', '=', $reportback_response['data'][0]['user']['id'])->first();
+
+        if (empty($user->parse_installation_ids)) {
+            return [];
+        }
+
+        // Message sent in the push notification
+        $message = 'Your photo received a kudos!';
+
+        // Build the push data object.
+        $data = [
+            'alert' => $message,
+            'extras' => [
+                'kudos' => [
+                    'title' => 'Kudos',
+                    'message' => $message,
+                    'reportback_item' => [
+                        'data' => $reportback_response,
+                    ],
+                ],
+            ],
+        ];
+
+        $push_data[] = [
+            'installation_ids' => $user->parse_installation_ids,
+            'data' => $data,
+        ];
+
+        return $push_data;
+    }
 }

--- a/app/Handlers/Events/SendSignupPushNotification.php
+++ b/app/Handlers/Events/SendSignupPushNotification.php
@@ -7,48 +7,110 @@ use Northstar\Services\Parse;
 
 class SendSignupPushNotification {
 
-  /**
-   * Parse API wrapper.
-   * @var Parse
-   */
-  protected $parse;
+    /**
+     * Parse API wrapper.
+     * @var Parse
+     */
+    protected $parse;
 
-  /**
-   * Create the event handler.
-   *
-   * @return void
-   */
-  public function __construct(Parse $parse)
-  {
-    $this->parse = $parse;
-  }
+    /**
+     * Drupal API wrapper
+     * @var DrupalAPI
+     */
+    protected $drupal;
 
-  /**
-   * Handle the event.
-   * @param  UserSignedUp  $event
-   * @return void
-   */
-  public function handle(UserSignedUp $event)
-  {
-    $group = User::group($event->campaign->signup_id);
-
-    if (count($group) > 0) {
-      // Loop through the users in the group.
-      foreach ($group as $user) {
-        $drupal_id = $user->drupal_id;
-
-        // Check that this user is not the user that triggered the event.
-        if ($drupal_id !== $event->user->drupal_id) {
-          // @TODO - This is placeholder content.
-          $data = array("alert" => "I just signed up to your group");
-
-          // Send notifications to the users devices.
-          if (!empty($user->parse_installation_ids)) {
-            $this->parse->sendPushNotification($user->parse_installation_ids, $data);
-          }
-        }
-      }
+    /**
+     * Create the event handler.
+     *
+     * @return void
+     */
+    public function __construct(Parse $parse)
+    {
+      $this->parse = $parse;
+      $this->drupal = $drupal;
     }
-  }
 
+    /**
+     * Handle the event.
+     *
+     * @param  UserSignedUp  $event
+     * @return void
+     */
+    public function handle(UserSignedUp $event)
+    {
+        $pushes = $this->createPushData($event);
+        foreach ($pushes as $push) {
+            // Send notifications to the user's devices.
+            $this->parse->sendPushNotification($push['installation_ids'], $push['data']);
+        }
+    }
+
+    /**
+     * Compile push data per user to send to Parse.
+     *
+     * @param  UserSignedUp  $event
+     * @return array
+     */
+    public function createPushData(UserSignedUp $event)
+    {
+        if (!empty($event->campaign->signup_group)) {
+            $group = User::group($event->campaign->signup_group);
+        } else {
+            $group = [];
+        }
+
+        // If group count is only 1, safe to assume this user is signing up to a group.
+        if (count($group) <= 1) {
+            return [];
+        }
+
+        // Get the user first name and last initial
+        $user_firstname = User::where('drupal_id', '=', $event->user->drupal_id)->first();
+        $username = 'A member';
+
+        if (!empty($reportback_user)) {
+            if (!empty($reportback_user->first_name)) {
+                $username = $reportback_user->first_name;
+            }
+
+            if (!empty($reportback_user->last_name)) {
+                $username .= ' ' . substr($reportback_user->last_name, 0, 1) . '.';
+            }
+        }
+
+        // Loop through the users in the group.
+        $push_data = [];
+        foreach ($group as $user) {
+            $drupal_id = $user->drupal_id;
+            // Check that this user is not the user that triggered the event.
+            if ($drupal_id !== $event->user->drupal_id && !empty($user->parse_installation_ids)) {
+
+                // Message sent in the push notification
+                $message = $username . ' joined your group!';
+
+                // @TODO group.data.users doesn't include detailed reportback info for each user, is that ok?
+                $data = [
+                    'alert' => $message,
+                    'extras' => [
+                        'group' => [
+                            'message' => $message,
+                            'group' => [
+                                'data' => [
+                                    'campaign_id' => $event->campaign->drupal_id,
+                                    'users' => $group,
+                                ],
+                            ],
+                        ],
+                    ],
+                ];
+
+                $push_data[] = [
+                    'installation_ids' => $user->parse_installation_ids,
+                    'data' => $data,
+                ];
+            }
+        }
+
+        return $push_data;
+    }
 }

--- a/app/Handlers/Events/SendSignupPushNotification.php
+++ b/app/Handlers/Events/SendSignupPushNotification.php
@@ -2,8 +2,8 @@
 
 use Northstar\Events\UserSignedUp;
 use Northstar\Models\User;
-
 use Northstar\Services\Parse;
+
 
 class SendSignupPushNotification {
 
@@ -14,12 +14,6 @@ class SendSignupPushNotification {
     protected $parse;
 
     /**
-     * Drupal API wrapper
-     * @var DrupalAPI
-     */
-    protected $drupal;
-
-    /**
      * Create the event handler.
      *
      * @return void
@@ -27,7 +21,6 @@ class SendSignupPushNotification {
     public function __construct(Parse $parse)
     {
       $this->parse = $parse;
-      $this->drupal = $drupal;
     }
 
     /**
@@ -65,16 +58,16 @@ class SendSignupPushNotification {
         }
 
         // Get the user first name and last initial
-        $user_firstname = User::where('drupal_id', '=', $event->user->drupal_id)->first();
+        $signup_user = User::where('drupal_id', '=', $event->user->drupal_id)->first();
         $username = 'A member';
 
-        if (!empty($reportback_user)) {
-            if (!empty($reportback_user->first_name)) {
-                $username = $reportback_user->first_name;
+        if (!empty($signup_user)) {
+            if (!empty($signup_user->first_name)) {
+                $username = $signup_user->first_name;
             }
 
-            if (!empty($reportback_user->last_name)) {
-                $username .= ' ' . substr($reportback_user->last_name, 0, 1) . '.';
+            if (!empty($signup_user->last_name)) {
+                $username .= ' ' . substr($signup_user->last_name, 0, 1) . '.';
             }
         }
 
@@ -92,7 +85,7 @@ class SendSignupPushNotification {
                 $data = [
                     'alert' => $message,
                     'extras' => [
-                        'group' => [
+                        'invitation' => [
                             'message' => $message,
                             'group' => [
                                 'data' => [
@@ -100,7 +93,7 @@ class SendSignupPushNotification {
                                     'users' => $group,
                                 ],
                             ],
-                        ],
+                        ]
                     ],
                 ];
 

--- a/app/Handlers/Events/SendSignupPushNotification.php
+++ b/app/Handlers/Events/SendSignupPushNotification.php
@@ -93,7 +93,7 @@ class SendSignupPushNotification {
                                     'users' => $group,
                                 ],
                             ],
-                        ]
+                        ],
                     ],
                 ];
 

--- a/app/Http/Controllers/KudosController.php
+++ b/app/Http/Controllers/KudosController.php
@@ -31,9 +31,6 @@ class KudosController extends Controller
 
         $response = $this->drupal->storeKudos($drupal_id, $request);
 
-        // Fire kudo event.
-        event(new UserGotKudo($user));
-
         return $this->respond($response);
     }
 

--- a/app/Http/Controllers/KudosController.php
+++ b/app/Http/Controllers/KudosController.php
@@ -31,6 +31,9 @@ class KudosController extends Controller
 
         $response = $this->drupal->storeKudos($drupal_id, $request);
 
+        // Fire kudo event.
+        event(new UserGotKudo($request->reportback_item_id));
+
         return $this->respond($response);
     }
 

--- a/app/Services/DrupalAPI.php
+++ b/app/Services/DrupalAPI.php
@@ -249,6 +249,9 @@ class DrupalAPI
 
         $body = $response->json();
 
+        // Fire kudo event.
+        event(new UserGotKudo($request->reportback_item_id));
+
         return $body;
     }
 
@@ -264,6 +267,21 @@ class DrupalAPI
     public function reportbackContent($reportback_id)
     {
         $response = $this->client->get('reportbacks/' . $reportback_id . '.json');
+
+        return $response->json();
+    }
+
+    /**
+     * Get a specific reportback item.
+     *
+     * @param String $reportback_item_id
+     *
+     * @return Array - Contents of the reportback item.
+     *
+     */
+    public function reportbackItemContent($reportback_item_id)
+    {
+        $response = $this->client->get('reportback-items/' . $reportback_item_id . '.json');
 
         return $response->json();
     }

--- a/app/Services/DrupalAPI.php
+++ b/app/Services/DrupalAPI.php
@@ -249,9 +249,6 @@ class DrupalAPI
 
         $body = $response->json();
 
-        // Fire kudo event.
-        event(new UserGotKudo($request->reportback_item_id));
-
         return $body;
     }
 

--- a/tests/PushNotificationTest.php
+++ b/tests/PushNotificationTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Northstar\Events\UserReportedBack;
+use Northstar\Events\UserSignedUp;
 use Northstar\Handlers\Events\SendReportbackPushNotification;
+use Northstar\Handlers\Events\SendSignupPushNotification;
 use Northstar\Models\User;
 use Northstar\Models\Campaign;
 
@@ -88,6 +90,45 @@ class PushNotificationTest extends TestCase
         // Verify reportback_item in push data matches the one in the event.
         $this->assertCount(1, $completion['reportback_items']['data']);
         $this->assertEquals($campaign->reportback_id, $completion['reportback_items']['data'][0]['id']);
+    }
+
+    /**
+     * @group signupPushNotification
+     *
+     * Test for verifying the push data compiled before it's sent to the Parse
+     * client.
+     */
+    public function testSignupPushData()
+    {
+        // Simulated user who just signed up
+        $user = new User();
+        $user->drupal_id = '100006';
+
+        // Simulated campaign info for user who just reported back
+        $campaign = new Campaign();
+        $campaign->signup_group = '200';
+        $campaign->drupal_id = '123';
+        $event = new UserSignedUp($user, $campaign);
+
+        $notification = new SendSignupPushNotification($this->parseMock);
+        $pushes = $notification->createPushData($event);
+
+        // Seeded table should be setup so that there's one other user in group
+        // '200'. That user should be receiving a push notification.
+        $this->assertCount(1, $pushes);
+        $this->assertCount(1, $pushes[0]['installation_ids']);
+        $this->assertEquals('parse-100', $pushes[0]['installation_ids'][0]);
+
+        // Verify structure of the push data.
+        $push_data = $pushes[0]['data'];
+        $this->assertArrayHasKey('alert', $push_data);
+        $this->assertArrayHasKey('extras', $push_data);
+        $this->assertArrayHasKey('invitation', $push_data['extras']);
+        $invitation = $push_data['extras']['invitation'];
+        $this->assertEquals($push_data['alert'], 'Push U. joined your group!');
+        $this->assertEquals($push_data['alert'], $invitation['message']);
+        $this->assertArrayHasKey('message', $invitation);
+        $this->assertArrayHasKey('group', $invitation);
     }
 
 }


### PR DESCRIPTION
#### What's this PR do?
* Adds custom data to the kudos and sign up push notification data.
* Adds two new unit test to check that the notification data is built correctly.

*minor changes*
- Adds a new `reportbackItemContent` function that retrieves a specific reportback item from drupal.
- Moves the event firing for the kudos event into the `storeKudos` function and instead of taking a user as parameter, takes the reportback item that received the kudo. 

#### Where should the reviewer start?
- `SendKudoPushNotifiacation` and ` SendSignupPushNotification` this is where the custom data object gets built out. 

#### How should this be manually tested?
Run the unit tests!
Kudos: `vendor/bin/phpunit --group kudoPushNotification`
Signup: `vendor/bin/phpunit --group signupPushNotification`

#### What are the relevant tickets?
Closes #177 and #176 
