### PR TITLE
Multiple users can be retrieved by _id and drupal_id

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -21,13 +21,14 @@ class UserController extends Controller
      */
     public function index()
     {
-        $inputs = Input::except(['page', '_id', 'drupal_id']);
+        $except_list = User::$indexes;
+        array_push($except_list, 'page');
+        $inputs = Input::except($except_list);
         $users = User::where($inputs);
 
         // Query for multiple ids
         $query_ids = [];
-        $id_keys = ['_id', 'drupal_id'];
-        foreach ($id_keys as $id_key) {
+        foreach (User::$indexes as $id_key) {
             if (Input::has($id_key)) {
                 $str_ids = Input::get($id_key);
                 $arr_ids = explode(',', $str_ids);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,7 +5,6 @@ use Northstar\Services\DrupalAPI;
 use Northstar\Models\User;
 use Input;
 use Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
@@ -22,8 +21,24 @@ class UserController extends Controller
      */
     public function index()
     {
-        $inputs = Input::except('page');
+        $inputs = Input::except(['page', '_id', 'drupal_id']);
         $users = User::where($inputs);
+
+        // Query for multiple ids
+        $query_ids = [];
+        $id_keys = ['_id', 'drupal_id'];
+        foreach ($id_keys as $id_key) {
+            if (Input::has($id_key)) {
+                $str_ids = Input::get($id_key);
+                $arr_ids = explode(',', $str_ids);
+                $query_ids[$id_key] = $arr_ids;
+            }
+        }
+
+        foreach ($query_ids as $id_key => $id_value) {
+            $users->whereIn($id_key, $id_value);
+        }
+
         $response = $this->respondPaginated($users, $inputs);
         return $response;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,18 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     ];
 
     /**
+     * Attributes that can be queried as unique identifiers.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * they are actual indexes on the database.
+     *
+     * @var array
+     */
+    public static $indexes = [
+        '_id', 'drupal_id',
+    ];
+
+    /**
      * The database collection used by the model.
      *
      * @var string


### PR DESCRIPTION
#### What's this PR do?
Primarily this allows for multiple identifiers to be used for the `_id` and `drupal_id` params on the `GET /users` endpoint. Additional attributes can still be included like before.

ex:
- GET /users?_id=100,101,102
- GET /users?drupal_id=100,101,102
- GET /users?_id=100,101,102&mobile=100

This PR also includes a unit test for the new functionality plus some unit test fixes for a plain ole `GET /users` and a test for a nonexistent user.

#### Where should the reviewer start?
The new stuff in UserController basically turns the comma-delimited values of the `_id` and `drupal_id` params into arrays. Those arrays then get added to the Builder query via a whereIn, but only if there was anything passed to `_id` or `drupal_id`.

#### How was this tested?
I manually tested the examples above with real values and ran the PHPUnit tests.

#### Any background context?
This should help with the slowness from the reportback-items endpoint. Ref https://github.com/DoSomething/phoenix/pull/5408

#### What are the relevant tickets?
Closes #212

#### Questions
I ran into an issue when using the `XDEBUG_SESSION_START=PHPSTORM` flag while debugging. Because of line 25 where it goes... `$users = User::where($inputs);`, it'd try to find user documents that had the `XDEBUG_SESSION_START` property and ultimately wouldn't find any. I added that string to the `except()` array, but it felt weird to commit that to the repository.

Should I have included it anyway for future debugging?

cc: @DFurnes @angaither @weerd 

I really don't know who I should be assigning Northstar stuff too.