### PR TITLE
Clean up Avatar controller.

### DIFF
--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -2,9 +2,11 @@
 
 namespace Northstar\Http\Controllers;
 
+use Northstar\Http\Transformers\UserTransformer;
 use Northstar\Services\AWS;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class AvatarController extends Controller
 {
@@ -14,16 +16,23 @@ class AvatarController extends Controller
      */
     protected $aws;
 
+    /**
+     * @var UserTransformer
+     */
+    protected $transformer;
+
     public function __construct(AWS $aws)
     {
         $this->aws = $aws;
+
+        $this->transformer = new UserTransformer();
 
         $this->middleware('key:user');
         $this->middleware('auth');
     }
 
     /**
-     * Store a new avatar for a user.
+     * Save a new avatar to a user's profile.
      * POST /users/:id/avatar
      *
      * @param Request $request
@@ -32,24 +41,26 @@ class AvatarController extends Controller
      */
     public function store(Request $request, $id)
     {
-        if ($request->file('photo')) {
-            $file = $request->file('photo');
-        } else {
-            $file = $request->photo;
-        }
-
         $this->validate($request, [
             'photo' => 'required',
         ]);
 
+        $user = User::where('_id', $id)->first();
+
+        if (! $user) {
+            throw new NotFoundHttpException('The resource does not exist.');
+        }
+
+        // If a file is attached via multipart/form-data, use that. Otherwise, look
+        // for a Base-64 encoded Data URI in the request body.
+        $file = $request->file('photo') ? $request->file('photo') : $request->photo;
         $filename = $this->aws->storeImage('avatars', $id, $file);
 
         // Save filename to User model
-        $user = User::where('_id', $id)->first();
         $user->photo = $filename;
         $user->save();
 
         // Respond to user with success and photo URL
-        return $this->respond($user);
+        return $this->item($user);
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -21,4 +21,17 @@ class UserPolicy
     {
         return $user->id === $profile->id;
     }
+
+    /**
+     * Determine if the authorized user can edit the profile details
+     * for the given user account.
+     *
+     * @param User $user
+     * @param User $profile
+     * @return bool
+     */
+    public function editProfile(User $user, User $profile)
+    {
+        return $user->id === $profile->id;
+    }
 }

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -2,7 +2,10 @@
 
 namespace Northstar\Services;
 
+use finfo;
 use Storage;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class AWS
 {
@@ -19,16 +22,48 @@ class AWS
     public function storeImage($folder, $filename, $file)
     {
         if (is_string($file)) {
-            $path = 'uploads/'.$folder.'/'.$filename;
-            $data = base64_decode($file);
+            $data = $this->base64StringToDataString($file);
+            $extension = $this->guessExtension($data);
         } else {
             $extension = $file->guessExtension();
-            $path = 'uploads/'.$folder.'/'.$filename.'.'.$extension;
             $data = file_get_contents($file);
         }
 
+        // Make sure we're only uploading valid image types
+        if(! in_array($extension, ['jpeg', 'png'])) {
+            throw new UnprocessableEntityHttpException('Invalid file type. Upload a JPEG or PNG.');
+        }
+
+        $path = 'uploads/'.$folder.'/'.$filename.'.'.$extension;
         Storage::disk('s3')->put($filename, $data);
 
         return config('filesystems.disks.s3.public_url').$path;
+    }
+
+    /**
+     * Guess the extension from a data buffer string.
+     * @param string $data - Data buffer string
+     * @return string - file extension
+     */
+    protected function guessExtension($data)
+    {
+        $f = new finfo();
+        $mimeType = $f->buffer($data, FILEINFO_MIME_TYPE);
+        $guesser = ExtensionGuesser::getInstance();
+
+        return $guesser->guess($mimeType);
+    }
+
+    /**
+     * Decode Base-64 encoded string into a raw data buffer string.
+     * @param $string - Base-64 encoded string
+     * @return string - raw data
+     */
+    protected function base64StringToDataString($string)
+    {
+        // Trim the mime-type (e.g. `data:image/png;base64,`) from the string
+        $file = last(explode(',', $string));
+
+        return base64_decode($file);
     }
 }

--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -30,7 +30,7 @@ class AWS
         }
 
         // Make sure we're only uploading valid image types
-        if(! in_array($extension, ['jpeg', 'png'])) {
+        if (! in_array($extension, ['jpeg', 'png'])) {
             throw new UnprocessableEntityHttpException('Invalid file type. Upload a JPEG or PNG.');
         }
 


### PR DESCRIPTION
#### Changes
Fixes issues parsing file extension from Data URLs (secret: we _weren't_ parsing file extensions) when uploading avatars. Also just tidies up logic so it’s easier to follow what’s going on. :leaves: 

Also locks down the avatar resource, so a user can only edit their own avatar. :lock: 

#### How should this be tested?
I ran through testing this on my local (with the `Storage::disk('s3')->put()` call commented out) and the paths & file data are now correctly formed now for both data URLs & multipart form submissions.

I'll test this for realsies once we have this up on QA.

---
For review: @angaither or @weerd 
/cc @aaronschachter @weerd 