### PR TITLE
Jeez why is this so slow i guess its because we never set an index

### DIFF
--- a/database/migrations/2015_10_26_193708_AddDrupalIDIndex.php
+++ b/database/migrations/2015_10_26_193708_AddDrupalIDIndex.php
@@ -23,6 +23,8 @@ class AddDrupalIDIndex extends Migration
      */
     public function down()
     {
-        $collection->dropIndex('drupal_id');
+        Schema::table('users', function ($collection) {
+            $collection->dropIndex('drupal_id');
+        });
     }
 }

--- a/database/migrations/2016_02_29_162723_AddKeyAndTokenIndexes.php
+++ b/database/migrations/2016_02_29_162723_AddKeyAndTokenIndexes.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddKeyAndTokenIndexes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tokens', function ($collection) {
+            $collection->index('key');
+        });
+
+        Schema::table('api_keys', function ($collection) {
+            $collection->index('api_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function ($collection) {
+            $collection->dropIndex('key');
+        });
+
+        Schema::table('api_keys', function ($collection) {
+            $collection->dropIndex('api_key');
+        });
+    }
+}


### PR DESCRIPTION
#### Changs
Adds indexes to the `key` on authentication tokens, and the `api_key` on API keys. So that we can look them up super fast even when there's a super lot of them.

#### How should this be tested?
Things should work exactly the same, but not slow as molasses.

---
For review: @angaither 