### PR TITLE
Fix on GET /users/:term/:id/campaigns when reportbacks are deleted on Drupal

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -47,7 +47,11 @@ class CampaignController extends Controller
         foreach ($campaigns as $campaign) {
             if ($campaign->reportback_id) {
                 $response = $this->drupal->reportbackContent($campaign->reportback_id);
-                $campaign['reportback_data'] = $response['data'];
+
+                // Possible for reportback data to be missing if it's been deleted on Drupal
+                if (isset($response['data'])) {
+                    $campaign['reportback_data'] = $response['data'];
+                }
             }
         }
 
@@ -75,7 +79,10 @@ class CampaignController extends Controller
 
         if ($campaign->reportback_id) {
             $response = $this->drupal->reportbackContent($campaign->reportback_id);
-            $campaign['reportback_data'] = $response['data'];
+
+            if (isset($response['data'])) {
+                $campaign['reportback_data'] = $response['data'];
+            }
         }
 
         return $this->respond($campaign);


### PR DESCRIPTION
#### What's this PR do?

When reportbacks get deleted on Drupal, they're not removed from Northstar. So when Northstar queries for them, there is no 'data' object that comes back in the response and it dies. This PR just does an `isset` check as a quick fix to prevent the process from terminating.

#### Questions

Thoughts on if we'll ultimately want to remove the reportback id from the user's document on Northstar too? Potentially could happen here - which feels iffy. Or could happen as an event triggered from Drupal when a reportback is deleted there.