### PR TITLE
Fixes fatal error on creating new API keys.

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -55,13 +55,13 @@ class ApiKey extends Model
 
         // Automatically set random API key. This field *may* be manually
         // set when seeding the database, so we first check if empty.
-        static::creating(function (ApiKey $key) {
-            if (empty($key->api_key)) {
+        static::creating(function (ApiKey $apiKey) {
+            if (empty($apiKey->api_key)) {
                 do {
                     $key = Str::random(32);
                 } while (static::where('api_key', $key)->exists());
 
-                $key->api_key = $key;
+                $apiKey->api_key = $key;
             }
         });
     }

--- a/tests/ApiKeyTest.php
+++ b/tests/ApiKeyTest.php
@@ -50,6 +50,30 @@ class ApiKeyTest extends TestCase
     }
 
     /**
+     * Test authentication & functionality of key creation endpoint.
+     * @test
+     */
+    public function testStore()
+    {
+        $attributes = [
+            'app_id' => 'dog',
+        ];
+
+        // Verify a "user" scoped key is not able to create new keys
+        $response = $this->call('POST', 'v1/keys', [], [], [], $this->userScope, json_encode($attributes));
+        $this->assertEquals(403, $response->getStatusCode());
+
+        // Verify an admin key is able to create a new key
+        $response = $this->call('POST', 'v1/keys', [], [], [], $this->adminScope, json_encode($attributes));
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $data = json_decode($response->getContent())->data;
+        $this->assertObjectHasAttribute('app_id', $data);
+        $this->assertObjectHasAttribute('api_key', $data);
+        $this->assertObjectHasAttribute('scope', $data);
+    }
+
+    /**
      * Test authentication & functionality of key details endpoint.
      * @test
      */


### PR DESCRIPTION
#### Changes
Quick bug fix. I cleverly named two variables `$key` and expected Laravel to figure it out.

#### How should this be tested?
I added a test for this endpoint (which fails before applying the fix, and is green now). :traffic_light: 

---

For review: @angaither or @weerd 

