### PR TITLE
Cleanup and password tests

### DIFF
--- a/app/Auth/DrupalPasswordHash.php
+++ b/app/Auth/DrupalPasswordHash.php
@@ -49,11 +49,6 @@ class DrupalPasswordHash
             return ($hash && $stored_hash == $hash);
     }
 
-    private static function hash($password)
-    {
-        return self::_password_crypt('sha512', $password, $stored_hash);
-    }
-
     // @see: https://api.drupal.org/api/drupal/includes%21password.inc/function/_password_crypt/7
     private static function _password_crypt($algo, $password, $setting)
     {

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -91,7 +91,6 @@ class Registrar
             // If this user has a Drupal-hashed password, rehash it, remove the
             // Drupal password field from the user document, and save the user.
             $user->password = $credentials['password'];
-            $user->unset('drupal_password');
             $user->save();
 
             return true;

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,201 +2,16 @@
 
 namespace Northstar\Http\Controllers;
 
-use Illuminate\Http\Request;
-use League\Fractal\Manager;
-use League\Fractal\Pagination\IlluminatePaginatorAdapter;
-use League\Fractal\Resource\Collection as FractalCollection;
-use League\Fractal\Resource\Item as FractalItem;
-use League\Fractal\Serializer\DataArraySerializer;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Database\Eloquent;
-use Northstar\Models\ApiKey;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Northstar\Http\Controllers\Traits\FiltersRequests;
+use Northstar\Http\Controllers\Traits\TransformsResponses;
+use Illuminate\Http\Request;
 
 abstract class Controller extends BaseController
 {
-    use DispatchesJobs, ValidatesRequests;
-
-    /**
-     * @var \League\Fractal\TransformerAbstract
-     */
-    protected $transformer;
-
-    /**
-     * Format & return a single item response.
-     *
-     * @param $item
-     * @param int $code
-     * @param array $meta
-     * @param null $transformer
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function item($item, $code = 200, $meta = [], $transformer = null)
-    {
-        if (is_null($transformer)) {
-            $transformer = $this->transformer;
-        }
-
-        $resource = new FractalItem($item, $transformer, 'thing');
-        $resource->setMeta($meta);
-
-        $manager = new Manager(new DataArraySerializer());
-        $response = $manager->createData($resource)->toArray();
-
-        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
-    }
-
-    /**
-     * Format & return a collection response.
-     *
-     * @param $collection
-     * @param int $code
-     * @param array $meta
-     * @param null $transformer
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function collection($collection, $code = 200, $meta = [], $transformer = null)
-    {
-        if (is_null($transformer)) {
-            $transformer = $this->transformer;
-        }
-
-        $resource = new FractalCollection($collection, $transformer, 'things');
-        $resource->setMeta($meta);
-
-        $manager = new Manager(new DataArraySerializer());
-        $response = $manager->createData($resource)->toArray();
-
-        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
-    }
-
-    /**
-     * Format & return a paginated collection response.
-     *
-     * @param $query - Eloquent query
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null)
-    {
-        if (is_null($transformer)) {
-            $transformer = $this->transformer;
-        }
-
-        $paginator = $query->paginate((int) $request->query('limit', 20));
-
-        $resource = new FractalCollection($paginator->getCollection(), $transformer);
-        $resource->setMeta($meta);
-
-        $queryParams = array_diff_key($request->query(), array_flip(['page']));
-        $paginator->appends($queryParams);
-        $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
-
-        $manager = new Manager(new DataArraySerializer());
-        $response = $manager->createData($resource)->toArray();
-
-        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
-    }
-
-    /**
-     * Format & return a standard object, array, or string response.
-     *
-     * @param mixed $data - Data to send in the response
-     * @param int $code - Status code
-     * @param string $status - When $data is a message string, this is the name of the object enclosing the message
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    protected function respond($data, $code = 200, $status = 'success')
-    {
-        $response = [];
-        if (is_string($data)) {
-            $response[$status] = ['message' => $data];
-        } elseif (is_object($data) || is_array($data)) {
-            $response['data'] = $data;
-        } else {
-            $response = $data;
-        }
-
-        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
-    }
-
-    /**
-     * Create a new query builder from the given Eloquent class, which can then be
-     * filtered, searched, and/or paginated.
-     *
-     * @param string $class - Eloquent model class name
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function newQuery($class)
-    {
-        return (new $class)->newQuery();
-    }
-
-    /**
-     * Limit results to users exactly matching a set of filters.
-     *
-     * @param $query
-     * @param $filters
-     * @param $indexes - Indexed fields (whitelisted for filtering)
-     * @return mixed
-     */
-    public function filter($query, $filters, $indexes)
-    {
-        if (! $filters) {
-            return $query;
-        }
-
-        // Requests may be filtered by indexed fields.
-        $filters = array_intersect_key($filters, array_flip($indexes));
-
-        // You can filter by multiple values, e.g. `filter[source]=agg,cgg`
-        // to get records that have a source value of either `agg` or `cgg`.
-        foreach ($filters as $filter => $values) {
-            $values = explode(',', $values);
-
-            // For the first `where` query, we want to limit results... from then on,
-            // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
-            $firstWhere = true;
-            foreach ($values as $value) {
-                $query->where($filter, '=', $value, ($firstWhere ? 'and' : 'or'));
-                $firstWhere = false;
-            }
-        }
-
-        return $query;
-    }
-
-    /**
-     * Limit results to users matching a set of search terms.
-     *
-     * @param $query - Query to apply search to
-     * @param array $searches - Key/value array of fields and search terms
-     * @param array $indexes - Indexed fields (whitelisted for search)
-     * @return mixed
-     */
-    public function search($query, $searches, $indexes)
-    {
-        if (! $searches) {
-            return $query;
-        }
-
-        // Only "admin" keys should be able to search
-        ApiKey::gate('admin');
-
-        // Searches may only be performed on indexed fields.
-        $searches = array_intersect_key($searches, array_flip($indexes));
-
-        // For the first `where` query, we want to limit results... from then on,
-        // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
-        $firstWhere = true;
-        foreach ($searches as $term => $value) {
-            $query->where($term, '=', $value, ($firstWhere ? 'and' : 'or'));
-            $firstWhere = false;
-        }
-
-        return $query;
-    }
+    use DispatchesJobs, ValidatesRequests, FiltersRequests, TransformsResponses;
 
     /**
      * Create the response for when a request fails validation. Overrides the
@@ -214,6 +29,6 @@ abstract class Controller extends BaseController
             'errors' => $errors,
         ];
 
-        return new JsonResponse($response, 422);
+        return response()->json($response, 422);
     }
 }

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -2,8 +2,6 @@
 
 namespace Northstar\Http\Controllers;
 
-use League\Fractal\Resource\Item;
-use League\Fractal\Resource\Collection;
 use Illuminate\Http\Request;
 use Northstar\Http\Transformers\ApiKeyTransformer;
 use Northstar\Models\ApiKey;
@@ -19,7 +17,7 @@ class KeyController extends Controller
 
     public function __construct(ApiKeyTransformer $transformer)
     {
-        $this->transformer = $transformer;
+        $this->transformer = new ApiKeyTransformer();
 
         $this->middleware('key:admin');
     }

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Northstar\Http\Controllers\Traits;
+
+use Northstar\Models\ApiKey;
+
+trait FiltersRequests
+{
+    /**
+     * Create a new query builder from the given Eloquent class, which can then be
+     * filtered, searched, and/or paginated.
+     *
+     * @param string $class - Eloquent model class name
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function newQuery($class)
+    {
+        return (new $class)->newQuery();
+    }
+
+    /**
+     * Limit results to users exactly matching a set of filters.
+     *
+     * @param $query
+     * @param $filters
+     * @param $indexes - Indexed fields (whitelisted for filtering)
+     * @return mixed
+     */
+    public function filter($query, $filters, $indexes)
+    {
+        if (! $filters) {
+            return $query;
+        }
+
+        // Requests may be filtered by indexed fields.
+        $filters = array_intersect_key($filters, array_flip($indexes));
+
+        // You can filter by multiple values, e.g. `filter[source]=agg,cgg`
+        // to get records that have a source value of either `agg` or `cgg`.
+        foreach ($filters as $filter => $values) {
+            $values = explode(',', $values);
+
+            // For the first `where` query, we want to limit results... from then on,
+            // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
+            $firstWhere = true;
+            foreach ($values as $value) {
+                $query->where($filter, '=', $value, ($firstWhere ? 'and' : 'or'));
+                $firstWhere = false;
+            }
+        }
+
+        return $query;
+    }
+
+    /**
+     * Limit results to users matching a set of search terms.
+     *
+     * @param $query - Query to apply search to
+     * @param array $searches - Key/value array of fields and search terms
+     * @param array $indexes - Indexed fields (whitelisted for search)
+     * @return mixed
+     */
+    public function search($query, $searches, $indexes)
+    {
+        if (! $searches) {
+            return $query;
+        }
+
+        // Only "admin" keys should be able to search
+        ApiKey::gate('admin');
+
+        // Searches may only be performed on indexed fields.
+        $searches = array_intersect_key($searches, array_flip($indexes));
+
+        // For the first `where` query, we want to limit results... from then on,
+        // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
+        $firstWhere = true;
+        foreach ($searches as $term => $value) {
+            $query->where($term, '=', $value, ($firstWhere ? 'and' : 'or'));
+            $firstWhere = false;
+        }
+
+        return $query;
+    }
+}

--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Northstar\Http\Controllers\Traits;
+
+use League\Fractal\Manager;
+use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+use League\Fractal\Resource\Collection as FractalCollection;
+use League\Fractal\Resource\Item as FractalItem;
+use League\Fractal\Serializer\DataArraySerializer;
+
+trait TransformsResponses
+{
+    /**
+     * The default transformer.
+     *
+     * @var \League\Fractal\TransformerAbstract
+     */
+    protected $transformer;
+
+    /**
+     * Transform the given item or collection.
+     *
+     * @param $resource
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function transform($resource, $code)
+    {
+        $manager = new Manager(new DataArraySerializer());
+        $response = $manager->createData($resource)->toArray();
+
+        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Format & return a single item response.
+     *
+     * @param $item
+     * @param int $code
+     * @param array $meta
+     * @param null $transformer
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function item($item, $code = 200, $meta = [], $transformer = null)
+    {
+        if (is_null($transformer)) {
+            $transformer = $this->transformer;
+        }
+
+        $resource = new FractalItem($item, $transformer, 'thing');
+        $resource->setMeta($meta);
+
+        return $this->transform($resource, $code);
+    }
+
+    /**
+     * Format & return a collection response.
+     *
+     * @param $collection
+     * @param int $code
+     * @param array $meta
+     * @param null $transformer
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function collection($collection, $code = 200, $meta = [], $transformer = null)
+    {
+        if (is_null($transformer)) {
+            $transformer = $this->transformer;
+        }
+
+        $resource = new FractalCollection($collection, $transformer, 'things');
+        $resource->setMeta($meta);
+
+        return $this->transform($resource, $code);
+    }
+
+    /**
+     * Format & return a paginated collection response.
+     *
+     * @param $query - Eloquent query
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null)
+    {
+        if (is_null($transformer)) {
+            $transformer = $this->transformer;
+        }
+
+        $paginator = $query->paginate((int) $request->query('limit', 20));
+
+        $resource = new FractalCollection($paginator->getCollection(), $transformer);
+        $resource->setMeta($meta);
+
+        $queryParams = array_diff_key($request->query(), array_flip(['page']));
+        $paginator->appends($queryParams);
+        $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
+
+        return $this->transform($resource, $code);
+    }
+
+    /**
+     * Return a string as the API response.
+     *
+     * @param string $message - Message to send in the response
+     * @param int $code - Status code
+     * @param string $status - The name of the object enclosing the message
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function respond($message, $code = 200, $status = 'success')
+    {
+        $response = [
+            $status => [
+                'message' => $message,
+            ],
+        ];
+
+        return response()->json($response, $code, [], JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -158,10 +158,15 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Mutator to automatically hash any value saved to the password field.
+     * Mutator to automatically hash any value saved to the password field,
+     * and remove the hashed Drupal password if one exists.
      */
     public function setPasswordAttribute($value)
     {
+        if (isset($this->drupal_password)) {
+            $this->unset('drupal_password');
+        }
+
         $this->attributes['password'] = Hash::make($value);
     }
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -127,41 +127,4 @@ class AuthTest extends TestCase
 
         $this->assertResponseStatus(401);
     }
-
-    /**
-     * Tests that Drupal password hasher is working correctly.
-     */
-    public function testAuthenticatingWithDrupalPassword()
-    {
-        $user = User::create([
-            'email' => 'dries.buytaert@example.com',
-            'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
-        ]);
-
-        $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
-            'email' => 'dries.buytaert@example.com',
-            'password' => 'secret',
-        ]);
-
-        // Assert response is 200 OK and has expected data
-        $this->assertResponseStatus(200);
-        $this->seeJsonSubset([
-            'data' => [
-                'id' => $user->_id,
-                'email' => $user->email,
-            ],
-        ]);
-
-        // Assert user has been updated in the database with a newly hashed password.
-        $user = $user->fresh();
-        $this->assertArrayNotHasKey('drupal_password', $user['attributes']);
-        $this->assertArrayHasKey('password', $user['attributes']);
-
-        // Finally, let's try logging in with the newly hashed password
-        $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
-            'email' => 'dries.buytaert@example.com',
-            'password' => 'secret',
-        ]);
-        $this->assertResponseStatus(200);
-    }
 }

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Northstar\Models\User;
+
+class PasswordTest extends TestCase
+{
+    /**
+     * Tests that Drupal password hasher is working correctly.
+     */
+    public function testAuthenticatingWithDrupalPassword()
+    {
+        $user = User::create([
+            'email' => 'dries.buytaert@example.com',
+            'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
+        ]);
+
+        $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
+            'email' => 'dries.buytaert@example.com',
+            'password' => 'secret',
+        ]);
+
+        // Assert response is 200 OK and has expected data
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->_id,
+                'email' => $user->email,
+            ],
+        ]);
+
+        // Assert user has been updated in the database with a newly hashed password.
+        $user = $user->fresh();
+        $this->assertArrayNotHasKey('drupal_password', $user['attributes']);
+        $this->assertArrayHasKey('password', $user['attributes']);
+
+        // Finally, let's try logging in with the newly hashed password
+        $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
+            'email' => 'dries.buytaert@example.com',
+            'password' => 'secret',
+        ]);
+        $this->assertResponseStatus(200);
+    }
+}

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Northstar\Auth\DrupalPasswordHash;
 use Northstar\Models\User;
 
 class PasswordTest extends TestCase
@@ -43,7 +44,6 @@ class PasswordTest extends TestCase
 
     /**
      * Test that updating a user's password will re-hash it.
-     * @test
      */
     public function testUpdatingUser()
     {
@@ -69,5 +69,24 @@ class PasswordTest extends TestCase
             'password' => 'secret',
         ]);
         $this->assertResponseStatus(200);
+    }
+
+    /**
+     * Test the Drupal password hasher against known good/bad
+     * password hashes.
+     */
+    public function testHashesCorrectly()
+    {
+        // Succeeds if given a good password
+        $this->assertTrue(DrupalPasswordHash::check('testtest', '$S$DYvEbMTfOWVPq5FyHhp70eXBrt8FClzE8bV8RoR8alahwR71PoLE'), 'Succeeds if given a good password');
+
+        // Fails if given a bad password
+        $this->assertFalse(DrupalPasswordHash::check('secret', '$S$DYvEbMTfOWVPq5FyHhp70eXBrt8FClzE8bV8RoR8alahwR71PoLE'), 'Fails if given a bad password');
+
+        // Can check older MD5 passwords.
+        $this->assertTrue(DrupalPasswordHash::check('derpalicious', '$P$DxTIL/YfZCdJtFYNh1Ef9ERbMBkuQ91'), 'Password check succeeds on valid MD5 password.');
+        $this->assertTrue(DrupalPasswordHash::check('derpalicious', '$H$DxTIL/YfZCdJtFYNh1Ef9ERbMBkuQ91'), 'Password check succeeds on valid MD5 password.');
+        $this->assertFalse(DrupalPasswordHash::check('nowaytraderjose', '$P$DxTIL/YfZCdJtFYNh1Ef9ERbMBkuQ91'), 'Password check fails on invalid MD5 password.');
+        $this->assertFalse(DrupalPasswordHash::check('nowaytraderjose', '$H$DxTIL/YfZCdJtFYNh1Ef9ERbMBkuQ91'), 'Password check fails on invalid MD5 password.');
     }
 }

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -40,4 +40,34 @@ class PasswordTest extends TestCase
         ]);
         $this->assertResponseStatus(200);
     }
+
+    /**
+     * Test that updating a user's password will re-hash it.
+     * @test
+     */
+    public function testUpdatingUser()
+    {
+        $user = User::create([
+            'email' => 'acquia.consultant@example.com',
+            'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
+        ]);
+
+        $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->_id, [
+            'password' => 'secret'
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // Assert user has been updated in the database with a newly hashed password.
+        $user = $user->fresh();
+        $this->assertArrayNotHasKey('drupal_password', $user['attributes']);
+        $this->assertArrayHasKey('password', $user['attributes']);
+
+        // Finally, let's try logging in with the newly hashed password
+        $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
+            'email' => 'acquia.consultant@example.com',
+            'password' => 'secret',
+        ]);
+        $this->assertResponseStatus(200);
+    }
 }

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -53,7 +53,7 @@ class PasswordTest extends TestCase
         ]);
 
         $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->_id, [
-            'password' => 'secret'
+            'password' => 'secret',
         ]);
 
         $this->assertResponseStatus(200);


### PR DESCRIPTION
#### Changes
I'm trying to figure out why some users aren't validating when we check Phoenix logins against Northstar... haven't found any big issues yet, but did figure out that we're not removing the `drupal_password` field when a user changes their password on Phoenix. (525627f)

I added some more unit tests with known good/bad Drupal password hashes as well (acc164c).

Finally, an unrelated change: I moved shared controller methods into traits, rather than having them all on the base `Controller` class. This makes it a bit easier to skim, and will make it easier to yank them out into a shared package at some point. (cd1e643)

#### How should this be reviewed?
I'd recommend going commit-by-commit. :1234: 

#### How should this be tested?
:traffic_light: 

---
For review: @angaither @weerd 