### PR TITLE
delete lines to convert druapl id to an int

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -120,10 +120,6 @@ class UserController extends Controller
      */
     public function show($term, $id)
     {
-        if ($term === 'drupal_id') {
-            $id = (int) $id;
-        }
-
         // Find the user.
         $user = User::where($term, $id)->get();
         if (!$user->isEmpty()) {


### PR DESCRIPTION
#### What's this PR do? 
Deletes code that converts `drupal_id` from a string to an integer. This was breaking the call from phoenix to northstar to grab user information (all user information with conversion from string to integer returned `null`). 

#### Where should the reviewer start?

UserController.php lines 121 - 130 

#### How should this be manually tested?

`http://northstar.dev:8000/v1/users/drupal_id/100001` should return user information. 

What are the relevant tickets?
Fixes https://github.com/DoSomething/phoenix/issues/5124
merge to convert `drupal_id` to integer https://github.com/DoSomething/northstar/commit/745c51b368cc6218b4aaad35d6fc7d580b649f32