### PR TITLE
Profile photo upload fix

### DIFF
--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -35,8 +35,8 @@ class AvatarController extends Controller
         $filename = $this->aws->storeImage('avatars', $id, $file);
 
         // Save filename to User model
-        $user = User::where($id)->first();
-        $user->avatar = $filename;
+        $user = User::where("_id", $id)->first();
+        $user->photo = $filename;
         $user->save();
 
         // Respond to user with success and photo URL


### PR DESCRIPTION
#### What's this PR do?
- Fixes the query that would find the user to update with an avatar submission
- Fixes the response to put the url in the `photo` param instead of an `avatar` param

#### Any background context?
The bug would manifest itself in updating the profile of a user that was not the user specified in the originating call.

#### What are the relevant tickets?
Fixes #200