### PR TITLE
Auth and users and profiles oh my

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -3,51 +3,159 @@
 namespace Northstar\Auth;
 
 use Hash;
+use Illuminate\Contracts\Auth\Guard;
+use Northstar\Models\Token;
 use Northstar\Models\User;
+use Northstar\Services\Phoenix;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Registrar
 {
-    public function login($input)
+    /**
+     * @var Guard
+     */
+    protected $guard;
+
+    /**
+     * @var Phoenix
+     */
+    protected $phoenix;
+
+    /**
+     * Registrar constructor.
+     * @param Guard $guard
+     * @param Phoenix $phoenix
+     */
+    public function __construct(Guard $guard, Phoenix $phoenix)
     {
-        $login_type = 'username';
-        if ($input['email']) {
-            $email = strtolower($input['email']);
-            $user = User::where('email', '=', $email)->first();
-            $login_type = 'email';
-        } elseif ($input['mobile']) {
-            $user = User::where('mobile', '=', $input['mobile'])->first();
-            $login_type = 'mobile';
+        $this->guard = $guard;
+        $this->phoenix = $phoenix;
+    }
+
+    /**
+     * Authenticate a user based on the given credentials,
+     * and create a new session token.
+     *
+     * @param array $credentials
+     * @return mixed
+     */
+    public function login($credentials)
+    {
+        $user = $this->resolve($credentials);
+
+        if(! $this->verify($user, $credentials)) {
+            throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 
-        if (($user instanceof User) && Hash::check($input['password'], $user->password)) {
-            $token = $user->login();
-            $token->user = $user->toArray();
+        return $this->createToken($user);
+    }
 
-            // Return the session token with the user.
-            $user->session_token = $token->key;
+    /**
+     * Resolve a user account from the given credentials.
+     *
+     * @param array $credentials
+     * @return User|null
+     */
+    public function resolve($credentials)
+    {
+        if ($credentials['email']) {
+            $email = strtolower($credentials['email']);
+            return User::where('email', $email)->first();
+        }
 
-            return $user;
-        } elseif (($user instanceof User) && ! ($user->password)) {
+        if ($credentials['mobile']) {
+            return User::where('mobile', $credentials['mobile'])->first();
+        }
 
-            // check to see if $input['password'] equals user's drupal password
-            if (DrupalPasswordHash::check($input['password'], $user->drupal_password)) {
+        return null;
+    }
 
-                // if they're the same, make $input['password'] into a hash and save it to the user.
-                $user->password = $input['password'];
-                $user->unset('drupal_password');
-                $user->save();
+    /**
+     * Verify the given user and credentials. If the user has a Drupal
+     * password & it matches, re-hash and save to the user document.
+     *
+     * @param User $user
+     * @param array $credentials
+     * @return bool
+     */
+    public function verify($user, $credentials)
+    {
+        if(!$user) return false;
 
-                $token = $user->login();
-                $token->user = $user->toArray();
+        if (Hash::check($credentials['password'], $user->password)) {
+            return true;
+        }
 
-                // Return the session token with the user.
-                $user->session_token = $token->key;
+        if (! $user->password && DrupalPasswordHash::check($credentials['password'], $user->drupal_password)) {
+            // If this user has a Drupal-hashed password, rehash it, remove the
+            // Drupal password field from the user document, and save the user.
+            $user->password = $credentials['password'];
+            $user->unset('drupal_password');
+            $user->save();
 
-                return $user;
+            return true;
+        }
+
+        // Well, looks like we couldn't authenticate...
+        return false;
+    }
+
+    /**
+     * Create a new authentication token & set the active user.
+     *
+     * @param User $user
+     * @return Token
+     */
+    public function createToken($user)
+    {
+        $token = $user->login();
+
+        $this->guard->setUser($user);
+
+        return $token;
+    }
+
+    /**
+     * Create a new user.
+     *
+     * @return User|null
+     */
+    public function register($input, $user = null)
+    {
+        // If there is no user provided, create a new one.
+        if (! $user) {
+            $user = new User;
+        }
+
+        $user->fill($input);
+        $user->save();
+
+        return $user;
+    }
+
+    /**
+     * @param $user
+     * @param $password
+     * @return mixed
+     */
+    public function createDrupalUser($user, $password)
+    {
+        // @TODO: we can't create a Drupal user without an email. Do we just create an @mobile one like we had done previously?
+        try {
+            $drupal_id = $this->phoenix->register($user, $password);
+            $user->drupal_id = $drupal_id;
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            // If user already exists (403 Forbidden), try to find the user to get the UID.
+            if ($e->getCode() == 403) {
+                try {
+                    $drupal_id = $this->phoenix->getUidByEmail($user->email);
+                    $user->drupal_id = $drupal_id;
+                } catch (\Exception $e) {
+                    // @TODO: still ok to just continue and allow the user to be saved?
+                }
             }
         }
 
-        throw new UnauthorizedHttpException(null, 'Invalid '.$login_type.' or password.');
+        return $user;
     }
 }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -119,6 +119,8 @@ class Registrar
     /**
      * Create a new user.
      *
+     * @param array $input - Profile fields
+     * @param User $user - Optionally, user to update
      * @return User|null
      */
     public function register($input, $user = null)
@@ -135,8 +137,10 @@ class Registrar
     }
 
     /**
-     * @param $user
-     * @param $password
+     * Attempt to create a Drupal user for the given account.
+     *
+     * @param User $user
+     * @param string $password
      * @return mixed
      */
     public function createDrupalUser($user, $password)

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -43,7 +43,7 @@ class Registrar
     {
         $user = $this->resolve($credentials);
 
-        if(! $this->verify($user, $credentials)) {
+        if (! $this->verify($user, $credentials)) {
             throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 
@@ -60,14 +60,13 @@ class Registrar
     {
         if ($credentials['email']) {
             $email = strtolower($credentials['email']);
+
             return User::where('email', $email)->first();
         }
 
         if ($credentials['mobile']) {
             return User::where('mobile', $credentials['mobile'])->first();
         }
-
-        return null;
     }
 
     /**
@@ -80,7 +79,9 @@ class Registrar
      */
     public function verify($user, $credentials)
     {
-        if(!$user) return false;
+        if (! $user) {
+            return false;
+        }
 
         if (Hash::check($credentials['password'], $user->password)) {
             return true;

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -122,6 +122,7 @@ class AuthController extends Controller
         $this->validate($request, [
             'email' => 'email|max:60|unique:users|required_without:mobile',
             'mobile' => 'unique:users|required_without:email',
+            'password' => 'required',
         ]);
 
         $user = $this->registrar->register($request->all());

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -53,6 +53,29 @@ class AuthController extends Controller
         $token = $this->registrar->login($credentials);
 
         return $this->item($token);
+    /**
+     * Verify user credentials without making a session.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     * @throws UnauthorizedHttpException
+     */
+    public function verify(Request $request)
+    {
+        $this->validate($request, [
+            'email' => 'email|required_without:mobile',
+            'mobile' => 'required_without:email',
+            'password' => 'required',
+        ]);
+
+        $credentials = $request->only('email', 'mobile', 'password');
+        $user = $this->registrar->resolve($credentials);
+
+        if(! $this->registrar->verify($user, $credentials)) {
+            throw new UnauthorizedHttpException(null, 'Invalid credentials.');
+        }
+
+        return $this->item($user, 200, [], new UserTransformer());
     }
 
     /**

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -74,7 +74,7 @@ class AuthController extends Controller
         $credentials = $request->only('email', 'mobile', 'password');
         $user = $this->registrar->resolve($credentials);
 
-        if(! $this->registrar->verify($user, $credentials)) {
+        if (! $this->registrar->verify($user, $credentials)) {
             throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -30,18 +30,19 @@ class AuthController extends Controller
         $this->transformer = new TokenTransformer();
 
         $this->middleware('key:user');
-        $this->middleware('auth', ['only' => 'logout']);
-        $this->middleware('guest', ['except' => 'logout']);
+        $this->middleware('auth', ['only' => 'invalidateToken']);
+        $this->middleware('guest', ['except' => 'invalidateToken']);
     }
 
     /**
-     * Authenticate a registered user
+     * Authenticate a registered user based on the given credentials,
+     * and return an authentication token.
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
      * @throws UnauthorizedHttpException
      */
-    public function login(Request $request)
+    public function createToken(Request $request)
     {
         $this->validate($request, [
             'email' => 'email|required_without:mobile',
@@ -52,7 +53,9 @@ class AuthController extends Controller
         $credentials = $request->only('email', 'mobile', 'password');
         $token = $this->registrar->login($credentials);
 
-        return $this->item($token);
+        return $this->item($token, 201);
+    }
+
     /**
      * Verify user credentials without making a session.
      *
@@ -86,7 +89,7 @@ class AuthController extends Controller
      * @return \Illuminate\Http\Response
      * @throws HttpException
      */
-    public function logout(Request $request)
+    public function invalidateToken(Request $request)
     {
         $token = Auth::token();
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,8 +3,9 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Northstar\Http\Transformers\TokenTransformer;
+use Northstar\Http\Transformers\UserTransformer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Northstar\Auth\Registrar;
 use Auth;
@@ -17,12 +18,20 @@ class AuthController extends Controller
      */
     protected $registrar;
 
+    /**
+     * @var TokenTransformer
+     */
+    protected $transformer;
+
     public function __construct(Registrar $registrar)
     {
         $this->registrar = $registrar;
 
+        $this->transformer = new TokenTransformer();
+
         $this->middleware('key:user');
         $this->middleware('auth', ['only' => 'logout']);
+        $this->middleware('guest', ['except' => 'logout']);
     }
 
     /**
@@ -34,16 +43,16 @@ class AuthController extends Controller
      */
     public function login(Request $request)
     {
-        $input = $request->only('email', 'mobile', 'password');
-
         $this->validate($request, [
-            'email' => 'email',
+            'email' => 'email|required_without:mobile',
+            'mobile' => 'required_without:email',
             'password' => 'required',
         ]);
 
-        $user = $this->registrar->login($input);
+        $credentials = $request->only('email', 'mobile', 'password');
+        $token = $this->registrar->login($credentials);
 
-        return $this->respond($user);
+        return $this->item($token);
     }
 
     /**
@@ -57,10 +66,6 @@ class AuthController extends Controller
     public function logout(Request $request)
     {
         $token = Auth::token();
-
-        if (! $token) {
-            throw new NotFoundHttpException('No active session found.');
-        }
 
         // Attempt to delete token.
         $deleted = $token->delete();
@@ -77,5 +82,32 @@ class AuthController extends Controller
         }
 
         return $this->respond('User logged out successfully.');
+    }
+
+    /**
+     * Authenticate a registered user
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     * @throws UnauthorizedHttpException
+     */
+    public function register(Request $request)
+    {
+        $this->validate($request, [
+            'email' => 'email|max:60|unique:users|required_without:mobile',
+            'mobile' => 'unique:users|required_without:email',
+        ]);
+
+        $user = $this->registrar->register($request->all());
+
+        // Should we try to make a Drupal account for this user?
+        if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {
+            $user = $this->registrar->createDrupalUser($user, $request->input('password'));
+            $user->save();
+        }
+
+        $token = $this->registrar->createToken($user);
+
+        return $this->item($token);
     }
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -3,7 +3,6 @@
 namespace Northstar\Http\Controllers;
 
 use Auth;
-use Illuminate\Contracts\Auth\Guard;
 use Northstar\Http\Transformers\UserTransformer;
 use Illuminate\Http\Request;
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+use Auth;
+use Illuminate\Contracts\Auth\Guard;
+use Northstar\Http\Transformers\UserTransformer;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    /**
+     * @var UserTransformer
+     */
+    protected $transformer;
+
+    public function __construct()
+    {
+        $this->transformer = new UserTransformer();
+
+        $this->middleware('key:user');
+        $this->middleware('auth');
+    }
+
+    /**
+     * Display the current user's profile.
+     * GET /profile
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function show()
+    {
+        // Find the user.
+        $user = Auth::user();
+
+        return $this->item($user);
+    }
+
+    /**
+     * Update the currently authenticated user's profile.
+     * PUT /profile
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request)
+    {
+        $user = Auth::user();
+
+        $this->validate($request, [
+            'email' => 'email|max:60|unique:users,email,'.$user->id.',_id',
+            'mobile' => 'unique:users,mobile,'.$user->id.',_id',
+        ]);
+
+        $user->fill($request->all());
+        $user->save();
+
+        return $this->item($user);
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -141,7 +141,7 @@ class UserController extends Controller
     public function update($term, $id, Request $request)
     {
         $user = User::where($term, $id)->first();
-        if(!$user) {
+        if (! $user) {
             throw new NotFoundHttpException('The resource does not exist.');
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -183,6 +183,10 @@ class UserController extends Controller
                     $user->$key = $value;
                 }
             }
+        $this->validate($request, [
+            'email' => 'email|max:60|unique:users,email,'.$user->id.',_id',
+            'mobile' => 'unique:users,mobile,'.$user->id.',_id',
+        ]);
 
             $user->save();
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -12,7 +12,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        'Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode',
+        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
     ];
 
     /**
@@ -21,7 +21,8 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => 'Northstar\Http\Middleware\Authenticate',
-        'key' => 'Northstar\Http\Middleware\AuthenticateAPIKey',
+        'auth' => \Northstar\Http\Middleware\Authenticate::class,
+        'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
+        'key' => \Northstar\Http\Middleware\AuthenticateAPIKey::class,
     ];
 }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -6,7 +6,7 @@ use Auth;
 use Closure;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class Authenticate
+class RedirectIfAuthenticated
 {
     /**
      * Handle an incoming request.
@@ -18,8 +18,8 @@ class Authenticate
      */
     public function handle($request, Closure $next)
     {
-        if (! Auth::check()) {
-            throw new HttpException(401, 'Authentication token mismatched.');
+        if (Auth::check()) {
+            throw new HttpException(401, 'You cannot do this with an active authentication token.');
         }
 
         return $next($request);

--- a/app/Http/Transformers/TokenTransformer.php
+++ b/app/Http/Transformers/TokenTransformer.php
@@ -13,7 +13,7 @@ class TokenTransformer extends TransformerAbstract
      * @var array
      */
     protected $defaultIncludes = [
-        'user'
+        'user',
     ];
 
     /**
@@ -24,7 +24,7 @@ class TokenTransformer extends TransformerAbstract
     {
         return [
             'key' => $token->key,
-            'user' => $token->user()
+            'user' => $token->user(),
         ];
     }
 

--- a/app/Http/Transformers/TokenTransformer.php
+++ b/app/Http/Transformers/TokenTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Northstar\Http\Transformers;
+
+use League\Fractal\TransformerAbstract;
+use Northstar\Models\Token;
+
+class TokenTransformer extends TransformerAbstract
+{
+    /**
+     * List of resources to automatically include
+     *
+     * @var array
+     */
+    protected $defaultIncludes = [
+        'user'
+    ];
+
+    /**
+     * @param Token $token
+     * @return array
+     */
+    public function transform(Token $token)
+    {
+        return [
+            'key' => $token->key,
+            'user' => $token->user()
+        ];
+    }
+
+    /**
+     * Include the user which owns the given token.
+     *
+     * @param Token $token
+     * @return \League\Fractal\Resource\Item
+     */
+    public function includeUser(Token $token)
+    {
+        return $this->item($token->user, new UserTransformer);
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -18,6 +18,7 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
     $router->post('login', 'AuthController@login');
     $router->post('logout', 'AuthController@logout');
     $router->post('register', 'AuthController@register');
+    $router->post('auth/verify', 'AuthController@verify');
 
     // Users
     $router->resource('users', 'UserController', ['except' => ['show', 'update']]);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -14,9 +14,10 @@ $router->get('/', function () {
 
 // https://api.dosomething.org/v1/
 $router->group(['prefix' => 'v1'], function () use ($router) {
-    // Sessions.
+    // Authentication
     $router->post('login', 'AuthController@login');
     $router->post('logout', 'AuthController@logout');
+    $router->post('register', 'AuthController@register');
 
     // Users
     $router->resource('users', 'UserController', ['except' => ['show', 'update']]);
@@ -41,7 +42,7 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
     $router->resource('signup-group', 'SignupGroupController');
     $router->get('signup-group/{id}', 'SignupGroupController@show');
 
-    // Api Keys
+    // API Keys
     $router->resource('keys', 'KeyController');
     $router->get('scopes', function () {
         return \Northstar\Models\ApiKey::scopes();

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -25,11 +25,12 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
     $router->get('users/{term}/{id}', 'UserController@show');
     $router->put('users/{term}/{id}', 'UserController@update');
     $router->post('users/{id}/avatar', 'AvatarController@store');
-
-    // User campaign activity
     $router->get('users/{term}/{id}/campaigns', 'CampaignController@index');
 
-    // Campaigns
+    // Profile (the currently authenticated user)
+    $router->get('profile', 'ProfileController@show');
+    $router->post('profile', 'ProfileController@update');
+
     $router->get('user/campaigns/{campaign_id}', 'CampaignController@show');
     $router->post('user/campaigns/{campaign_id}/signup', 'CampaignController@signup');
     $router->post('user/campaigns/{campaign_id}/reportback', 'CampaignController@reportback');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -12,13 +12,13 @@ $router->get('/', function () {
     return redirect()->to('https://github.com/DoSomething/api');
 });
 
-// https://api.dosomething.org/v1/
+// https://northstar.dosomething.org/v1/
 $router->group(['prefix' => 'v1'], function () use ($router) {
     // Authentication
-    $router->post('login', 'AuthController@login');
-    $router->post('logout', 'AuthController@logout');
-    $router->post('register', 'AuthController@register');
+    $router->post('auth/token', 'AuthController@createToken');
+    $router->post('auth/invalidate', 'AuthController@invalidateToken');
     $router->post('auth/verify', 'AuthController@verify');
+    $router->post('auth/register', 'AuthController@register');
 
     // Users
     $router->resource('users', 'UserController', ['except' => ['show', 'update']]);

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -76,12 +76,12 @@ class AuthTest extends TestCase
             'password' => 'secret',
         ];
 
-        $response = $this->call('POST', 'v1/login', [], [], [], $this->server, json_encode($credentials));
+        $response = $this->call('POST', 'v1/auth/token', [], [], [], $this->server, json_encode($credentials));
         $content = $response->getContent();
         $data = json_decode($content, true);
 
-        // The response should return a 200 Created status code
-        $this->assertEquals(200, $response->getStatusCode());
+        // The response should return a 201 Created status code
+        $this->assertEquals(201, $response->getStatusCode());
 
         // Response should be valid JSON
         $this->assertJson($content);
@@ -130,7 +130,7 @@ class AuthTest extends TestCase
      */
     public function testLogout()
     {
-        $response = $this->call('POST', 'v1/logout', [], [], [], $this->loggedInServer);
+        $response = $this->call('POST', 'v1/auth/invalidate', [], [], [], $this->loggedInServer);
         $content = $response->getContent();
 
         // The response should return a 200 Created status code
@@ -153,7 +153,7 @@ class AuthTest extends TestCase
             'parse_installation_ids' => 'parse-abc123',
         ];
 
-        $logoutResponse = $this->call('POST', 'v1/logout', [], [], [], $this->serverForParseTest, json_encode($payload));
+        $logoutResponse = $this->call('POST', 'v1/auth/invalidate', [], [], [], $this->serverForParseTest, json_encode($payload));
 
         // The response should return a 200 Created status code
         $this->assertEquals(200, $logoutResponse->getStatusCode());
@@ -200,13 +200,13 @@ class AuthTest extends TestCase
             'password' => 'secret',
         ];
 
-        $response = $this->call('POST', 'v1/login', [], [], [], $this->serverDrupalPasswordChecker, json_encode($credentials));
+        $response = $this->call('POST', 'v1/auth/token', [], [], [], $this->serverDrupalPasswordChecker, json_encode($credentials));
         $content = $response->getContent();
         $data = json_decode($content, true);
         $user = User::find('5430e850dt8hbc541c37cal3');
 
-        // Assert response is 200 and has expected data
-        $this->assertEquals(200, $response->getStatusCode());
+        // Assert response is 201 Created and has expected data
+        $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals($credentials['email'], $data['data']['user']['data']['email']);
         $this->assertEquals(null, $user->drupal_password);
         $this->assertArrayHasKey('password', $user['attributes']);

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -97,6 +97,32 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test for logging in a user
+     * POST /login
+     *
+     * @return void
+     */
+    public function testVerify()
+    {
+        // User login info
+        $credentials = [
+            'email' => 'test@dosomething.org',
+            'password' => 'secret',
+        ];
+
+        $response = $this->call('POST', 'v1/auth/verify', [], [], [], $this->server, json_encode($credentials));
+        $content = $response->getContent();
+        $data = json_decode($content, true);
+
+        // The response should return a 200 Okay status code
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Response should be valid JSON, & include user data
+        $this->assertJson($content);
+        $this->assertArrayHasKey('_id', $data['data']);
+    }
+
+    /**
      * Test for logging out a user
      * POST /logout
      *

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -279,8 +279,8 @@ class UserTest extends TestCase
         $content = $response->getContent();
         $data = json_decode($content, true);
 
-        // The response should return a 202 Accepted status code
-        $this->assertEquals(202, $response->getStatusCode());
+        // The response should return a 200 status code
+        $this->assertEquals(200, $response->getStatusCode());
 
         // Response should be valid JSON
         $this->assertJson($content);


### PR DESCRIPTION
## Changes

#### Updates authentication endpoints
This PR includes some changes to authentication endpoints, aimed at simplifying "permission" logic and separating the use cases for user-facing tokens and internal service "administrative" tasks.

:warning: __Breaking Change:__ Login requests should now post to `auth/token`, and will return Tokens (with a nested user object), rather than a "hacked" user object. The associated user will be given under a `user` property in the JSON response.

In addition to being more "true" to the real underlying process (users don't have a `session_token` property in the database), this also allows us to use our transformer classes so the user response will be consistent with that given elsewhere.

:warning: __Breaking Change:__ Logout requests should now post to `auth/invalidate` (but otherwise are functionally identical to the old `/logout`).

:white_check_mark: __New Feature:__ The `auth/verify` endpoint lets us verify user credentials without creating a new user authentication token. This will be useful for testing credentials when users log into Phoenix (without creating bajillions of unused tokens). References DoSomething/phoenix#4526.

:warning: __Breaking Change:__ Users should now be registered via `POST auth/register`. In contrast to the `POST /users` endpoint, this _requires_ a password & will create and return an authentication token as well.

There are also some nice behind-the-scenes changes in this PR: authentication "methods" are now shared within the `Registrar` class, which helps clean up shared registration behaviors that occur conditionally in multiple places.

#### Updates user endpoints
:warning: __Breaking Change:__ User modification endpoints (`POST /users`, `PUT /users/:term/:id`, and `DELETE /users/:id`) are now _only_ accessible to admin-scoped keys. Because of this, they no longer require a user's password to change their profile!

 This lets us differentiate "user-facing" endpoints from internal endpoints (e.g. forwarding a user from CGG or Message Broker) which should neither require a password or create a new session. This also means that admin-scoped keys will no longer require a password to change user records! Closes #238. Closes #94.

:white_check_mark: __New Feature:__ The `POST /profile` endpoint allows user-scoped keys to update the currently authenticated user's profile. `GET /profile` is a convenient shortcut for getting the currently authenticated user's profile, and is equivalent to `GET /users/_id/:id`.

:hammer: __Bug Fix:__ User profiles can no longer be modified so that they contain duplicate emails or mobile numbers. Input validation, yeah! Fixes #131.

## Where should the reviewer start?
I would recommend looking at things commit-by-commit, as usual. It might also be helpful to look at the before and after for the `Registrar` ([before](https://github.com/DoSomething/northstar/blob/aaf40d5024250b076c78374e5daf287c8d4f57c5/app/Auth/Registrar.php), [after](https://github.com/DFurnes/northstar/blob/74e46152fa507f34ab25d9579af54b5ea488f682/app/Auth/Registrar.php)), `AuthController` ([before](https://github.com/DoSomething/northstar/blob/aaf40d5024250b076c78374e5daf287c8d4f57c5/app/Http/Controllers/AuthController.php), [after](https://github.com/DFurnes/northstar/blob/74e46152fa507f34ab25d9579af54b5ea488f682/app/Http/Controllers/AuthController.php)) and `UserController` ([before](https://github.com/DoSomething/northstar/blob/aaf40d5024250b076c78374e5daf287c8d4f57c5/app/Http/Controllers/UserController.php), [after](https://github.com/DFurnes/northstar/blob/74e46152fa507f34ab25d9579af54b5ea488f682/app/Http/Controllers/UserController.php)).

Sorry, I know this is a huge PR but it didn't seem to make sense to do piecemeal. :grimacing: 

## How should this be tested?
Automated tests should continue to pass. :traffic_light: I'll add tests for the profile endpoints and admin key restriction on the user-modifying endpoints in just a bit!

I'll also update documentation once this merges! :memo: 

---
For review: @angaither or @weerd 
/cc @aaronschachter @jonuy 