### PR TITLE
Key scope should always return an array.

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -60,11 +60,25 @@ class ApiKey extends Model
     }
 
     /**
-     * Mutator for 'app_id' field.
+     * Mutator for 'app_id' attribute.
+     * @return string
      */
     public function setAppIdAttribute($app_id)
     {
         $this->attributes['app_id'] = snake_case(str_replace(' ', '', $app_id));
+    }
+
+    /**
+     * Mutator for 'scope' attribute.
+     * @return array
+     */
+    public function getScopeAttribute()
+    {
+        if (! isset($this->attributes['scope']) || ! is_array($this->attributes['scope'])) {
+            return [];
+        }
+
+        return $this->attributes['scope'];
     }
 
     /**


### PR DESCRIPTION
#### Changes

When I removed the "default" `user` value for scope, we started returning `null` for some key scopes that had been created before keys were given an empty array default value. This broke a couple of API keys, and the API key admin interface in Aurora.

---
For review: @angaither 