### PR TITLE
Reportback Source Property

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -1,6 +1,7 @@
 <?php namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Input;
 use Northstar\Events\UserSignedUp;
 use Northstar\Events\UserReportedBack;
 use Northstar\Models\Campaign;
@@ -191,7 +192,7 @@ class CampaignController extends Controller
         // Fire reportback event.
         event(new UserReportedBack($user, $campaign));
 
-        return $this->respond(['reportback_id' => $reportback_id, 'created_at' => $campaign->updated_at], $statusCode);
+        return $this->respond($campaign, $statusCode);
     }
 
 }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -152,7 +152,8 @@ class CampaignController extends Controller
             'quantity' => ['required', 'integer'],
             'why_participated' => ['required'],
             'file' => ['required', 'string'], // Data URL!
-            'caption' => ['string']
+            'caption' => ['string'],
+            'source' => ['string'],
         ]);
 
         // Get the currently authenticated Northstar user.
@@ -180,6 +181,11 @@ class CampaignController extends Controller
         }
 
         $campaign->reportback_id = $reportback_id;
+
+        if (Input::has('source')) {
+            $campaign->reportback_source = Input::get('source');
+        }
+
         $campaign->save();
 
         // Fire reportback event.

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -1,7 +1,6 @@
 <?php namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Input;
 use Northstar\Events\UserSignedUp;
 use Northstar\Events\UserReportedBack;
 use Northstar\Models\Campaign;
@@ -183,8 +182,8 @@ class CampaignController extends Controller
 
         $campaign->reportback_id = $reportback_id;
 
-        if (Input::has('source')) {
-            $campaign->reportback_source = Input::get('source');
+        if ($request->has('source')) {
+            $campaign->reportback_source = $request->input('source');
         }
 
         $campaign->save();

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -43,6 +43,7 @@ class Campaign extends Eloquent
     protected $attributes = [
         'drupal_id' => null,
         'reportback_id' => null,
+        'reportback_source' => null,
         'signup_group' => null,
         'signup_id' => null,
         'signup_source' => null,

--- a/app/Services/DrupalAPI.php
+++ b/app/Services/DrupalAPI.php
@@ -210,7 +210,8 @@ class DrupalAPI
             'why_participated' => $contents['why_participated'],
             'file' => $contents['file'],
             'filename' => 'test123456.jpg',
-            'caption' => $contents['caption']
+            'caption' => $contents['caption'],
+            'source' => $contents['source'],
         ];
 
         $response = $this->client->post('campaigns/' . $campaign_id . '/reportback', [

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -155,7 +155,6 @@ class CampaignTest extends TestCase
 
         // Response should return created at and rbid columns
         $this->assertArrayHasKey('reportback_id', $data['data']);
-        $this->assertArrayHasKey('created_at', $data['data']);
         $this->assertEquals(100, $data['data']['reportback_id']);
     }
 
@@ -189,7 +188,6 @@ class CampaignTest extends TestCase
 
         // Response should return created at and rbid columns
         $this->assertArrayHasKey('reportback_id', $data['data']);
-        $this->assertArrayHasKey('created_at', $data['data']);
         $this->assertEquals(100, $data['data']['reportback_id']);
     }
 


### PR DESCRIPTION
#### What's this PR do?
Adds support for a `source` property for campaign reportbacks. We're already both saving a `source` property to Northstar and forwarding it along to Phoenix for user registrations and campaign signups.

#### Where should the reviewer start?
**CampaignController.php**

- A `source` string passed to the reportback endpoint will be saved in the campaign doc under `reportback_source`.
- The response from the reportback endpoint will now give the entirety of the campaign activity doc. Previously it would give something like...
```
{
        "data": {
          "reportback_id": "1622",
          "created_at": {
            "date": "2015-07-15 15:29:10",
            "timezone_type": 3,
            "timezone": "UTC"
          },
          "drupal_id": null,
          "signup_group": null,
          "signup_id": null,
          "signup_source": null
        }
      }
```
... where a bunch of fields were incorrectly `null`.

cc: @DFurnes @angaither 