### PR TITLE
Don't trigger Runscope tests on deploy.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -40,6 +40,3 @@ deploy:
           subdomain: dosomething
           token: $SLACK_TOKEN
           channel: $SLACK_ROOM
-      - script:
-          name: Run Runscope tests
-          code: curl $RUNSCOPE_TRIGGER_URL


### PR DESCRIPTION
#### Changes
Let's not trigger Runscope tests on deploys (at least for the moment), since they add a lot of noise to chat & are not testing the same environment that the deploy is sent to. :grimacing: 

---
For review: @angaither @jonuy 