### PR TITLE
Error formatz

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -24,9 +24,11 @@ abstract class Controller extends BaseController
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {
         $response = [
-            'code' => 422,
-            'message' => 'Failed validation.',
-            'errors' => $errors,
+            'error' => [
+                'code' => 422,
+                'message' => 'Failed validation.',
+                'fields' => $errors,
+            ],
         ];
 
         return response()->json($response, 422);

--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -109,6 +109,7 @@ trait TransformsResponses
     {
         $response = [
             $status => [
+                'code' => $code,
                 'message' => $message,
             ],
         ];

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -123,6 +123,12 @@ of the problem:
     "error": {
         "code": 418,
         "message": "Tea. Earl Grey. Hot."
+        
+        // For 422 Unprocessable Entity, the "fields" object has specific validation errors:
+        "fields": {
+          "email": ["The email must be a valid email address."],
+          "mobile": ["The mobile has already been taken."]
+        }
     },
     // When running locally, debug information will be included in the response:
     "debug": {

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -102,8 +102,8 @@ Pagination & other meta-information may be provided in a `meta` key on the respo
 
 ### Errors & Status Codes
 Northstar returns standard HTTP status codes to indicate how a request turned out. In general, `2xx` codes are returned
-on successful requests, `4xx` requests indicate an error due to improper user input, and `5xx` error codes indicate an
-unexpected problem on the API end.
+on successful requests, `4xx` codes indicate an error in the request, and `5xx` error codes indicate an unexpected 
+problem on the API end.
 
 Code | Meaning
 ---- | -------
@@ -112,6 +112,7 @@ Code | Meaning
 403  | __Forbidden__ – The authenticated user doesn't have the proper privileges.
 404  | __Not Found__ – The specified resource could not be found.
 418  | __I'm a teapot__ – The user [needs more caffeine](https://www.ietf.org/rfc/rfc2324.txt).
+422  | __Unprocessable Entity__ – The request couldn't be completed due to validation errors. See the `error.fields` property on the response.
 500  | __Internal Server Error__ – Northstar has encountered an internal error. Please [make a bug report](https://github.com/DoSomething/northstar/issues/new) with as much detail as possible about what led to the error!
 503  | __Service Unavailable__ – Northstar is temporarily unavailable.
 

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -138,6 +138,7 @@ curl -X POST \
 
 {
   "success": {
+    "code": 200,
     "message": "User logged out successfully."
   }
 }

--- a/documentation/endpoints/keys.md
+++ b/documentation/endpoints/keys.md
@@ -196,6 +196,7 @@ curl -X DELETE \
 
 {
   "success": {
+    "code": 200,
     "message": "Deleted key."
   }
 }

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -313,6 +313,7 @@ curl -X DELETE \
 
 {
     "success": {
+        "code": 200,
         "message": "No Content."
     }
 }


### PR DESCRIPTION
#### Changes
Up for discussion, but two changes based on feedback by @aaronschachter:

1. Add a `code` to the `respond()` method on the controller, so it's consistent with error responses.
2. Wrap `422 Unprocessable entity` validation errors in `error` object, so it's consistent with other error codes. Since `error.errors` seems a bit strange, maybe we should rename that to `fields` since it's an array of errors per field?

I did a quick search through each of the app repositories and it doesn't look like this will _break break_ anything, but [any code that looks for those individual field errors](https://github.com/DoSomething/LetsDoThis-Android/blob/52422e7f8170d942cb756f2b9aed1f05be284a06/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java#L85-L91) will have to be updated to check for the new "path" in the object.

---
For review: @angaither @weerd @jonuy
/cc @aaronschachter @jonuy 