### PR TITLE
Source should be immutable

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -79,14 +79,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $dates = ['created_at', 'updated_at'];
 
     /**
-     * Email address mutator that converts the email value to lowercase.
-     */
-    public function setEmailAttribute($value)
-    {
-        $this->attributes['email'] = strtolower($value);
-    }
-
-    /**
      * Computed last initial field, for public profiles.
      * @return string
      */
@@ -98,7 +90,25 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Interests mutator converting comma-delimited string to an array.
+     * Mutator to normalize email addresses to lowercase.
+     *
+     * @param string $value
+     */
+    public function setEmailAttribute($value)
+    {
+        // Skip mutator if attribute is null.
+        if (empty($value)) {
+            return;
+        }
+
+        $this->attributes['email'] = strtolower($value);
+    }
+
+    /**
+     * Mutator to add interests to the user's interests array, either by
+     * passing an array or a comma-separated list of values.
+     *
+     * @param string|array $value
      */
     public function setInterestsAttribute($value)
     {
@@ -108,7 +118,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Mobile number mutator that converts number value to only numbers.
+     * Mutator to strip non-numeric characters from mobile numbers.
+     *
+     * @param string $value
      */
     public function setMobileAttribute($value)
     {
@@ -122,7 +134,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Mutator saves Parse installation ids as an array.
+     * Mutator to add new Parse IDs to the user's installation IDs array,
+     * either by passing an array or a comma-separated list of values.
      */
     public function setParseInstallationIdsAttribute($value)
     {
@@ -132,7 +145,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Password mutator that hashes the password field
+     * Mutator to automatically hash any value saved to the password field.
      */
     public function setPasswordAttribute($value)
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -153,14 +153,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Define embedded relationship with the Campaign Model
-     */
-    public function campaigns()
-    {
-        return $this->embedsMany('Northstar\Models\Campaign');
-    }
-
-    /**
      * Generate a token to authenticate a user
      *
      * @return mixed

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -134,6 +134,19 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Mutator to make the `source` field immutable (e.g. once a user has been assigned
+     * a source, that value cannot be changed). This allows applications to always
+     * pass their own identifier in the user's source, without overwriting that value
+     * for existing users.
+     */
+    public function setSourceAttribute($value)
+    {
+        if(empty($this->attributes['source'])) {
+           $this->attributes['source'] = $value;
+        }
+    }
+
+    /**
      * Mutator to add new Parse IDs to the user's installation IDs array,
      * either by passing an array or a comma-separated list of values.
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -141,8 +141,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setSourceAttribute($value)
     {
-        if(empty($this->attributes['source'])) {
-           $this->attributes['source'] = $value;
+        if (empty($this->attributes['source'])) {
+            $this->attributes['source'] = $value;
         }
     }
 

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -118,6 +118,7 @@ Either a mobile number or email is required.
   agg_id: Number
   cgg_id: Number
   drupal_id: String
+  source: String // Immutable (can only be set if existing value is `null`)
   race: String
   religion: String
   college_name: String
@@ -129,7 +130,6 @@ Either a mobile number or email is required.
   sat_math: Number
   sat_verbal: Number
   sat_writing: Number
-  source: String
 }
 ```
 

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -95,16 +95,16 @@ Either a mobile number or email is required.
 // Content-Type: application/json
 
 {
-  /* Required if 'mobile' is not provided */
+  // Required if 'mobile' is not provided
   email: String
 
-  /* Required if 'email' is not provided */
+  // Required if 'email' is not provided
   mobile: String
 
-  /* Optional, but required for user to be able to log in! */
+  // Optional, but required for user to be able to log in!
   password: String
 
-  /* Optional */
+  // Optional:
   birthdate: Date
   first_name: String
   last_name: String
@@ -118,7 +118,10 @@ Either a mobile number or email is required.
   agg_id: Number
   cgg_id: Number
   drupal_id: String
+  interests: String
   source: String // Immutable (can only be set if existing value is `null`)
+  
+  // Hidden fields (optional):
   race: String
   religion: String
   college_name: String
@@ -126,7 +129,6 @@ Either a mobile number or email is required.
   major_name: String
   hs_gradyear: String
   hs_name: String
-  interests: String
   sat_math: Number
   sat_verbal: Number
   sat_writing: Number

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -232,33 +232,68 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test for registering a new user
+     * Test for creating a new user.
      * POST /users
      *
      * @return void
      */
-    public function testRegisterUser()
+    public function testCreateUser()
     {
         // Create a new user object
         $user = [
             'email' => 'new@dosomething.org',
-            'mobile' => '5556667777',
-            'password' => 'secret',
+            'source' => 'phpunit',
         ];
 
         $response = $this->call('POST', 'v1/users', [], [], [], $this->server, json_encode($user));
         $content = $response->getContent();
-        $data = json_decode($content, true);
+        $data = json_decode($content, true)['data'];
 
-        // The response should return a 200 Okay status code
+        // The response should return JSON with a 200 Okay status code
         $this->assertEquals(200, $response->getStatusCode());
-
-        // Response should be valid JSON
         $this->assertJson($content);
 
         // Response should return created at and id columns
-        $this->assertArrayHasKey('created_at', $data['data']);
-        $this->assertArrayHasKey('_id', $data['data']);
+        $this->assertArrayHasKey('created_at', $data);
+        $this->assertArrayHasKey('id', $data);
+    }
+
+    /**
+     * Test for "upserting" an existing user.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testUpsertUser()
+    {
+        User::create([
+            'email' => 'upsert-me@dosomething.org',
+            'source' => 'database'
+        ]);
+
+        // Post a "new" user object to merge into existing record
+        $user = [
+            'email' => 'upsert-me@dosomething.org',
+            'mobile' => '5556667777',
+            'password' => 'secret',
+            'first_name' => 'Puppet',
+            'source' => 'phpunit',
+        ];
+
+        $response = $this->call('POST', 'v1/users', [], [], [], $this->server, json_encode($user));
+        $content = $response->getContent();
+        $data = json_decode($content, true)['data'];
+
+        // The response should return JSON with a 200 Okay status code
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertJson($content);
+
+        // Check for the new fields we "upserted".
+        $this->assertEquals('Puppet', $data['first_name']);
+        $this->assertEquals('5556667777', $data['mobile']);
+
+        // Ensure the `source` field is immutable (since it was set to 'phpunit' above).
+        $this->assertEquals('database', $data['source']);
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -268,7 +268,7 @@ class UserTest extends TestCase
     {
         User::create([
             'email' => 'upsert-me@dosomething.org',
-            'source' => 'database'
+            'source' => 'database',
         ]);
 
         // Post a "new" user object to merge into existing record


### PR DESCRIPTION
#### Changes
:warning: Makes `source` an immutable property on the User document. This allows us to always include a value in `source` when making an "upsert" to `POST users/` but _only_ save that value if that's really the initial source of the user.

:book: Update docblocks on `User` mutators, and [tidy up listing of user fields](https://github.com/DFurnes/northstar/blob/source-should-be-immutable/documentation/endpoints/users.md#create-a-user) in docs. 

#### How should this be tested?
I tested in my local Paw manually, and added a simple functional test for this and the expected "upsert" behavior (from #292) to make sure this doesn't break down the road.

---
For review: @angaither or @weerd 