### PR TITLE
Unique random keys

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Http\Middleware;
 
+use Auth;
 use Northstar\Models\Token;
 use Closure;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -18,13 +19,8 @@ class Authenticate
      */
     public function handle($request, Closure $next)
     {
-        $token = $request->header('Session');
-        if (! $token) {
-            throw new HttpException(401, 'No token found.');
-        }
-
-        if (! Token::where('key', $token)->exists()) {
-            throw new HttpException(401, 'Token mismatched.');
+        if (! Auth::check()) {
+            throw new HttpException(401, 'Authentication token mismatched.');
         }
 
         return $next($request);

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -67,20 +67,6 @@ class ApiKey extends Model
     }
 
     /**
-     * Generate a secure, unique API key.
-     *
-     * @return string
-     */
-    public function generateAPIKey()
-    {
-        do {
-            $api_key = Str::random(40);
-        } while(static::where('api_key', $api_key)->exists());
-
-        return $api_key;
-    }
-
-    /**
      * Mutator for 'app_id' attribute.
      * @return string
      */
@@ -145,10 +131,9 @@ class ApiKey extends Model
      */
     public static function current()
     {
-        $app_id = request()->header('X-DS-Application-Id');
         $api_key = request()->header('X-DS-REST-API-Key');
 
-        return static::where('app_id', $app_id)->where('api_key', $api_key)->first();
+        return static::where('api_key', $api_key)->first();
     }
 
     /**

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Models;
 
+use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Model;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -54,9 +55,29 @@ class ApiKey extends Model
 
         // Automatically set random API key. This field *may* be manually
         // set when seeding the database, so we first check if empty.
-        if (empty($this->api_key)) {
-            $this->api_key = str_random(40);
-        }
+        static::creating(function (ApiKey $key) {
+            if (empty($key->api_key)) {
+                do {
+                    $key = Str::random(32);
+                } while(static::where('api_key', $key)->exists());
+
+                $key->api_key = $key;
+            }
+        });
+    }
+
+    /**
+     * Generate a secure, unique API key.
+     *
+     * @return string
+     */
+    public function generateAPIKey()
+    {
+        do {
+            $api_key = Str::random(40);
+        } while(static::where('api_key', $api_key)->exists());
+
+        return $api_key;
     }
 
     /**

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -59,7 +59,7 @@ class ApiKey extends Model
             if (empty($key->api_key)) {
                 do {
                     $key = Str::random(32);
-                } while(static::where('api_key', $key)->exists());
+                } while (static::where('api_key', $key)->exists());
 
                 $key->api_key = $key;
             }

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -37,7 +37,7 @@ class Token extends Model
             if (empty($token->key)) {
                 do {
                     $key = Str::random(32);
-                } while(static::where('key', $key)->exists());
+                } while (static::where('key', $key)->exists());
 
                 $token->key = $key;
             }


### PR DESCRIPTION
### Changes
Three changes, none of which are breaking!

##### Ensure API keys & Tokens are unique
We used to have a _small_ chance of key collisions (and also used two different methods for generating keys, whaaaa) – this PR standardizes to use Laravel's battle-tested `Str::random` and ensures the key is unique before saving.

##### Deprecates `X-DS-Application-Id` header
API keys are 40 characters long, so I don't think an extra (relatively easily guessable) 5-10 characters increases our security too much. No changes are needed, but this header will just be silently ignored from now on.

##### Use Auth facade for Authentication middleware
I forgot to update the `auth` middleware when making updates in #265, so it was not using the same logic to get the key from the request. This removes hardcoded references to the `Session` header. (Although it will still continue to function identically, if set!)

---

For review: @angaither @weerd 
/cc @aaronschachter @jonuy 