### PR TITLE
Signup group should require a user scoped key.

### DIFF
--- a/app/Http/Controllers/SignupGroupController.php
+++ b/app/Http/Controllers/SignupGroupController.php
@@ -19,7 +19,7 @@ class SignupGroupController extends Controller
     {
         $this->phoenix = $phoenix;
 
-        $this->middleware('key:admin');
+        $this->middleware('key:user');
     }
 
     /**


### PR DESCRIPTION
#### Changes
I incorrectly scoped signup groups to require an `admin` scoped key in #239. This fixes that. :hammer: 

#### How should this be tested?
Signup groups should be accessible from non-admin API keys.

#### Questions
...do we use signup groups anymore?

---
For review: @angaither @jonuy 