### PR TITLE
Tidying things up

### DIFF
--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -12,14 +12,14 @@ class AvatarController extends Controller
         $this->aws = $aws;
     }
 
-   /**
-   * Store a new avatar for a user.
-   * POST /users/{id}/avatar
-   *
-   * @param Request $request
-   * @param $id - User ID
-   * @return Response
-   */
+    /**
+     * Store a new avatar for a user.
+     * POST /users/{id}/avatar
+     *
+     * @param Request $request
+     * @param $id - User ID
+     * @return \Illuminate\Http\Response
+     */
     public function store(Request $request, $id)
     {
         if ($request->file('photo')) {

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -5,7 +5,7 @@ use Northstar\Events\UserSignedUp;
 use Northstar\Events\UserReportedBack;
 use Northstar\Models\Campaign;
 use Northstar\Models\User;
-use Northstar\Services\DrupalAPI;
+use Northstar\Services\Phoenix;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -13,14 +13,14 @@ class CampaignController extends Controller
 {
 
     /**
-     * Drupal API wrapper.
-     * @var DrupalAPI
+     * Phoenix Drupal API wrapper.
+     * @var Phoenix
      */
-    protected $drupal;
+    protected $phoenix;
 
-    public function __construct(DrupalAPI $drupal)
+    public function __construct(Phoenix $drupal)
     {
-        $this->drupal = $drupal;
+        $this->phoenix = $drupal;
     }
 
     /**
@@ -46,7 +46,7 @@ class CampaignController extends Controller
 
         foreach ($campaigns as $campaign) {
             if ($campaign->reportback_id) {
-                $response = $this->drupal->reportbackContent($campaign->reportback_id);
+                $response = $this->phoenix->reportbackContent($campaign->reportback_id);
 
                 // Possible for reportback data to be missing if it's been deleted on Drupal
                 if (isset($response['data'])) {
@@ -78,7 +78,7 @@ class CampaignController extends Controller
         }
 
         if ($campaign->reportback_id) {
-            $response = $this->drupal->reportbackContent($campaign->reportback_id);
+            $response = $this->phoenix->reportbackContent($campaign->reportback_id);
 
             if (isset($response['data'])) {
                 $campaign['reportback_data'] = $response['data'];
@@ -123,7 +123,7 @@ class CampaignController extends Controller
             $statusCode = 201;
 
             // Create a Drupal signup via Drupal API, and store signup ID in Northstar.
-            $signup_id = $this->drupal->campaignSignup($user->drupal_id, $campaign_id, $request->input('source'));
+            $signup_id = $this->phoenix->campaignSignup($user->drupal_id, $campaign_id, $request->input('source'));
 
             // Save reference to the signup on the user object.
             $campaign = new Campaign;
@@ -179,7 +179,7 @@ class CampaignController extends Controller
         }
 
         // Create a reportback via the Drupal API, and store reportback ID in Northstar
-        $reportback_id = $this->drupal->campaignReportback($user->drupal_id, $campaign_id, $request->all());
+        $reportback_id = $this->phoenix->campaignReportback($user->drupal_id, $campaign_id, $request->all());
 
         // Set status code based on whether `reportback_id` field already exists or not
         $statusCode = 201;

--- a/app/Http/Controllers/KudosController.php
+++ b/app/Http/Controllers/KudosController.php
@@ -1,7 +1,7 @@
 <?php namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Northstar\Services\DrupalAPI;
+use Northstar\Services\Phoenix;
 use Northstar\Models\User;
 use Northstar\Events\UserGotKudo;
 
@@ -9,9 +9,15 @@ use Northstar\Events\UserGotKudo;
 class KudosController extends Controller
 {
 
-    public function __construct(DrupalAPI $drupal)
+    /**
+     * Phoenix Drupal API wrapper.
+     * @var Phoenix
+     */
+    protected $phoenix;
+
+    public function __construct(Phoenix $phoenix)
     {
-        $this->drupal = $drupal;
+        $this->phoenix = $phoenix;
     }
 
    /**
@@ -29,7 +35,7 @@ class KudosController extends Controller
 
         $drupal_id = $user->drupal_id;
 
-        $response = $this->drupal->storeKudos($drupal_id, $request);
+        $response = $this->phoenix->storeKudos($drupal_id, $request);
 
         // Fire kudo event.
         event(new UserGotKudo($request->reportback_item_id));

--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -2,16 +2,21 @@
 
 use Illuminate\Http\Request;
 use Northstar\Models\User;
-use Northstar\Services\DrupalAPI;
+use Northstar\Services\Phoenix;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class SignupGroupController extends Controller
 {
-    protected $drupal;
 
-    public function __construct(DrupalAPI $drupal)
+    /**
+     * Phoenix Drupal API wrapper.
+     * @var Phoenix
+     */
+    protected $phoenix;
+
+    public function __construct(Phoenix $phoenix)
     {
-        $this->drupal = $drupal;
+        $this->phoenix = $phoenix;
     }
 
     /**
@@ -90,7 +95,7 @@ class SignupGroupController extends Controller
 
                     if (isset($user->campaigns[$i]->reportback_id)) {
                         // get reportback data from drupal
-                        $rbResponse = $this->drupal->reportbackContent($user->campaigns[$i]->reportback_id);
+                        $rbResponse = $this->phoenix->reportbackContent($user->campaigns[$i]->reportback_id);
                         $user->campaigns[$i]->reportback_data = $rbResponse['data'];
                     }
                 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,7 +1,7 @@
 <?php namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Northstar\Services\DrupalAPI;
+use Northstar\Services\Phoenix;
 use Northstar\Models\User;
 use Input;
 use Response;
@@ -11,6 +11,17 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class UserController extends Controller
 {
+
+    /**
+     * Phoenix Drupal API wrapper.
+     * @var Phoenix
+     */
+    protected $phoenix;
+
+    public function __construct(Phoenix $phoenix)
+    {
+        $this->phoenix = $phoenix;
+    }
 
     /**
      * Display a listing of the resource.
@@ -92,8 +103,7 @@ class UserController extends Controller
             // @TODO: we can't create a Drupal user without an email. Do we just create an @mobile one like we had done previously?
             if (Input::has('create_drupal_user') && Input::has('password') && !$user->drupal_id) {
                 try {
-                    $drupal = new DrupalAPI;
-                    $drupal_id = $drupal->register($user, Input::get('password'));
+                    $drupal_id = $this->phoenix->register($user, Input::get('password'));
                     $user->drupal_id = $drupal_id;
                 } catch (\Exception $e) {
                     // If user already exists, find the user to get the uid.

--- a/app/Listeners/SendKudoPushNotification.php
+++ b/app/Listeners/SendKudoPushNotification.php
@@ -4,7 +4,7 @@ namespace Northstar\Listeners;
 
 use Northstar\Events\UserGotKudo;
 use Northstar\Models\User;
-use Northstar\Services\DrupalAPI;
+use Northstar\Services\Phoenix;
 use Northstar\Services\Parse;
 
 
@@ -17,20 +17,20 @@ class SendKudoPushNotification {
     protected $parse;
 
     /**
-     * Drupal API wrapper
-     * @var DrupalAPI
+     * Phoenix Drupal API wrapper
+     * @var Phoenix
      */
-    protected $drupal;
+    protected $phoenix;
 
     /**
      * Create the event listener.
      * @param Parse $parse - Injected Parse API wrapper
-     * @param DrupalAPI $drupal - Injected Drupal API wrapper
+     * @param Phoenix $phoneix - Injected Drupal API wrapper
      */
-    public function __construct(Parse $parse, DrupalAPI $drupal)
+    public function __construct(Parse $parse, Phoenix $phoenix)
     {
         $this->parse = $parse;
-        $this->drupal = $drupal;
+        $this->drupal = $phoenix;
     }
 
     /**

--- a/app/Listeners/SendReportbackPushNotification.php
+++ b/app/Listeners/SendReportbackPushNotification.php
@@ -4,7 +4,7 @@ namespace Northstar\Listeners;
 
 use Northstar\Events\UserReportedBack;
 use Northstar\Models\User;
-use Northstar\Services\DrupalAPI;
+use Northstar\Services\Phoenix;
 use Northstar\Services\Parse;
 
 
@@ -17,20 +17,20 @@ class SendReportbackPushNotification {
     protected $parse;
 
     /**
-     * Drupal API wrapper
-     * @var DrupalAPI
+     * Phoenix Drupal API wrapper
+     * @var Phoenix
      */
-    protected $drupal;
+    protected $phoenix;
 
     /**
      * Create the event listener.
      * @param Parse $parse - Injected Parse API wrapper
-     * @param DrupalAPI $drupal - Injected Drupal API wrapper
+     * @param Phoenix $phoenix - Injected Drupal API wrapper
      */
-    public function __construct(Parse $parse, DrupalAPI $drupal)
+    public function __construct(Parse $parse, Phoenix $phoenix)
     {
         $this->parse = $parse;
-        $this->drupal = $drupal;
+        $this->phoenix = $phoenix;
     }
 
     /**
@@ -68,7 +68,7 @@ class SendReportbackPushNotification {
         }
 
         // Get reportback content
-        $reportback_response = $this->drupal->reportbackContent($event->campaign->reportback_id);
+        $reportback_response = $this->phoenix->reportbackContent($event->campaign->reportback_id);
 
         // Assuming the last item in this array is the latest reportback submitted
         $reportback_items = $reportback_response['data']['reportback_items']['total'];

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -7,22 +7,27 @@ class AWS
     /**
      * Store an image in S3.
      *
-     * @param string $bucket
-     * @param File $file
+     * @param string $folder - Folder to write image to
+     * @param string $filename - Filename to write image to
+     * @param \Symfony\Component\HttpFoundation\File\File|string $file
+     *   File object, or a base-64 encoded data URI
+     *
+     * @return string - URL of stored image
      */
-    public function storeImage($folder, $id, $file)
+    public function storeImage($folder, $filename, $file)
     {
         if (is_string($file)) {
+            $path = 'uploads/' . $folder . '/' . $filename;
             $data = base64_decode($file);
-            $filename = 'uploads/' . $folder . '/' . $id;
-            Storage::disk('s3')->put($filename, $data);
         } else {
             $extension = $file->guessExtension();
-            $filename = 'uploads/' . $folder . '/' . $id . '.' . $extension;
-            Storage::disk('s3')->put($filename, file_get_contents($file));
+            $path = 'uploads/' . $folder . '/' . $filename . '.' . $extension;
+            $data = file_get_contents($file);
         }
 
-        return getenv('S3_URL') . $filename;
+        Storage::disk('s3')->put($filename, $data);
+
+        return getenv('S3_URL') . $path;
     }
 
 }

--- a/app/Services/DrupalPasswordChecker.php
+++ b/app/Services/DrupalPasswordChecker.php
@@ -1,26 +1,24 @@
-<?php namespace Northstar\Services;
+<?php
 
-use Northstar\Models\User;
-use Hash;
+namespace Northstar\Services;
 
-/**
-* The minimum allowed log2 number of iterations for password stretching.
- */
 define('DRUPAL_MIN_HASH_COUNT', 7);
-
-/**
-* The maximum allowed log2 number of iterations for password stretching.
-*/
 define('DRUPAL_MAX_HASH_COUNT', 30);
-
-/**
-* The expected (and maximum) number of characters in a hashed password.
-*/
 define('DRUPAL_HASH_LENGTH', 55);
 
 class DrupalPasswordChecker
 {
-    public function user_check_password($password, $drupal_password)
+    /**
+     * Check if a given password matches the hash created by Drupal. For details,
+     * see Drupal 7's `user_check_password` function.
+     * @see https://api.drupal.org/api/drupal/includes!password.inc/function/user_check_password/7
+     *
+     * @param $password - Unhashed password to verify
+     * @param $drupal_password - Hashed password
+     *
+     * @return bool - Do they match?
+     */
+    public function check($password, $drupal_password)
     {
         if (substr($drupal_password, 0, 2) == 'U$') {
             // This may be an updated password from user_update_7000(). Such hashes
@@ -51,8 +49,8 @@ class DrupalPasswordChecker
             return ($hash && $stored_hash == $hash);
     }
 
-
-    public function _password_crypt($algo, $password, $setting)
+    // @see: https://api.drupal.org/api/drupal/includes%21password.inc/function/_password_crypt/7
+    private function _password_crypt($algo, $password, $setting)
     {
         // Prevent DoS attacks by refusing to hash large passwords.
         if (strlen($password) > 512) {
@@ -92,17 +90,7 @@ class DrupalPasswordChecker
         return (strlen($output) == $expected) ? substr($output, 0, DRUPAL_HASH_LENGTH) : FALSE;
     }
 
-    /**
-     * Encodes bytes into printable base 64 using the *nix standard from crypt().
-     *
-     * @param $input
-     *   The string containing bytes to encode.
-     * @param $count
-     *   The number of characters (bytes) to encode.
-     *
-     * @return
-     *   Encoded string
-     */
+    // @see https://api.drupal.org/api/drupal/includes%21password.inc/function/_password_base64_encode/7
     private function _password_base64_encode($input, $count) {
       $output = '';
       $i = 0;
@@ -130,18 +118,14 @@ class DrupalPasswordChecker
       return $output;
     }
 
-    /**
-     * Parse the log2 iteration count from a stored hash or setting string.
-     */
+    // @see https://api.drupal.org/api/drupal/includes%21password.inc/function/_password_get_count_log2/7
     private function _password_get_count_log2($setting)
     {
       $itoa64 = $this->_password_itoa64();
       return strpos($itoa64, $setting[3]);
     }
 
-    /**
-    * Returns a string for mapping an int to the corresponding base 64 character.
-    */
+    // @see https://api.drupal.org/api/drupal/includes%21password.inc/function/_password_itoa64/7
     private function _password_itoa64() {
         return './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
     }

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -1,19 +1,18 @@
 <?php namespace Northstar\Services;
 
 use GuzzleHttp\Client;
-use Config;
 use Cache;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
-class DrupalAPI
+class Phoenix
 {
 
     protected $client;
 
     public function __construct()
     {
-        $base_url = Config::get('services.drupal.url');
-        $version = Config::get('services.drupal.version');
+        $base_url = config('services.drupal.url');
+        $version = config('services.drupal.version');
 
         $this->client = new Client([
             'base_url' => [$base_url . '/api/{version}/', ['version' => $version]],
@@ -29,7 +28,7 @@ class DrupalAPI
     /**
      * Returns a token for making authenticated requests to the Drupal API.
      *
-     * @return Array - Cookie & token for authenticated requests
+     * @return array - Cookie & token for authenticated requests
      */
     private function authenticate()
     {
@@ -60,7 +59,7 @@ class DrupalAPI
     /**
      * Get the CSRF token for the authenticated API session.
      *
-     * @return String - token
+     * @return string - token
      */
     private function getAuthenticationToken()
     {
@@ -70,7 +69,7 @@ class DrupalAPI
     /**
      * Get the cookie for the authenticated API session.
      *
-     * @return Array - cookie key/value
+     * @return array - cookie key/value
      */
     private function getAuthenticationCookie()
     {
@@ -82,6 +81,7 @@ class DrupalAPI
      * @see https://github.com/DoSomething/dosomething/wiki/API#campaigns
      *
      * @param int $id - Optional campaign ID to get information on.
+     *
      * @return mixed
      */
     public function campaigns($id = NULL)
@@ -100,7 +100,7 @@ class DrupalAPI
      * Forward registration to Drupal.
      * @see: https://github.com/DoSomething/dosomething/wiki/API#create-a-user
      *
-     * @param \User $user - User to be registered on Drupal site
+     * @param \Northstar\Models\User $user - User to be registered on Drupal site
      * @param String $password - Password to register with
      *
      * @return int - Created Drupal user UID
@@ -127,6 +127,7 @@ class DrupalAPI
      * @see: https://github.com/DoSomething/dosomething/wiki/API#find-a-user
      *
      * @param String $email - Email of user to search for
+     *
      * @return String - Drupal User ID
      * @throws \Exception
      */
@@ -143,7 +144,7 @@ class DrupalAPI
         ]);
 
         $json = $response->json();
-        if (sizeof($json) > 0) {
+        if (count($json) > 0) {
             return $json[0]['uid'];
         }
         else {
@@ -201,10 +202,11 @@ class DrupalAPI
      *
      * @param String $user_id - UID of user on the Drupal site
      * @param String $campaign_id - NID of campaign on the Drupal site
-     * @param Array $contents - Contents of reportback
-     * @option String quantity - Quantity of reportback
-     * @option String why_participated - Why the user participated in this campaign
-     * @option String file - Reportback image as a Data URL
+     * @param array $contents - Contents of reportback
+     *   @option string $quantity - Quantity of reportback
+     *   @option string $why_participated - Why the user participated in this campaign
+     *   @option string $file - Reportback image as a Data URL
+     *
      * @return String - Reportback ID
      * @throws \Exception
      *
@@ -263,11 +265,9 @@ class DrupalAPI
     /**
      * Get a user's full reportback content if reportback exists.
      *
-     * @param String $term - email or mobile
-     * @param String $id - email or mobile
-     * @param String $campaign_id - NID of campaign on the Drupal site
-     * @return Array - Contents of reportback
+     * @param string $reportback_id - NID of campaign on the Drupal site
      *
+     * @return array - Contents of reportback
      */
     public function reportbackContent($reportback_id)
     {
@@ -279,10 +279,9 @@ class DrupalAPI
     /**
      * Get a specific reportback item.
      *
-     * @param String $reportback_item_id
+     * @param String $reportback_item_id - NID of the reportback item on the Drupal site
      *
-     * @return Array - Contents of the reportback item.
-     *
+     * @return array - Contents of the reportback item.
      */
     public function reportbackItemContent($reportback_item_id)
     {

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -1,7 +1,7 @@
 <?php namespace Northstar\Services;
 
-use Northstar\Models\User;
 use Hash;
+use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Registrar

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -33,7 +33,7 @@ class Registrar
         } else if (($user instanceof User) && !($user->password)) {
 
             // check to see if $input['password'] equals user's drupal password
-            if ($this->drupal_password_checker->user_check_password($input['password'], $user->drupal_password)) {
+            if ($this->drupal_password_checker->check($input['password'], $user->drupal_password)) {
 
                 // if they're the same, make $input['password'] into a hash and save it to the user.
                 $user->password = $input['password'];

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -1,9 +1,7 @@
 <?php namespace Northstar\Services;
 
 use Northstar\Models\User;
-use Northstar\Models\Token;
 use Hash;
-use Northstar\Services\DrupalPasswordChecker;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Registrar

--- a/tests/CampaignTest.php
+++ b/tests/CampaignTest.php
@@ -6,7 +6,7 @@ use Northstar\Models\Campaign;
 class CampaignTest extends TestCase
 {
 
-    protected $drupalMock;
+    protected $phoenixMock;
 
     protected $server;
     protected $signedUpServer;
@@ -50,8 +50,8 @@ class CampaignTest extends TestCase
             'HTTP_Session' => User::find('bf1039b0271bcc636aa5477a')->login()->key
         );
 
-        // Mock Drupal API class
-        $this->drupalMock = $this->mock('Northstar\Services\DrupalAPI');
+        // Mock Phoenix Drupal API class
+        $this->phoenixMock = $this->mock('Northstar\Services\Phoenix');
     }
 
 
@@ -87,7 +87,7 @@ class CampaignTest extends TestCase
         ];
 
         // Mock successful response from Drupal API
-        $this->drupalMock->shouldReceive('campaignSignup')->once()->andReturn(100);
+        $this->phoenixMock->shouldReceive('campaignSignup')->once()->andReturn(100);
 
         $response = $this->call('POST', 'v1/user/campaigns/123/signup', [], [], [], $this->server, json_encode($payload));
         $content = $response->getContent();
@@ -141,7 +141,7 @@ class CampaignTest extends TestCase
         ];
 
         // Mock successful response from Drupal API
-        $this->drupalMock->shouldReceive('campaignReportback')->once()->andReturn(100);
+        $this->phoenixMock->shouldReceive('campaignReportback')->once()->andReturn(100);
 
         $response = $this->call('POST', 'v1/user/campaigns/123/reportback', [], [], [], $this->signedUpServer, json_encode($payload));
         $content = $response->getContent();
@@ -174,7 +174,7 @@ class CampaignTest extends TestCase
         ];
 
         // Mock successful response from Drupal API
-        $this->drupalMock->shouldReceive('campaignReportback')->once()->andReturn(100);
+        $this->phoenixMock->shouldReceive('campaignReportback')->once()->andReturn(100);
 
         $response = $this->call('PUT', 'v1/user/campaigns/123/reportback', [], [], [], $this->reportedBackServer, json_encode($payload));
         $content = $response->getContent();

--- a/tests/PushNotificationTest.php
+++ b/tests/PushNotificationTest.php
@@ -12,6 +12,18 @@ use Northstar\Models\Campaign;
 class PushNotificationTest extends TestCase
 {
 
+    /**
+     * Mock Phoenix Drupal API wrapper
+     * @var \Northstar\Services\Phoenix
+     */
+    protected $phoenixMock;
+
+    /**
+     * Mock Parse API wrapper
+     * @var \Northstar\Services\Parse
+     */
+    protected $parseMock;
+
     public function setUp()
     {
         parent::setUp();
@@ -20,7 +32,7 @@ class PushNotificationTest extends TestCase
         Artisan::call('migrate');
         $this->seed();
 
-        $this->drupalMock = $this->mock('Northstar\Services\DrupalAPI');
+        $this->phoenixMock = $this->mock('Northstar\Services\Phoenix');
         $this->parseMock = $this->mock('Northstar\Services\Parse');
     }
 
@@ -66,8 +78,8 @@ class PushNotificationTest extends TestCase
             ]
         ];
 
-        $this->drupalMock->shouldReceive('reportbackContent')->once()->andReturn($reportback_response);
-        $notification = new SendReportbackPushNotification($this->parseMock, $this->drupalMock);
+        $this->phoenixMock->shouldReceive('reportbackContent')->once()->andReturn($reportback_response);
+        $notification = new SendReportbackPushNotification($this->parseMock, $this->phoenixMock);
 
         $pushes = $notification->createPushData($event);
 
@@ -165,9 +177,9 @@ class PushNotificationTest extends TestCase
             ],
         ];
 
-        $this->drupalMock->shouldReceive('reportbackItemContent')->once()->andReturn($reportback_response);
+        $this->phoenixMock->shouldReceive('reportbackItemContent')->once()->andReturn($reportback_response);
 
-        $notification = new SendKudoPushNotification($this->parseMock, $this->drupalMock);
+        $notification = new SendKudoPushNotification($this->parseMock, $this->phoenixMock);
         $pushes = $notification->createPushData($event);
 
         $this->assertEquals('parse-100', $pushes[0]['installation_ids'][0]);


### PR DESCRIPTION
#### Changes
As part of [kicking off Data 2.0](https://github.com/DoSomething/quasar/issues/5) (oooOOOooh!), I'm doing a quick once-over to see what needs documenting or cleaning up in Northstar. I made a few changes, broken up into individual commits by change. Feel free to argue against any changes that don't make sense!

Highlights:
 - Renamed `DrupalAPI` to `Phoenix`. This seems a bit more straightforward (it's an API wrapped _specifically_ for Phoenix, not all Drupal APIs), and it was our only "API" class with the `API` suffix on the class name. (db0bba2)
 - Use Laravel 5's `Request` object rather than the `Input` facade. This reads a bit better, since rather than grabbing the input "out of thin air", it's just an object passed to the controller method. The API is exactly the same. (056fe9d)
 - Update documentation for the `AWS` class (had fallen out of date). (b8ab83a)
 - Reference Drupal's API documentation for `DrupalPasswordChecker` methods, so it's clear that those are not our code and can be treated as a "black box". (c6450b7)
 - Fixed indentation and removed some unnecessary class aliases. (4a97fdd, 08899c6, c59ba50)

#### How do I test this?
Unit tests should continue to pass, so that's good. :traffic_light:

---
For review: @jonuy 
/cc @chloealee @weerd 