### PR TITLE
writes test for drupal password checker

### DIFF
--- a/app/Services/DrupalPasswordHash.php
+++ b/app/Services/DrupalPasswordHash.php
@@ -49,6 +49,11 @@ class DrupalPasswordHash
             return ($hash && $stored_hash == $hash);
     }
 
+    private static function hash($password)
+    {
+        return self::_password_crypt('sha512', $password, $stored_hash);
+    }
+
     // @see: https://api.drupal.org/api/drupal/includes%21password.inc/function/_password_crypt/7
     private static function _password_crypt($algo, $password, $setting)
     {

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -46,8 +46,8 @@ class Registrar
 
                 return $user;
             }
-        } else {
-            throw new UnauthorizedHttpException(null, 'Invalid '.$login_type.' or password.');
         }
+
+        throw new UnauthorizedHttpException(null, 'Invalid '.$login_type.' or password.');
     }
 }

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -168,6 +168,24 @@ class UserTableSeeder extends Seeder
             'password' => 'secret',
         ]);
 
+        // User with a drupal_password but no password
+        User::create([
+            '_id' => '5430e850dt8hbc541c37cal3',
+            'email' => 'test4@dosomething.org',
+            'mobile' => '5555550103',
+            'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
+            'drupal_id' => '100007',
+            'addr_street1' => '123',
+            'addr_street2' => '456',
+            'addr_city' => 'Paris',
+            'addr_state' => 'Florida',
+            'addr_zip' => '555555',
+            'country' => 'US',
+            'birthdate' => '12/17/91',
+            'first_name' => 'First',
+            'last_name' => 'Last',
+        ]);
+
         if (App::environment('local')) {
             $faker = Faker\Factory::create();
             foreach (range(1, 50) as $index) {

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -177,7 +177,6 @@ class AuthTest extends TestCase
         $content = $response->getContent();
         $data = json_decode($content, true);
         $user = User::find('5430e850dt8hbc541c37cal3');
-        dd($user);
 
         // Assert reponse is 200 and has expected data
         $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
#### What does this PR do?
Builds a unit test for drupal password checker (#229). The drupal password checker allows a user to sign into the mobile app if they have a `drupal_password` but no `password`. It checks if the inputted `password` is the same as their `drupal_password` and if so, signs them in, deletes the `drupal_password`, hashes the `password` and saves it to their user object. 

#### Where should the reviewer start?
tests/AuthTest.php lines 168-195

In line 186, I have this assertion: `$this->assertArrayHasKey('password', $user['attributes']);` 
I tried to do `$user->toArray();` but this didn't output the user with the new `password` attribute. When I just did `dd($user)` however, the object did contain the `password` attribute so went the above route instead. 

Does it matter if I use `$user['attributes']` or `$user['original']`? They're both the same array.   

#### How should this be manually tested?
SSH into northstar vagrant environment. Run `vendor/bin/phpunit`

#### What are the relevant tickets?
Fixes #230 