### PR TITLE
Add an index to `drupal_id` column.

### DIFF
--- a/database/migrations/2015_10_26_193708_AddDrupalIDIndex.php
+++ b/database/migrations/2015_10_26_193708_AddDrupalIDIndex.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDrupalIDIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function ($collection) {
+            $collection->index('drupal_id', ['sparse' => true]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $collection->dropIndex('drupal_id');
+    }
+}


### PR DESCRIPTION
#### Changes
Adds a [sparse index](https://docs.mongodb.org/manual/core/index-sparse/) on the `drupal_id` field for the `users` collection. This should fix the really slow performance we're seeing on the the UserController@show endpoint.

#### Screenshots
Indexes before the migration:
![screen shot 2015-10-26 at 3 40 16 pm](https://cloud.githubusercontent.com/assets/583202/10740430/9f88ee56-7bf8-11e5-8e0d-fb821c433aab.png)

Indexes after migration:
![screen shot 2015-10-26 at 3 40 59 pm](https://cloud.githubusercontent.com/assets/583202/10740433/a328449e-7bf8-11e5-87bc-808bd0dc26ee.png)

---
For review: @jonuy 