### PR TITLE
Add search parameter for loosely finding matching results.

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -185,7 +185,7 @@ abstract class Controller extends BaseController
         }
 
         // Searches may only be performed on indexed fields.
-        $filters = array_intersect_key($searches, array_flip($indexes));
+        $searches = array_intersect_key($searches, array_flip($indexes));
 
         // For the first `where` query, we want to limit results... from then on,
         // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Model;
 use League\Fractal\Manager;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use League\Fractal\Resource\Collection as FractalCollection;
@@ -13,6 +12,7 @@ use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Database\Eloquent;
 use Illuminate\Http\Request;
+use Northstar\Models\ApiKey;
 
 abstract class Controller extends BaseController
 {
@@ -183,6 +183,9 @@ abstract class Controller extends BaseController
         if (! $searches) {
             return $query;
         }
+
+        // Only "admin" keys should be able to search
+        ApiKey::gate('admin');
 
         // Searches may only be performed on indexed fields.
         $searches = array_intersect_key($searches, array_flip($indexes));

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -49,7 +49,7 @@ class KeyController extends Controller
     {
         $this->validate($request, [
             'app_id' => 'required|unique:api_keys,app_id',
-            'scope' => 'array|scope' // @see ApiKey::validateScopes
+            'scope' => 'array|scope', // @see ApiKey::validateScopes
         ]);
 
         $key = ApiKey::create($request->all());
@@ -86,7 +86,7 @@ class KeyController extends Controller
     public function update($key, Request $request)
     {
         $this->validate($request, [
-            'scope' => 'array|scope' // @see ApiKey::validateScopes
+            'scope' => 'array|scope', // @see ApiKey::validateScopes
         ]);
 
         $key = ApiKey::where('api_key', $key)->firstOrFail();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -45,27 +45,10 @@ class UserController extends Controller
     {
         // Create an empty User query, which we can either filter (below)
         // or paginate to retrieve all user records.
-        $query = (new User)->newQuery();
+        $query = $this->newQuery(User::class);
 
-        // Requests may be filtered by indexed fields.
-        $filters = $request->query('filter');
-        if($filters) {
-            $filters = array_intersect_key($filters, array_flip(User::$indexes));
-
-            // You can filter by multiple values, e.g. `filter[source]=agg,cgg`
-            // to get records that have a source value of either `agg` or `cgg`.
-            foreach ($filters as $filter => $values) {
-                $values = explode(',', $values);
-
-                // For the first `where` query, we want to limit results... from then on,
-                // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
-                $firstWhere = true;
-                foreach ($values as $value) {
-                    $query->where($filter, '=', $value, ($firstWhere ? 'and' : 'or'));
-                    $firstWhere = false;
-                }
-            }
-        }
+        $query = $this->filter($query,$request->query('filter'), User::$indexes);
+        $query = $this->search($query,$request->query('search'), User::$indexes);
 
         return $this->paginatedCollection($query, $request);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -47,8 +47,8 @@ class UserController extends Controller
         // or paginate to retrieve all user records.
         $query = $this->newQuery(User::class);
 
-        $query = $this->filter($query,$request->query('filter'), User::$indexes);
-        $query = $this->search($query,$request->query('search'), User::$indexes);
+        $query = $this->filter($query, $request->query('filter'), User::$indexes);
+        $query = $this->search($query, $request->query('search'), User::$indexes);
 
         return $this->paginatedCollection($query, $request);
     }
@@ -148,7 +148,7 @@ class UserController extends Controller
         // Find the user.
         $user = User::where($term, $id)->first();
 
-        if(! $user) {
+        if (! $user) {
             throw new NotFoundHttpException('The resource does not exist.');
         }
 

--- a/app/Http/Middleware/AuthenticateAPIKey.php
+++ b/app/Http/Middleware/AuthenticateAPIKey.php
@@ -17,18 +17,7 @@ class AuthenticateAPIKey
      */
     public function handle($request, Closure $next, $scope = 'user')
     {
-        $app_id = $request->header('X-DS-Application-Id');
-        $api_key = $request->header('X-DS-REST-API-Key');
-
-        $key = ApiKey::where('app_id', $app_id)->where('api_key', $api_key)->first();
-
-        if (! $key) {
-            return response()->json('Unauthorized access.', 401);
-        }
-
-        if (! in_array($scope, $key->scope)) {
-            return response()->json('API key is missing required scope.', 403);
-        }
+        ApiKey::gate($scope);
 
         return $next($request);
     }

--- a/app/Http/Transformers/ApiKeyTransformer.php
+++ b/app/Http/Transformers/ApiKeyTransformer.php
@@ -15,7 +15,7 @@ class ApiKeyTransformer extends TransformerAbstract
     {
         return [
             'app_id' => $key->app_id,
-            'api_key' => $key-> api_key,
+            'api_key' => $key->api_key,
             'scope' => $key->scope,
 
             'updated_at' => $key->updated_at->toISO8601String(),

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -43,7 +43,7 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
 
     // Api Keys
     $router->resource('keys', 'KeyController');
-    $router->get('scopes', function() {
+    $router->get('scopes', function () {
         return \Northstar\Models\ApiKey::scopes();
     });
 });

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -87,7 +87,7 @@ class ApiKey extends Model
      */
     public function hasScope($scope)
     {
-       return in_array($scope, $this->scope);
+        return in_array($scope, $this->scope);
     }
 
     /**
@@ -136,7 +136,7 @@ class ApiKey extends Model
      */
     public static function gate($scope)
     {
-        $key = ApiKey::current();
+        $key = self::current();
 
         if (! $key || ! $key->hasScope($scope)) {
             throw new AccessDeniedHttpException('You must be using an API key with "'.$scope.'" scope to do that.');

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -82,13 +82,15 @@ class ApiKey extends Model
      * Validate if all the given scopes are valid.
      *
      * @param $scopes
-     * @return boolean
+     * @return bool
      */
     public static function validateScopes($scopes)
     {
-        if(! is_array($scopes)) return false;
+        if (! is_array($scopes)) {
+            return false;
+        }
 
-        return !array_diff($scopes, array_keys(static::$scopes));
+        return ! array_diff($scopes, array_keys(static::$scopes));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,7 +39,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      * @var array
      */
     public static $indexes = [
-        '_id', 'drupal_id', 'email', 'mobile'
+        '_id', 'drupal_id', 'email', 'mobile',
     ];
 
     /**

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -186,6 +186,18 @@ class UserTableSeeder extends Seeder
             'last_name' => 'Last',
         ]);
 
+        // Seeded users for UserTest@testSearchUsers
+        foreach (range(1, 5) as $index) {
+            $faker = Faker\Factory::create();
+            User::create([
+                'first_name' => $faker->firstName,
+                'last_name' => $faker->lastName,
+                'email' => $faker->unique()->userName.'@search.example.com',
+                'password' => 'secret',
+                'birthdate' => '12/17/91',
+            ]);
+        }
+
         if (App::environment('local')) {
             $faker = Faker\Factory::create();
             foreach (range(1, 50) as $index) {

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -88,10 +88,10 @@ class UserTest extends TestCase
 
     /**
      * Tests retrieving multiple users by their id
-     * GET /users?_id=:id_1,...,:id_N
-     * GET /users?drupal_id=:id_1,...,:id_N
+     * GET /users?filter[_id]=:id_1,...,:id_N
+     * GET /users?filter[drupal_id]=:id_1,...,:id_N
      */
-    public function testGetMultipleUsersById()
+    public function testFilterUsersById()
     {
         // Retrieve multiple users by _id
         $response1 = $this->call(
@@ -122,7 +122,25 @@ class UserTest extends TestCase
     }
 
     /**
-     * Tests retreiving a user
+     * Tests searching users.
+     * GET /users/?search[field]=term
+     */
+    public function testSearchUsers()
+    {
+        // Query by a "known" search term
+        $response = $this->call(
+            'GET',
+            'v1/users?search[email]=search.example.com',
+            [], [], [], $this->server
+        );
+        $data = json_decode($response->getContent());
+
+        // We seeded 5 users with this email domain.
+        $this->assertCount(5, $data->data);
+    }
+
+    /**
+     * Tests retrieving a user
      * GET /users/{term}/{id}
      */
     public function testRetrieveUser()

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -30,6 +30,14 @@ class UserTest extends TestCase
             'HTTP_X-DS-REST-API-Key' => 'abc4324',
         ];
 
+        $this->userScope = [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_Accept' => 'application/json',
+            'HTTP_X-DS-Application-Id' => '123',
+            'HTTP_X-DS-REST-API-Key' => '5464utyrs',
+            'HTTP_Session' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz0=',
+        ];
+
         // Mock AWS API class
         $this->awsMock = $this->mock('Northstar\Services\AWS');
     }
@@ -127,6 +135,14 @@ class UserTest extends TestCase
      */
     public function testSearchUsers()
     {
+        // Search should be limited to `admin` scoped keys.
+        $response = $this->call(
+            'GET',
+            'v1/users?search[email]=search.example.com',
+            [], [], [], $this->userScope
+        );
+        $this->assertEquals(403, $response->getStatusCode());
+
         // Query by a "known" search term
         $response = $this->call(
             'GET',


### PR DESCRIPTION
#### Changes
Adds a `search` parameter for loosely finding matching results. This is used to power [Aurora's search functionality](https://github.com/DoSomething/aurora/pull/122). For example, to find all users with emails containing `example.com`:

```
GET /v1/users/?search[email]=example.com
```

The Laravel MongoDB `like` operator looks like it is a shortcut [for performing a regex query on the MongoDB database](https://github.com/jenssegers/laravel-mongodb/blob/4526972eb65ea47399df18e42f843b0b733c28d3/src/Jenssegers/Mongodb/Query/Builder.php#L929-L940). I'm not sure exactly how performance on this kind of query is, but it looks like [it still uses any indexes on the relevant fields](https://docs.mongodb.org/manual/reference/operator/query/regex/#index-use) so hopefully not too bad.

#### Open Questions
Should this parameter be limited to `admin` scoped keys?

#### How should this be tested?
I added a unit test for the new search parameter in `UserTest.php`. (a250a4b)

---
For review: @angaither 