### PR TITLE
Fixes error that was ocurring during Artisan optimize.

### DIFF
--- a/config/compile.php
+++ b/config/compile.php
@@ -16,8 +16,6 @@ return [
     'files' => [
 
         realpath(__DIR__ . '/../app/Providers/AppServiceProvider.php'),
-        realpath(__DIR__ . '/../app/Providers/BusServiceProvider.php'),
-        realpath(__DIR__ . '/../app/Providers/ConfigServiceProvider.php'),
         realpath(__DIR__ . '/../app/Providers/EventServiceProvider.php'),
         realpath(__DIR__ . '/../app/Providers/RouteServiceProvider.php'),
 


### PR DESCRIPTION
#### Changes

I forgot to remove these from the providers array when I was [updating things to Laravel 5.1](https://github.com/DoSomething/northstar/pull/217), so it was getting all angry that it couldn't load them (because the files don't exist anymore). Whoops!

#### How should this be tested?
Either run `php artisan optimize --force`, or just verify the Wercker build is happy. :cactus: 

---

For review: @sheyd 
