### PR TITLE
Add reportbacks and signups shortcuts to the profile.

### DIFF
--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -3,6 +3,7 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Northstar\Models\User;
 use Northstar\Services\Phoenix;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Auth;
@@ -40,7 +41,14 @@ class ReportbackController extends Controller
      */
     public function index(Request $request)
     {
-        return $this->phoenix->getReportbackIndex($request->query());
+        $options = $request->query();
+
+        // If a user is specified, turn Northstar ID into Drupal ID
+        if (! empty($options['user'])) {
+            $options['user'] = User::drupalIDForNorthstarId($options['user']);
+        }
+
+        return $this->phoenix->getReportbackIndex($options);
     }
 
     /**

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -24,8 +24,8 @@ class ReportbackController extends Controller
     {
         $this->phoenix = $phoenix;
 
-        $this->middleware('key:user', ['only' => 'store']);
-        $this->middleware('auth', ['only' => 'store']);
+        $this->middleware('key:user', ['only' => ['profile', 'store']]);
+        $this->middleware('auth', ['only' => ['profile', 'store']]);
     }
 
     /**
@@ -41,6 +41,28 @@ class ReportbackController extends Controller
     public function index(Request $request)
     {
         return $this->phoenix->getReportbackIndex($request->query());
+    }
+
+    /**
+     * Displays the currently authenticated user's reportbacks.
+     * GET /profile/reportbacks
+     *
+     * @see Phoenix /api/v1/reportbacks endpoint
+     * <https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-reportback-collection>
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function profile()
+    {
+        // Get the currently authenticated Northstar user.
+        $user = Auth::user();
+
+        // Return an error if the user doesn't exist in Phoenix.
+        if (! $user->drupal_id) {
+            throw new HttpException(401, 'The user must have a Drupal ID to sign up for a campaign.');
+        }
+
+        return $this->phoenix->getReportbackIndex(['user' => $user->drupal_id]);
     }
 
     /**

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -3,6 +3,7 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Northstar\Models\User;
 use Northstar\Services\Phoenix;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Auth;
@@ -40,7 +41,14 @@ class SignupController extends Controller
      */
     public function index(Request $request)
     {
-        return $this->phoenix->getSignupIndex($request->query());
+        $options = $request->query();
+
+        // If a user is specified, turn Northstar ID into Drupal ID
+        if (! empty($options['user'])) {
+            $options['user'] = User::drupalIDForNorthstarId($options['user']);
+        }
+
+        return $this->phoenix->getSignupIndex($options);
     }
 
     /**

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -24,12 +24,12 @@ class SignupController extends Controller
     {
         $this->phoenix = $phoenix;
 
-        $this->middleware('key:user', ['only' => 'store']);
-        $this->middleware('auth', ['only' => 'store']);
+        $this->middleware('key:user', ['only' => ['profile', 'store']]);
+        $this->middleware('auth', ['only' => ['profile', 'store']]);
     }
 
     /**
-     * Displays the authenticated user's signups.
+     * Displays the (optionally filtered) index of signups.
      * GET /signups
      *
      * @see Phoenix /api/v1/signups endpoint
@@ -41,6 +41,28 @@ class SignupController extends Controller
     public function index(Request $request)
     {
         return $this->phoenix->getSignupIndex($request->query());
+    }
+
+    /**
+     * Displays the currently authenticated user's signups.
+     * GET /profile/signups
+     *
+     * @see Phoenix /api/v1/signups endpoint
+     * <https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection>
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function profile()
+    {
+        // Get the currently authenticated Northstar user.
+        $user = Auth::user();
+
+        // Return an error if the user doesn't exist in Phoenix.
+        if (! $user->drupal_id) {
+            throw new HttpException(401, 'The user must have a Drupal ID to sign up for a campaign.');
+        }
+
+        return $this->phoenix->getSignupIndex(['user' => $user->drupal_id]);
     }
 
     /**
@@ -77,7 +99,7 @@ class SignupController extends Controller
         // Get the currently authenticated Northstar user.
         $user = Auth::user();
 
-        // Return an error if the user doesn't exist.
+        // Return an error if the user doesn't exist in Phoenix.
         if (! $user->drupal_id) {
             throw new HttpException(401, 'The user must have a Drupal ID to sign up for a campaign.');
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -161,6 +161,25 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Get the corresponding Drupal ID for the given Northstar ID,
+     * if it exists.
+     *
+     * @param $northstar_id
+     * @return string|null
+     */
+    public static function drupalIDForNorthstarId($northstar_id)
+    {
+        $user = self::find($northstar_id);
+
+        if ($user) {
+            return $user->drupal_id;
+        }
+
+        // If user doesn't exist, return null.
+        return null;
+    }
+
+    /**
      * Scope a query to get all of the users in a group.
      *
      * @return \Illuminate\Database\Eloquent\Builder

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -241,7 +241,7 @@ class Phoenix
      */
     public function getReportbackIndex(array $query = [])
     {
-        $response = $this->client->get('signups', [
+        $response = $this->client->get('reportbacks', [
             'query' => $query,
             'cookies' => $this->getAuthenticationCookie(),
             'headers' => [

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -70,7 +70,7 @@ class SignupTest extends TestCase
     public function testSignupIndex()
     {
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['user' => 12345])->once()->andReturn([
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['user' => '100001'])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
@@ -83,7 +83,7 @@ class SignupTest extends TestCase
             ],
         ]);
 
-        $response = $this->call('GET', 'v1/signups?user=12345', [], [], [], $this->server);
+        $response = $this->call('GET', 'v1/signups?user=5430e850dt8hbc541c37tt3d', [], [], [], $this->server);
         $content = $response->getContent();
 
         // The response should return a 200 OK status code


### PR DESCRIPTION
#### Changes
:white_check_mark: __New Feature:__ Adds a `/profile/signups` "shortcut" endpoint to get the authenticated user's signups. This will return the same format of response as `/signups` index.

:white_check_mark: __New Feature:__ Adds a `/profile/reportbacks` "shortcut" endpoint to get the authenticated user's reportbacks. This will return the same format of response as `/reportbacks` index.

:arrows_counterclockwise: __Changed:__ The `?user=xxx` query string on the `/signups` and `/reportbacks` indexes will now translate a Northstar ID into a Phoenix user ID when forwarding the request to Phoenix. So make sure to provide the full Northstar ID when setting a filter on this endpoint. :smile: 

Fixes #277.

#### How should this be tested?
Automated tests should continue to pass. :traffic_light: 

---
For review: @angaither or @weerd 
/cc @aaronschachter @jonuy 