### PR TITLE
Reportback bugfixes

### DIFF
--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -260,10 +260,10 @@ class Phoenix
      * @throws NotFoundHttpException
      * @throws Exception
      */
-    public function getReportback($signup_id)
+    public function getReportback($reportback_id)
     {
         try {
-            $response = $this->client->get('signups/'.$signup_id, [
+            $response = $this->client->get('reportbacks/'.$reportback_id, [
                 'cookies' => $this->getAuthenticationCookie(),
                 'headers' => [
                     'X-CSRF-Token' => $this->getAuthenticationToken(),
@@ -273,7 +273,7 @@ class Phoenix
             return $response->json();
         } catch (ClientException $e) {
             if ($e->getCode() === 404) {
-                throw new NotFoundHttpException('That signup could not be found.');
+                throw new NotFoundHttpException('That reportback could not be found.');
             }
 
             throw new Exception('Unknown error getting signup: '.$e->getMessage());

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -5,6 +5,7 @@ namespace Northstar\Services;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Cache;
 
@@ -301,6 +302,7 @@ class Phoenix
             'quantity' => $contents['quantity'],
             'why_participated' => $contents['why_participated'],
             'file' => $contents['file'],
+            'filename' => Str::random(10).'.jpg', // Hackz. This sets the filename Phoenix saves reportback with.
             'caption' => $contents['caption'],
             'source' => $contents['source'],
         ];


### PR DESCRIPTION
#### Changes
Two quick bug fixes:

:bug: __Fixed bug:__ I made a typo when making the `getReportback` method, so fixed that.

:bug: __Fixed bug:__ Adds a randomly generated `filename` value to the `createReportback` payload, so it doesn't kaboom when trying to report back for a campaign. References #279.

---
For review: @weerd @aaronschachter 