### PR TITLE
Return the full reportback object from the store endpoint.

### DIFF
--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -121,9 +121,10 @@ class ReportbackController extends Controller
 
         // HACK: Since the "create reportback" services endpoint returns a less-than-helpful
         // response (see above), we'll use that to fetch the full transformed response.
+        $reportbackResponse = $this->phoenix->getReportback($reportback[0]);
+
         // NOTE: Since we don't know whether a reportback is new or just updating an existing RB,
         // we'll always just return 200 OK. This will probably change when we update Phoenix.
-        $reportbackResponse = $this->phoenix->getReportback($reportback[0]);
         return response()->json($reportbackResponse, 200);
     }
 }

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -116,6 +116,11 @@ class ReportbackController extends Controller
             throw new HttpException(401, 'The user must have a Drupal ID to submit a reportback.');
         }
 
-        return $this->phoenix->createReportback($user->drupal_id, $request->input('campaign_id'), $request->except('campaign_id'));
+        // Phoenix returns [":reportback_id"] on successful creation.
+        $reportback = $this->phoenix->createReportback($user->drupal_id, $request->input('campaign_id'), $request->except('campaign_id'));
+
+        // HACK: Since the "create reportback" services endpoint returns a less-than-helpful
+        // response (see above), we'll use that to fetch the full transformed response.
+        return $this->phoenix->getReportback($reportback[0]);
     }
 }

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -121,6 +121,9 @@ class ReportbackController extends Controller
 
         // HACK: Since the "create reportback" services endpoint returns a less-than-helpful
         // response (see above), we'll use that to fetch the full transformed response.
-        return $this->phoenix->getReportback($reportback[0]);
+        // NOTE: Since we don't know whether a reportback is new or just updating an existing RB,
+        // we'll always just return 200 OK. This will probably change when we update Phoenix.
+        $reportbackResponse = $this->phoenix->getReportback($reportback[0]);
+        return response()->json($reportbackResponse, 200);
     }
 }

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -117,9 +117,18 @@ class SignupController extends Controller
 
         // If signup already exists, return a polite response.
         if ($signup[0] === false) {
-            return $this->respond('Signup already exists.', 200);
+            $signups = $this->phoenix->getSignupIndex(['user' => $user->drupal_id, 'campaigns' => $request->input('campaign_id')]);
+
+            if(count($signups['data']) === 0) {
+                throw new HttpException(500, 'Signup already exists, but could not display.');
+            }
+
+            // Return a "mocked" 200 individual item response.
+            return response()->json(['data' => $signups['data'][0]], 200);
         }
 
-        return $this->phoenix->getSignup($signup[0]);
+        // If we successfully created signup, return "show" response w/ 201
+        $signupResponse = $this->phoenix->getSignup($signup[0]);
+        return response()->json($signupResponse, 201);
     }
 }

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -112,6 +112,14 @@ class SignupController extends Controller
             throw new HttpException(401, 'The user must have a Drupal ID to sign up for a campaign.');
         }
 
-        return $this->phoenix->createSignup($user->drupal_id, $request->input('campaign_id'), $request->input('source'));
+        // Phoenix returns [":signup_id"] on new signup, or [false] if a signup already exists.
+        $signup = $this->phoenix->createSignup($user->drupal_id, $request->input('campaign_id'), $request->input('source'));
+
+        // If signup already exists, return a polite response.
+        if ($signup[0] === false) {
+            return $this->respond('Signup already exists.', 200);
+        }
+
+        return $this->phoenix->getSignup($signup[0]);
     }
 }

--- a/tests/ReportbackTest.php
+++ b/tests/ReportbackTest.php
@@ -77,9 +77,16 @@ class ReportbackTest extends TestCase
             'caption' => 'Here I am helping others.',
         ];
 
-        // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('createReportback')->once()->andReturn([
+        // For testing, we'll mock successful Phoenix API responses.
+        $phoenix = $this->mock(Phoenix::class);
+        $phoenix->shouldReceive('createReportback')->once()->andReturn([
             '127',
+        ]);
+        $phoenix->shouldReceive('getReportback')->once()->andReturn([
+            'data' => [
+                'id' => 127,
+                // ...
+            ],
         ]);
 
         $response = $this->call('POST', 'v1/reportbacks', [], [], [], $this->signedUpServer, json_encode($payload));

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -145,8 +145,8 @@ class SignupTest extends TestCase
             'source' => 'test',
         ]));
 
-        // The response should return a 200 OK status code
-        $this->assertEquals(200, $response->getStatusCode());
+        // The response should return a 201 Created status code
+        $this->assertEquals(201, $response->getStatusCode());
 
         // Response should be valid JSON
         $content = $response->getContent();

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -128,8 +128,15 @@ class SignupTest extends TestCase
     public function testSubmitSignup()
     {
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('createSignup')->once()->andReturn([
+        $mock = $this->mock(Phoenix::class);
+        $mock->shouldReceive('createSignup')->once()->andReturn([
             '1307',
+        ]);
+        $mock->shouldReceive('getSignup')->with('1307')->once()->andReturn([
+            'data' => [
+                'id' => '1307',
+                // ...
+            ],
         ]);
 
         // Make the request


### PR DESCRIPTION
### Changes
References #281. This is a temporary measure until we can update the underlying API on Phoenix!

:warning: __Breaking Change:__ The `POST /reportbacks` endpoint will now return a full reportback object (same formatting as the `GET /reportbacks/:id` endpoint), rather than an array with a string ID.

:warning: __Breaking Change:__ The `POST /signups` endpoint will now return a full signup object (same formatting as the `GET /signups/:id` endpoint), rather than an array with a string ID.

### Discussion
~~For the signup endpoint, I'm not sure whether I _can_ fetch the existing signup... I tried fetching signups from the `signups/` endpoint with the proper `?user=xxx` and `&campaign=xxx` filter parameters, but it ended up returning like 5 campaigns. :disappointed: 

This might be a campaign-run issue...? Not 100% sure but would love thoughts if anyone has them.~~

Okay, never mind! I was passing a single `campaign=123` rather than `campaigns=123` and I am very dumb so never mind anything okay bye.

---
For review: @weerd @angaither 
/cc @jonuy @aaronschachter 