### PR TITLE
Standardizing error response on failed login

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -4,12 +4,17 @@ use Illuminate\Foundation\Bus\DispatchesCommands;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Database\Eloquent;
+use Illuminate\Http\Request;
 use Input;
 
 abstract class Controller extends BaseController
 {
 
-    use DispatchesCommands, ValidatesRequests;
+    use DispatchesCommands;
+
+    use ValidatesRequests {
+        buildFailedValidationResponse as traitBuildFailedValidationResponse;
+    }
 
     /**
      * Method to standardize responses sent from child controllers.
@@ -39,7 +44,8 @@ abstract class Controller extends BaseController
      * @param $query - Eloquent query
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function respondPaginated($query, $inputs) {
+    protected function respondPaginated($query, $inputs)
+    {
         if (is_a($query, 'Illuminate\Database\Eloquent\Builder')) {
             $limit = Input::get('limit') ?: 20;
             $response = $query->paginate((int)$limit);
@@ -48,4 +54,15 @@ abstract class Controller extends BaseController
         }
     }
 
+    /**
+     * Create the response for when a request fails validation. Overrides the ValidatesRequests trait.
+     *
+     * @param Request $request
+     * @param array $errors
+     * @return \Illuminate\Http\Response
+     */
+    protected function buildFailedValidationResponse(Request $request, array $errors)
+    {
+        return $this->traitBuildFailedValidationResponse($request, $errors);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
Standardizes the error message response when credentials fail to be like...
```
{
  "error": {
    "code": 401,
    "message": "Invalid email or password."
  }
}
```

When a user tries to register with an email or mobile that already exists, the response is...
```
{
  "error": {
    "code": 401,
    "message": "The mobile has already been taken."
  }
}
```

#### Where should the reviewer start?
- **AuthController.php**: The exception thrown when the auth is incorrect now has a status code of 401, and it specifies `email` or `mobile` in the error message as opposed to `username`.
- **UserController.php**:
  - Simplifies the password check logic so that we're not executing a `User::where` query multiple times.
  - Overrides the `buildFailedValidationResponse` function to deliver a custom error response.
- **Controller.php**: Overrides the `buildFailedValidationResponse` function from the `ValidatesRequests` trait

#### What are the relevant tickets?
Closes #183

cc: @DFurnes - Am I doing this ValidatesRequests trait thing right?