### PR TITLE
changes drupal_id to an integer

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -120,6 +120,10 @@ class UserController extends Controller
      */
     public function show($term, $id)
     {
+        if ($term === 'drupal_id') {
+            $id = (int) $id;
+        }
+
         // Find the user.
         $user = User::where($term, $id)->get();
         if (!$user->isEmpty()) {


### PR DESCRIPTION
#### What does this PR do? 
Changes the `drupal_id` to an integer to fix the `GET /users/drupal_id/<drupal_id>` endpoint
