### PR TITLE
Fixes /users PUT response to include actual user data

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -161,9 +161,7 @@ class UserController extends Controller
 
             $user->save();
 
-            $response = array('updated_at' => $user->updated_at);
-
-            return $this->respond($response, 202);
+            return $this->respond($user, 202);
         }
 
         throw new NotFoundHttpException('The resource does not exist.');

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -112,8 +112,9 @@ class UserTest extends TestCase
         // Response should be valid JSON
         $this->assertJson($content);
 
-        // Response should return updated at and id columns
+        // Response should return updated_at and unchanged user values should remain unchanged
         $this->assertArrayHasKey('updated_at', $data['data']);
+        $this->assertEquals('5555550101', $data['data']['mobile']);
 
         // Verify user data got updated
         $getResponse = $this->call('GET', 'v1/users/_id/5480c950bffebc651c8b456f', [], [], [], $this->server);


### PR DESCRIPTION
#### What's this PR do?
The response to a PUT /users request used to only have a valid `updated_at` field. All other user data was null. This fixes that.

This also updates a phpunit test to verify that.

#### Any background context?
Came across this while doing work on the Android app. The app would update its cache of user information based on what'd get returned from the /users PUT response. And the previous response basically seemed like it would null everything out.

#### What are the relevant tickets?
Fixes #205