### PR TITLE
Query string kaboom

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -40,7 +40,7 @@ class SignupController extends Controller
      */
     public function index(Request $request)
     {
-        return $this->phoenix->getSignupIndex($request->getQueryString());
+        return $this->phoenix->getSignupIndex($request->query());
     }
 
     /**

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -159,10 +159,10 @@ class Phoenix
      * Get an index of (optionally filtered) campaign signups from Phoenix.
      * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection
      *
-     * @param array|string $query - query string, for filtering results
+     * @param array $query - query string, for filtering results
      * @return array - JSON response
      */
-    public function getSignupIndex($query)
+    public function getSignupIndex(array $query = [])
     {
         $response = $this->client->get('signups', [
             'query' => $query,

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -70,7 +70,7 @@ class SignupTest extends TestCase
     public function testSignupIndex()
     {
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->once()->andReturn([
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['user' => 12345])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
@@ -83,7 +83,7 @@ class SignupTest extends TestCase
             ],
         ]);
 
-        $response = $this->call('GET', 'v1/signups', [], [], [], $this->server);
+        $response = $this->call('GET', 'v1/signups?user=12345', [], [], [], $this->server);
         $content = $response->getContent();
 
         // The response should return a 200 OK status code


### PR DESCRIPTION
#### Changes
I didn't test whether query strings were properly forwarded, and things were blowing up. Fixes the error by getting the query string as an array, and added a test just cuz.

---
For review: @angaither 
/cc @aaronschachter 