### PR TITLE
Fix inability to search for an ID.

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -194,7 +194,15 @@ abstract class Controller extends BaseController
         // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
         $firstWhere = true;
         foreach ($searches as $term => $value) {
-            $query->where($term, 'like', '%'.$value.'%', ($firstWhere ? 'and' : 'or'));
+            $operator = '=';
+
+            // We can't query the Object ID by regex. For everything else, prepare a regex query.
+            if ($term !== '_id') {
+                $value = '%'.preg_quote($value).'%';
+                $operator = 'like';
+            }
+
+            $query->where($term, $operator, $value, ($firstWhere ? 'and' : 'or'));
             $firstWhere = false;
         }
 


### PR DESCRIPTION
#### Changes
The MongoDB Object ID doesn’t seem to be queryable by regex. Luckily, I don’t think you’d ever really *want* to, so let’s just force that field to only search by exact match.

References DoSomething/aurora#125.

---
For review: @angaither 