### PR TITLE
Validate email is <=  60 characters on registration.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -95,7 +95,7 @@ class UserController extends Controller
             // is for unique email or phone numbers, and that should return a user
             // from the query above.
             $this->validate($request, [
-                'email' => 'email|unique:users|required_without:mobile',
+                'email' => 'email|max:60|unique:users|required_without:mobile',
                 'mobile' => 'unique:users|required_without:email',
             ]);
         }


### PR DESCRIPTION
#### Changes
Fixes #240. 

Drupal was failing to register users with longer email addresses, leading to unexpected behavior with campaigns/signups. This seems like a suitable quick fix, and we can get a better longer term fix in when we update Drupal to authenticate against Northstar sometime in the (hopefully near) future.

#### How should I test this?
Registering a user with a very long email address should give an error response, like so:
```
{
  "error": {
    "code": 401,
    "message": "The email may not be greater than 60 characters."
  }
}
```

Unit tests, as always, should continue to pass. :traffic_light: 

---
For review: @angaither 
/cc @tongxiang 
