### PR TITLE
Fix POST upsert issue & add Mobile Commons fields to user.

### DIFF
--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -50,12 +50,12 @@ class UserTransformer extends TransformerAbstract
         // Signup source (e.g. drupal, cgg, mobile...)
         $response['source'] = $user->source;
 
-        // References to app-specific user IDs.
+        // Internal & third-party service IDs:
         $response['drupal_id'] = $user->drupal_id;
-        $response['cgg_id'] = $user->cgg_id;
-        $response['agg_id'] = $user->agg_id;
-
+        $response['mobilecommons_id'] = $user->mobilecommons_id;
         $response['parse_installation_ids'] = $user->parse_installation_ids;
+
+        $response['mobilecommons_status'] = $user->mobilecommons_status;
 
         $response['updated_at'] = $user->updated_at->toISO8601String();
         $response['created_at'] = $user->created_at->toISO8601String();

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -35,8 +35,6 @@ class UserTransformer extends TransformerAbstract
 
         if (ApiKey::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['birthdate'] = $user->birthdate;
-            $response['race'] = $user->race;
-            $response['religion'] = $user->religion;
 
             $response['addr_street1'] = $user->addr_street1;
             $response['addr_street2'] = $user->addr_street2;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,7 +36,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip', 'country',
 
-        'cgg_id', 'drupal_id', 'agg_id', 'source',
+        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'source',
 
         'parse_installation_ids',
     ];


### PR DESCRIPTION
#### Changes

:bug: Fixes issue where the `POST users/` route was not [upserting](https://docs.mongodb.org/v2.6/reference/glossary/#term-upsert) because validation was not excluding the "existing" document when checking for uniques.

:white_check_mark: Adds `mobilecommons_id` and `mobilecommons_status` fields to the user document and exposes them through the API. Content for the two new fields is coming soon!

:warning: Remove `race` and `religion` from the user profile. These are never being set by the user (and not being used by the mobile app), so it seems silly to be returning them.

---
For review: @angaither or @weerd 