### PR TITLE
Use a better Slack notification step.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -36,11 +36,10 @@ deploy:
           echo -e $WERCKER_APP_KEY_PRIVATE > $CAP_PRIVATE_KEY
     - cap
   after-steps:
-      - iansmith9876/pretty-slack-notify:
-          team: dosomething
+      - sherzberg/slack-notify:
+          subdomain: dosomething
           token: $SLACK_TOKEN
           channel: $SLACK_ROOM
-          username: george
       - script:
           name: Run Runscope tests
           code: curl $RUNSCOPE_TRIGGER_URL


### PR DESCRIPTION
#### Changes
Switches to an [alternative Slack notification step](https://app.wercker.com/#applications/527ac6e85930ceca130041c3/tab/details) that seems a little more user-friendly. We've been using this step on the Voting App for the past month, and it offers a lot more useful notifications for deploy steps. For example, see the following example of deploying `dev` to `CelebsGoneGoodProd`:

![screen shot 2015-12-07 at 5 21 55 pm](https://cloud.githubusercontent.com/assets/583202/11641617/370c3ace-9d07-11e5-9a07-27da67b2ae11.png)

Niiiiiice. :sunglasses: 

---
For review: @angaither 