### PR TITLE
Response permissions

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -11,6 +11,12 @@ use Northstar\Services\Registrar;
 
 class AuthController extends Controller
 {
+    /**
+     * The registrar.
+     * @var Registrar
+     */
+    protected $registrar;
+
     public function __construct(Registrar $registrar)
     {
         $this->registrar = $registrar;

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -13,10 +13,6 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         'Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode',
-        'Illuminate\Cookie\Middleware\EncryptCookies',
-        'Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse',
-        'Illuminate\Session\Middleware\StartSession',
-        'Illuminate\View\Middleware\ShareErrorsFromSession',
     ];
 
     /**

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Http\Transformers;
 
+use Northstar\Models\ApiKey;
 use Northstar\Models\User;
 use League\Fractal\TransformerAbstract;
 
@@ -13,39 +14,51 @@ class UserTransformer extends TransformerAbstract
      */
     public function transform(User $user)
     {
-        return [
+        $response = [
             'id' => $user->_id,
             '_id' => $user->_id, // @DEPRECATED: Will be removed.
-
-            'first_name' => $user->first_name,
-            'last_initial' => $user->last_initial,
-            'photo' => $user->photo,
-            'interests' => $user->interests,
-            'country' => $user->country,
-
-            // @TODO: Restrict these, based on API key scope or authenticated user.
             'email' => $user->email,
             'mobile' => $user->mobile,
-            // 'last_name' => $user->last_name,
-            // 'birthdate' => $user->birthdate,
-            // 'race' => $user->race,
-            // 'religion' => $user->religion,
-            // 'addr_street1' => $user->addr_street1,
-            // 'addr_street2' => $user->addr_street2,
-            // 'addr_city' => $user->addr_city,
-            // 'addr_state' => $user->addr_state,
-            // 'addr_zip' => $user->addr_zip,
 
-            // References to app-specific user IDs.
-            'drupal_id' => $user->drupal_id,
-            'cgg_id' => $user->cgg_id,
-            'agg_id' => $user->agg_id,
-            'source' => $user->source,
-
-            'parse_installation_ids' => $user->parse_installation_ids,
-
-            'updated_at' => $user->updated_at->toISO8601String(),
-            'created_at' => $user->created_at->toISO8601String(),
+            'first_name' => $user->first_name,
         ];
+
+        if (ApiKey::current()->hasScope('admin')) {
+            $response['last_name'] = $user->last_name;
+        }
+
+        $response['last_initial'] = $user->last_initial;
+
+        $response['photo'] = $user->photo;
+        $response['interests'] = $user->interests;
+
+        if (ApiKey::current()->hasScope('admin')) {
+            $response['birthdate'] = $user->birthdate;
+            $response['race'] = $user->race;
+            $response['religion'] = $user->religion;
+
+            $response['addr_street1'] = $user->addr_street1;
+            $response['addr_street2'] = $user->addr_street2;
+            $response['addr_city'] = $user->addr_city;
+            $response['addr_state'] = $user->addr_state;
+            $response['addr_zip'] = $user->addr_zip;
+        }
+
+        $response['country'] = $user->country;
+
+        // Signup source (e.g. drupal, cgg, mobile...)
+        $response['source'] = $user->source;
+
+        // References to app-specific user IDs.
+        $response['drupal_id'] = $user->drupal_id;
+        $response['cgg_id'] = $user->cgg_id;
+        $response['agg_id'] = $user->agg_id;
+
+        $response['parse_installation_ids'] = $user->parse_installation_ids;
+
+        $response['updated_at'] = $user->updated_at->toISO8601String();
+        $response['created_at'] = $user->created_at->toISO8601String();
+
+        return $response;
     }
 }

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -20,7 +20,7 @@ class ApiKey extends Model
      * @var array
      */
     protected $attributes = [
-        'scope' => ['user'],
+        'scope' => [],
     ];
 
     /**
@@ -65,18 +65,6 @@ class ApiKey extends Model
     public function setAppIdAttribute($app_id)
     {
         $this->attributes['app_id'] = snake_case(str_replace(' ', '', $app_id));
-    }
-
-    /**
-     * Getter for 'scope' field.
-     */
-    public function getScopeAttribute()
-    {
-        if (empty($this->attributes['scope'])) {
-            return ['user'];
-        }
-
-        return $this->attributes['scope'];
     }
 
     /**

--- a/database/seeds/ApiKeyTableSeeder.php
+++ b/database/seeds/ApiKeyTableSeeder.php
@@ -23,6 +23,7 @@ class ApiKeyTableSeeder extends Seeder
         ApiKey::create([
             'app_id' => '123',
             'api_key' => '5464utyrs',
+            'scope' => ['user'],
         ]);
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -43,12 +43,38 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test for retrieving a user
-     * GET /users
+     * Test for retrieving a user with a non-admin key.
+     * GET /users/:term/:id
      *
      * @return void
      */
-    public function testGetDataFromUser()
+    public function testGetPublicDataFromUser()
+    {
+        $response = $this->call('GET', 'v1/users/email/test@dosomething.org', [], [], [], $this->userScope);
+        $content = $response->getContent();
+
+        // The response should return a 200 OK status code
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Response should be valid JSON
+        $this->assertJson($content);
+        $json = json_decode($content);
+
+        // Check that public profile fields are visible...
+        $this->assertObjectHasAttribute('id', $json->data);
+        $this->assertObjectHasAttribute('email', $json->data);
+
+        // ...and private profile fields are hidden.
+        $this->assertObjectNotHasAttribute('last_name', $json->data);
+    }
+
+    /**
+     * Test for retrieving a user with an admin key.
+     * GET /users/:term/:id
+     *
+     * @return void
+     */
+    public function testGetAllDataFromUser()
     {
         $response = $this->call('GET', 'v1/users/email/test@dosomething.org', [], [], [], $this->server);
         $content = $response->getContent();
@@ -58,6 +84,12 @@ class UserTest extends TestCase
 
         // Response should be valid JSON
         $this->assertJson($content);
+        $json = json_decode($content);
+
+        // Check that public & private profile fields are visible
+        $this->assertObjectHasAttribute('id', $json->data);
+        $this->assertObjectHasAttribute('email', $json->data);
+        $this->assertObjectHasAttribute('last_name', $json->data);
     }
 
     /**


### PR DESCRIPTION
#### Changes
This pull request allows admin-scoped keys to view full user profile details. This allows tools like Aurora to access a user's full profile (including last name, address, etc.), while still keeping it under lock and key :closed_lock_with_key: for normal "public" API responses.

#### What about letting users see their own full profiles?
Yes! I've started on that work (which involves #108) but am going to put it up as its own branch later, so as not to make another monster PR. :japanese_ogre: 

#### How should this be tested?
Automated tests added in f71cbca should pass. :traffic_light: 

---
For review: @angaither 