### PR TITLE
Make DrupalPasswordHash static

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Http\Controllers;
 
-use Northstar\Models\User;
 use Northstar\Models\Token;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -20,7 +20,7 @@ class AuthController extends Controller
      * Authenticate a registered user
      *
      * @param Request $request
-     * @return Response
+     * @return \Illuminate\Http\Response
      * @throws UnauthorizedHttpException
      */
     public function login(Request $request)
@@ -39,7 +39,7 @@ class AuthController extends Controller
 
     /**
      * Logout the current user by invalidating their session token.
-     * @return Response
+     * @return \Illuminate\Http\Response
      * @throws HttpException
      */
     public function logout(Request $request)

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -8,11 +8,6 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Registrar
 {
-    public function __construct(DrupalPasswordChecker $drupal_password_checker)
-    {
-        $this->drupal_password_checker = $drupal_password_checker;
-    }
-
     public function login($input)
     {
         $login_type = 'username';
@@ -36,7 +31,7 @@ class Registrar
         } elseif (($user instanceof User) && ! ($user->password)) {
 
             // check to see if $input['password'] equals user's drupal password
-            if ($this->drupal_password_checker->check($input['password'], $user->drupal_password)) {
+            if (DrupalPasswordHash::check($input['password'], $user->drupal_password)) {
 
                 // if they're the same, make $input['password'] into a hash and save it to the user.
                 $user->password = $input['password'];


### PR DESCRIPTION
#### Changes
This just occurred to me while looking into [other](https://github.com/DoSomething/northstar/issues/228) [authentication](https://github.com/DoSomething/northstar/issues/202) [improvements](https://github.com/DoSomething/northstar/issues/108) & I think it seems like a nice little touchup. Renamed `DrupalPasswordChecker` to `DrupalPasswordHash` and made `check` a static method, since that makes its API read identically to Laravel's built-in `Hash::check` and removes the overhead of instantiating and dependency-injecting the class since it doesn't have any internal state.

### How should this be tested?
Automated tests should still pass. :traffic_light: 

---
For review: @jonuy @angaither 