### PR TITLE
Add timestamp to upload filenames to fix caching issue.

### DIFF
--- a/app/Services/AWS.php
+++ b/app/Services/AWS.php
@@ -49,7 +49,9 @@ class AWS
             throw new UnprocessableEntityHttpException('Invalid file type. Upload a JPEG or PNG.');
         }
 
-        $path = 'uploads/'.$folder.'/'.$filename.'.'.$extension;
+        // Add a unique timestamp (e.g. uploads/folder/filename-1456498664.jpeg) to
+        // uploads to prevent AWS cache giving the user an old upload.
+        $path = 'uploads/'.$folder.'/'.$filename.'-'.time().'.'.$extension;
         $success = $this->filesystem->put($path, $data);
 
         if (! $success) {

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -329,7 +329,8 @@ curl -X DELETE \
 ```
 
 ## Set User Avatar
-Save an avatar to the user's Northstar profile. Accepts a file or Base64 string in the data request.
+Save an avatar to the user's Northstar profile. Accepts a file or Base64 string in the data request. This will return
+the updated User profile document, with a `photo` attribute pointing to the newly created image.
 
 ```
 POST /users/:user_id/avatar
@@ -363,7 +364,7 @@ curl -X POST \
 {
     "data": {
         "id": "5430e850dt8hbc541c37tt3d",
-        "photo": "https://avatar.dosomething.org/uploads/avatars/55566327bffebc0b3e8b45a5.jpeg"
+        "photo": "https://avatar.dosomething.org/uploads/avatars/55566327bffebc0b3e8b45a5-1456498835.jpeg"
         // the rest of the user object...
         "updated_at": "2016-02-25T18:33:25+0000"
     }


### PR DESCRIPTION
#### Changes
Fixes #272... again! :weary: AWS wasn't expiring cache on image uploads when we overwrote an old avatar, so adding a timestamp to the filename to ensure that it's a unique URL.

Example response:
```js
// POST /users/5430e850dt8hbc541c37tt3d/avatar

{
     "data": {
         "id": "5430e850dt8hbc541c37tt3d",
         "photo": "https://avatar.dosomething.org/uploads/avatars/5430e850dt8hbc541c37tt3d-1456498835.png"
         // the rest of the user object...
         "updated_at": "2016-02-25T18:33:25+0000"
     }
}
```

#### How should this be tested?
I tested on my local and everything should be working great now.

---
For review: @angaither or @weerd 
/cc @aaronschachter @jonuy 