### PR TITLE
Scope gotchas

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -23,15 +23,6 @@ class ApiKey extends Model
     ];
 
     /**
-     * The attributes that should be casted to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'scope' => 'array',
-    ];
-
-    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -66,8 +66,6 @@ class ApiKey extends Model
             return ['user'];
         }
 
-        $scope = $this->attributes['scope'];
-
-        return is_string($scope) ? json_decode($scope) : $scope;
+        return $this->attributes['scope'];
     }
 }


### PR DESCRIPTION
#### Changes
Fixes some little _gotchas_ that I ran into when trying to add scopes to existing API keys (using the Artisan REPL). Check out each commit for details, but the basic gist is that the [laravel-mongodb](https://github.com/jenssegers/laravel-mongodb) seems to have some unexpected behavior with casting and arrays that removing this code seems to clean up. :innocent: 

For review: @angaither 