### PR TITLE
Use custom Guard for authentication.

### DIFF
--- a/app/Auth/DrupalPasswordHash.php
+++ b/app/Auth/DrupalPasswordHash.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Services;
+namespace Northstar\Auth;
 
 define('DRUPAL_MIN_HASH_COUNT', 7);
 define('DRUPAL_MAX_HASH_COUNT', 30);

--- a/app/Auth/NorthstarTokenGuard.php
+++ b/app/Auth/NorthstarTokenGuard.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Northstar\Auth;
+
+use Illuminate\Auth\TokenGuard;
+use Illuminate\Http\Request;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\UserProvider;
+use Mockery\CountValidator\Exception;
+use Northstar\Models\Token;
+use Northstar\Models\User;
+
+class NorthstarTokenGuard extends TokenGuard implements Guard
+{
+    /**
+     * Create a new authentication guard.
+     *
+     * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function __construct(UserProvider $provider, Request $request)
+    {
+        parent::__construct($provider, $request);
+
+        $this->inputKey = 'token';
+        $this->storageKey = 'key';
+    }
+
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function user()
+    {
+        // If we've already retrieved the user for the current request we can just
+        // return it back immediately. We do not want to fetch the user data on
+        // every call to this method because that would be tremendously slow.
+        if (! is_null($this->user)) {
+            return $this->user;
+        }
+
+        $user = null;
+
+        $token = $this->getTokenForRequest();
+
+        if (! empty($token)) {
+            $user = $this->getUserForToken($token);
+        }
+
+        return $this->user = $user;
+    }
+
+    /**
+     * Get the associated user for a given token string.
+     *
+     * @param string $tokenKey
+     * @return \Northstar\Models\User|null
+     */
+    public function getUserForToken($tokenKey)
+    {
+        $token = Token::where($this->storageKey, $tokenKey)->first();
+
+        if (empty($token)) {
+            return;
+        }
+
+        return User::find($token->user_id);
+    }
+
+    /**
+     * Get the token key for the current request.
+     *
+     * @return string
+     */
+    public function getTokenForRequest()
+    {
+        // Support deprecated "Session" header authentication.
+        $tokenKey = $this->request->header('Session');
+
+        if (! empty($tokenKey)) {
+            return $tokenKey;
+        }
+
+        return parent::getTokenForRequest();
+    }
+
+    /**
+     * Validate a user's credentials.
+     *
+     * @param  array  $credentials
+     * @return bool
+     */
+    public function validate(array $credentials = [])
+    {
+        if ($this->getUserForToken($credentials[$this->inputKey])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the Token instance for the current request.
+     *
+     * @return Token
+     */
+    public function token()
+    {
+        $tokenKey = $this->getTokenForRequest();
+
+        return Token::where($this->storageKey, $tokenKey)->first();
+    }
+
+    /**
+     * Log a user into the application without sessions or cookies.
+     *
+     * @throws Exception
+     */
+    public function once()
+    {
+        throw new Exception('Token-based authentication is stateless. Use Auth::check instead.');
+    }
+}

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Services;
+namespace Northstar\Auth;
 
 use Hash;
 use Northstar\Models\User;

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Northstar\Services\Registrar;
+use Auth;
 
 class AuthController extends Controller
 {
@@ -48,6 +49,7 @@ class AuthController extends Controller
 
     /**
      * Logout the current user by invalidating their session token.
+     * POST /logout
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
@@ -55,29 +57,26 @@ class AuthController extends Controller
      */
     public function logout(Request $request)
     {
-        if (! $request->header('Session')) {
-            throw new HttpException(422, 'No token given.');
+        $token = Auth::token();
+
+        if (! $token) {
+            throw new NotFoundHttpException('No active session found.');
         }
 
-        $input_token = $request->header('Session');
-        $token = Token::where('key', '=', $input_token)->first();
-        $user = Token::userFor($input_token);
-
-        if (empty($token)) {
-            throw new NotFoundHttpException('No active session found.');
-        } elseif ($token->user_id !== $user->_id) {
-            throw new HttpException(403, 'You do not own this token.');
-        } elseif ($token->delete()) {
-            // Remove Parse installation ID. Disables push notifications.
-            if ($request->has('parse_installation_ids')) {
-                $removeId = $request->parse_installation_ids;
-                $user->pull('parse_installation_ids', $removeId);
-                $user->save();
-            }
-
-            return $this->respond('User logged out successfully.');
-        } else {
+        // Attempt to delete token.
+        $deleted = $token->delete();
+        if (! $deleted) {
             throw new HttpException(400, 'User could not log out. Please try again.');
         }
+
+        // Remove Parse installation ID. Disables push notifications.
+        $user = $token->user;
+        if ($user && $request->has('parse_installation_ids')) {
+            $removeIds = $request->input('parse_installation_ids');
+            $user->pull('parse_installation_ids', $removeIds);
+            $user->save();
+        }
+
+        return $this->respond('User logged out successfully.');
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Http\Controllers;
 
-use Northstar\Models\Token;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Northstar\Services\Registrar;
+use Northstar\Auth\Registrar;
 use Auth;
 
 class AuthController extends Controller

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -3,6 +3,7 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Northstar\Events\UserSignedUp;
 use Northstar\Events\UserReportedBack;
 use Northstar\Http\Transformers\CampaignTransformer;
@@ -81,7 +82,7 @@ class CampaignController extends Controller
      */
     public function show($campaign_id)
     {
-        $user = User::current();
+        $user = Auth::user();
 
         $campaign = $user->campaigns()->where('drupal_id', $campaign_id)->first();
 
@@ -118,7 +119,7 @@ class CampaignController extends Controller
         ]);
 
         // Get the currently authenticated Northstar user.
-        $user = User::current();
+        $user = Auth::user();
 
         // Return an error if the user doesn't exist.
         if (! $user->drupal_id) {
@@ -174,7 +175,7 @@ class CampaignController extends Controller
         ]);
 
         // Get the currently authenticated Northstar user.
-        $user = User::current();
+        $user = Auth::user();
 
         // Return an error if the user doesn't exist.
         if (! $user->drupal_id) {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Http\Controllers;
 
+use Illuminate\Http\Request;
 use League\Fractal\Manager;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use League\Fractal\Resource\Collection as FractalCollection;
@@ -11,16 +12,12 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Database\Eloquent;
-use Illuminate\Http\Request;
 use Northstar\Models\ApiKey;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 abstract class Controller extends BaseController
 {
-    use DispatchesJobs;
-
-    use ValidatesRequests {
-        buildFailedValidationResponse as traitBuildFailedValidationResponse;
-    }
+    use DispatchesJobs, ValidatesRequests;
 
     /**
      * @var \League\Fractal\TransformerAbstract
@@ -202,14 +199,21 @@ abstract class Controller extends BaseController
     }
 
     /**
-     * Create the response for when a request fails validation. Overrides the ValidatesRequests trait.
+     * Create the response for when a request fails validation. Overrides the
+     * `buildFailedValidationResponse` method from the `ValidatesRequests` trait.
      *
-     * @param Request $request
-     * @param array $errors
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $errors
      * @return \Illuminate\Http\Response
      */
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {
-        return $this->traitBuildFailedValidationResponse($request, $errors);
+        $response = [
+            'code' => 422,
+            'message' => 'Failed validation.',
+            'errors' => $errors,
+        ];
+
+        return new JsonResponse($response, 422);
     }
 }

--- a/app/Http/Controllers/KudosController.php
+++ b/app/Http/Controllers/KudosController.php
@@ -30,11 +30,11 @@ class KudosController extends Controller
      * POST /kudos
      *
      * @param Request $request
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
-        $user = User::current();
+        $user = Auth::user();
 
         $drupal_id = $user->drupal_id;
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -212,28 +212,4 @@ class UserController extends Controller
             throw new NotFoundHttpException('The resource does not exist.');
         }
     }
-
-    /**
-     * Create the response for when a request fails validation. Overrides the ValidatesRequests trait.
-     *
-     * @param Request $request
-     * @param array $errors
-     * @return \Illuminate\Http\Response
-     * @throws UnauthorizedHttpException
-     */
-    protected function buildFailedValidationResponse(Request $request, array $errors)
-    {
-        $error_message = '';
-        if (count($errors) > 0) {
-            foreach ($errors as $e) {
-                foreach ($e as $message) {
-                    $error_message .= $message.' ';
-                }
-            }
-
-            throw new UnauthorizedHttpException(null, trim($error_message));
-        } else {
-            return parent::buildFailedValidationResponse($request, $errors);
-        }
-    }
 }

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -2,9 +2,9 @@
 
 namespace Northstar\Http\Transformers;
 
-use Northstar\Models\ApiKey;
 use Northstar\Models\User;
 use League\Fractal\TransformerAbstract;
+use Gate;
 
 class UserTransformer extends TransformerAbstract
 {
@@ -23,7 +23,7 @@ class UserTransformer extends TransformerAbstract
             'first_name' => $user->first_name,
         ];
 
-        if (ApiKey::current()->hasScope('admin')) {
+        if (Gate::allows('viewFullProfile', $user)) {
             $response['last_name'] = $user->last_name;
         }
 
@@ -32,7 +32,7 @@ class UserTransformer extends TransformerAbstract
         $response['photo'] = $user->photo;
         $response['interests'] = $user->interests;
 
-        if (ApiKey::current()->hasScope('admin')) {
+        if (Gate::allows('viewFullProfile', $user)) {
             $response['birthdate'] = $user->birthdate;
             $response['race'] = $user->race;
             $response['religion'] = $user->religion;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Http\Transformers;
 
+use Northstar\Models\ApiKey;
 use Northstar\Models\User;
 use League\Fractal\TransformerAbstract;
 use Gate;
@@ -23,7 +24,7 @@ class UserTransformer extends TransformerAbstract
             'first_name' => $user->first_name,
         ];
 
-        if (Gate::allows('view-full-profile', $user)) {
+        if (ApiKey::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['last_name'] = $user->last_name;
         }
 
@@ -32,7 +33,7 @@ class UserTransformer extends TransformerAbstract
         $response['photo'] = $user->photo;
         $response['interests'] = $user->interests;
 
-        if (Gate::allows('view-full-profile', $user)) {
+        if (ApiKey::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['birthdate'] = $user->birthdate;
             $response['race'] = $user->race;
             $response['religion'] = $user->religion;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -23,7 +23,7 @@ class UserTransformer extends TransformerAbstract
             'first_name' => $user->first_name,
         ];
 
-        if (Gate::allows('viewFullProfile', $user)) {
+        if (Gate::allows('view-full-profile', $user)) {
             $response['last_name'] = $user->last_name;
         }
 
@@ -32,7 +32,7 @@ class UserTransformer extends TransformerAbstract
         $response['photo'] = $user->photo;
         $response['interests'] = $user->interests;
 
-        if (Gate::allows('viewFullProfile', $user)) {
+        if (Gate::allows('view-full-profile', $user)) {
             $response['birthdate'] = $user->birthdate;
             $response['race'] = $user->race;
             $response['religion'] = $user->religion;

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -131,16 +131,28 @@ class ApiKey extends Model
     }
 
     /**
-     * Throw an exception if a properly scoped API key is not
-     * provided with the current request.
+     * Return whether a properly scoped API key is provided
+     * with the current request.
      *
-     * @param $scope
+     * @param $scope - Required scope
+     * @return bool
      */
-    public static function gate($scope)
+    public static function allows($scope)
     {
         $key = self::current();
 
-        if (! $key || ! $key->hasScope($scope)) {
+        return $key && $key->hasScope($scope);
+    }
+
+    /**
+     * Throw an exception if a properly scoped API key is not
+     * provided with the current request.
+     *
+     * @param $scope - Required scope
+     */
+    public static function gate($scope)
+    {
+        if (! static::allows($scope)) {
             throw new AccessDeniedHttpException('You must be using an API key with "'.$scope.'" scope to do that.');
         }
     }

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -55,33 +55,9 @@ class Token extends Model
         return base64_encode($key);
     }
 
-    /**
-     * Create a new token. DEPRECATED: Use standard class
-     * constructor instead.
-     *
-     * @return Token
-     * @deprecated
-     */
-    public static function getInstance()
+    public function user()
     {
-        $token = new self();
-
-        return $token;
-    }
-
-    /**
-     * Get the user associated with a given token key.
-     * @param int $token - Token key
-     * @return User|null
-     */
-    public static function userFor($token)
-    {
-        $token = self::where('key', '=', $token)->first();
-        if (empty($token)) {
-            return;
-        }
-
-        return User::find($token->user_id);
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,16 +2,16 @@
 
 namespace Northstar\Models;
 
+use Illuminate\Foundation\Auth\Access\Authorizable;
 use Jenssegers\Mongodb\Model;
 use Illuminate\Auth\Authenticatable;
-use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
-use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Hash;
 
-class User extends Model implements AuthenticatableContract, CanResetPasswordContract
+class User extends Model implements AuthenticatableContract, AuthorizableContract
 {
-    use Authenticatable, CanResetPassword;
+    use Authenticatable, Authorizable;
 
     /**
      * Indicates if the IDs are auto-incrementing.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -153,24 +153,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      */
     public function login()
     {
-        $token = Token::getInstance();
+        $token = new Token();
         $token->user_id = $this->_id;
         $token->save();
 
         return $token;
-    }
-
-    /**
-     * Get the currently authenticated user from the session token.
-     *
-     * @return User
-     */
-    public static function current()
-    {
-        $token = request()->header('Session');
-        $user = Token::userFor($token);
-
-        return $user;
     }
 
     /**

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Northstar\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Northstar\Models\ApiKey;
+use Northstar\Models\User;
+
+class UserPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * If current request is made with an admin-scoped API key,
+     * grant "superuser" privileges.
+     * @return bool
+     */
+    public function before()
+    {
+        $token = ApiKey::current();
+        if ($token && $token->hasScope('admin')) {
+            return true;
+        }
+    }
+
+    /**
+     * Determine if the authorized user can see full profile details
+     * for the given user account.
+     *
+     * @param User $user
+     * @param User $profile
+     * @return bool
+     */
+    public function viewFullProfile(User $user, User $profile)
+    {
+        return $user->id === $profile->id;
+    }
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,25 +3,11 @@
 namespace Northstar\Policies;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Northstar\Models\ApiKey;
 use Northstar\Models\User;
 
 class UserPolicy
 {
     use HandlesAuthorization;
-
-    /**
-     * If current request is made with an admin-scoped API key,
-     * grant "superuser" privileges.
-     * @return bool
-     */
-    public function before()
-    {
-        $token = ApiKey::current();
-        if ($token && $token->hasScope('admin')) {
-            return true;
-        }
-    }
 
     /**
      * Determine if the authorized user can see full profile details

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,8 @@ namespace Northstar\Providers;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Northstar\Auth\NorthstarTokenGuard;
+use Northstar\Models\User;
+use Northstar\Policies\UserPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -14,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // ...
+        User::class => UserPolicy::class,
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,7 @@ namespace Northstar\Providers;
 
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Northstar\Auth\NorthstarTokenGuard;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -24,6 +25,17 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(GateContract $gate)
     {
+        /**
+         * The authentication manager.
+         * @var \Illuminate\Auth\AuthManager $auth
+         */
+        $auth = $this->app['auth'];
+
+        // Register our custom token Guard implementation
+        $auth->extend('northstar-token', function ($app, $name, array $config) use ($auth) {
+            return new NorthstarTokenGuard($auth->createUserProvider($config['provider']), request());
+        });
+
         parent::registerPolicies($gate);
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -14,7 +14,7 @@ return [
     */
 
     'defaults' => [
-        'guard' => 'web',
+        'guard' => 'api',
         'passwords' => 'users',
     ],
 
@@ -36,13 +36,8 @@ return [
     */
 
     'guards' => [
-        'web' => [
-            'driver' => 'session',
-            'provider' => 'users',
-        ],
-
         'api' => [
-            'driver' => 'token',
+            'driver' => 'northstar-token',
             'provider' => 'users',
         ],
     ],


### PR DESCRIPTION
### Changes

##### Custom Guard & Token Authentication
By registering a [custom guard](https://laravel.com/docs/5.2/authentication#adding-custom-guards) that understands how our `tokens` collection is structured, we can use Laravel’s built-in Auth facade (and Gate, etc.) to manage user sessions and permissions. (56cb07d)

There are no "user-facing" behavior changes to token authentication in this pull request, although it _does_ introduce two alternative ways to provide a User's session token. I'd like to remove support for the `Session` header in the future (since the API is stateless and so calling it a session is a bit of a misnomer).

```sh
# quick n' easy (as a query string)
GET /v1/users?token=xxxxxxx

# preferred (Authorization header)
GET /v1/users
Authorization: Bearer xxxxxxx

# legacy (as Session header)
GET /v1/users
Session: xxxxxxx
```

Closes #108.

##### Authorization
Now that we're using Laravel's built-in authentication code, we can also take advantage of Laravel 5.2's excellent [new authorization tools](https://laravel.com/docs/5.2/authorization)! We use the `Gate` facade (and an associated policy class) to determine whether to show full profile details for any given user. (bc0afa9)

This doesn't break any existing behavior, but will provide additional fields when querying the current user's profile data from the mobile app (or other non-privileged clients).

### Where should the reviewer start?
I'd recommend reviewing commit-by-commit.

### How should this be tested?
Automated tests should all pass! :traffic_light: 

---
For review: @angaither @weerd
/cc @jonuy @aaronschachter 