### PR TITLE
Fix registration and login issues.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -51,10 +51,10 @@ class Registrar
     }
 
     /**
-     * Normalize the given credentials (either before validating, or
-     * before saving to the database).
+     * Normalize the given credentials in the array or request (for example, before
+     * validating, or before saving to the database).
      *
-     * @param $credentials
+     * @param \ArrayAccess|array $credentials
      * @return mixed
      */
     public function normalize($credentials)

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -51,6 +51,26 @@ class Registrar
     }
 
     /**
+     * Normalize the given credentials (either before validating, or
+     * before saving to the database).
+     *
+     * @param $credentials
+     * @return mixed
+     */
+    public function normalize($credentials)
+    {
+        if (! empty($credentials['email'])) {
+            $credentials['email'] = strtolower($credentials['email']);
+        }
+
+        if (! empty($credentials['mobile'])) {
+            $credentials ['mobile'] = preg_replace('/[^0-9]/', '', $credentials['mobile']);
+        }
+
+        return $credentials;
+    }
+
+    /**
      * Resolve a user account from the given credentials.
      *
      * @param array $credentials
@@ -58,13 +78,13 @@ class Registrar
      */
     public function resolve($credentials)
     {
-        if ($credentials['email']) {
-            $email = strtolower($credentials['email']);
+        $credentials = $this->normalize($credentials);
 
-            return User::where('email', $email)->first();
+        if (! empty($credentials['email'])) {
+            return User::where('email', $credentials['email'])->first();
         }
 
-        if ($credentials['mobile']) {
+        if (! empty($credentials['mobile'])) {
             return User::where('mobile', $credentials['mobile'])->first();
         }
     }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -120,6 +120,7 @@ class AuthController extends Controller
      */
     public function register(Request $request)
     {
+        $request = $this->registrar->normalize($request);
         $this->validate($request, [
             'email' => 'email|max:60|unique:users|required_without:mobile',
             'mobile' => 'unique:users|required_without:email',

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -6,20 +6,29 @@ use Northstar\Models\User;
 class AuthTest extends TestCase
 {
     /**
-     * Test for logging in a user
-     * POST /login
+     * Test for logging in a user by email.
      * POST /auth/token
      *
      * @return void
      */
-    public function testLogin()
+    public function testLoginByEmail()
     {
-        // User login info
         $credentials = [
-            'email' => 'test@dosomething.org',
+            'email' => 'login-test@dosomething.org',
             'password' => 'secret',
         ];
 
+        // Create user to attempt to log in as.
+        User::create($credentials);
+
+        // Test logging in with bogus info
+        $this->withScopes(['user'])->json('POST', 'v1/auth/token', [
+            'email' => 'login-test@dosomething.org',
+            'password' => 'letmein',
+        ]);
+        $this->assertResponseStatus(401);
+
+        // Test with the right credentials
         $this->withScopes(['user'])->json('POST', 'v1/auth/token', $credentials);
         $this->assertResponseStatus(201);
         $this->seeJsonStructure([

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -8,6 +8,7 @@ class AuthTest extends TestCase
     /**
      * Test for logging in a user
      * POST /login
+     * POST /auth/token
      *
      * @return void
      */
@@ -41,6 +42,7 @@ class AuthTest extends TestCase
     /**
      * Test for logging in a user
      * POST /login
+     * POST /auth/verify
      *
      * @return void
      */
@@ -55,6 +57,32 @@ class AuthTest extends TestCase
         $this->seeJsonStructure([
             'data' => [
                 'id',
+            ],
+        ]);
+    }
+
+    /**
+     * Test for registering in a user
+     * POST /auth/register
+     *
+     * @return void
+     */
+    public function testRegister()
+    {
+        $this->withScopes(['user'])->json('POST', 'v1/auth/register', [
+            'email' => 'test-registration@dosomething.org',
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'data' => [
+                'key',
+                'user' => [
+                    'data' => [
+                        'id',
+                    ],
+                ],
             ],
         ]);
     }

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -133,6 +133,23 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test that you can't register a duplicate user.
+     * POST /auth/register
+     *
+     * @return void
+     */
+    public function testRegisterDuplicate()
+    {
+        // Try to register an account that already exists, but with different capitalization
+        $this->withScopes(['user'])->json('POST', 'v1/auth/register', [
+            'email' => 'TEST@dosomething.org',
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /**
      * Test for logging out a user
      * POST /logout
      *

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -49,8 +49,44 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test for logging in a user by mobile.
+     * POST /auth/token
+     *
+     * @return void
+     */
+    public function testLoginByMobile()
+    {
+        // Create user to attempt to log in as.
+        User::create([
+            'mobile' => '5551234455',
+            'password' => 'secret',
+        ]);
+
+        $this->withScopes(['user'])->json('POST', 'v1/auth/token', [
+            'mobile' => '(555) 123-4455',
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(201);
+        $this->seeJsonStructure([
+            'data' => [
+                'key',
+                'user' => [
+                    'data' => [
+                        'id',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Assert token given in the response also exists in database
+        $this->seeInDatabase('tokens', [
+            'key' => $this->decodeResponseJson()['data']['key'],
+        ]);
+    }
+
+    /**
      * Test for logging in a user
-     * POST /login
      * POST /auth/verify
      *
      * @return void


### PR DESCRIPTION
#### Changes
This PR adds two fixes for the login and registration flows:

:bug: Fixes logging in by mobile. Previously the user had to be a machine and strip out special characters themselves in order to resolve the right account. Now they can be human and just go wild with all the characters - we'll strip out non-numeric ones before trying to find it in the database.

:bug: Fixes #303. Previously, duplicate users could be created on registration if you used a different capitalization. To fix that, we run the mutators for unique fields (`email` and `mobile`) before running the validator, so it checks the thing it should be checking!

#### How should this be reviewed?
I tried a red-green-refactor thing for fun, so reviewing commit-by-commit will first add a failing test for things that are wrong, and then a fix for that failing test in the following commit. :traffic_light: 

---
For review: @angaither @weerd 
/cc @aaronschachter @jonuy 