### PR TITLE
Limit results to 100 per page.

### DIFF
--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -85,13 +85,15 @@ trait TransformsResponses
             $transformer = $this->transformer;
         }
 
-        $paginator = $query->paginate((int) $request->query('limit', 20));
-
-        $resource = new FractalCollection($paginator->getCollection(), $transformer);
-        $resource->setMeta($meta);
+        $pages = (int) $request->query('limit', 20);
+        $paginator = $query->paginate(min($pages, 100));
 
         $queryParams = array_diff_key($request->query(), array_flip(['page']));
         $paginator->appends($queryParams);
+
+        $resource = new FractalCollection($paginator->getCollection(), $transformer);
+
+        $resource->setMeta($meta);
         $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
 
         return $this->transform($resource, $code);

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -8,7 +8,7 @@ GET /users
 
 **Additional Query Parameters:**
 
-- `limit`: Set the number of results you want to receive per page. Default is 20.
+- `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v1/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.
 - `search`: Search the collection for users with fields whose value match the query. For example, `/v1/users?search[_id]=test@example.com&search[email]=test@example.org` would return all users with either an ID or email address matching `test@example.org`. You can search by one or more indexed fields. This is limited to admin-scoped API keys!

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -70,6 +70,32 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test retrieving multiple users.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testIndexPagination()
+    {
+        $this->get('v1/users?limit=200'); // set a "per page" above the allowed max
+        $this->assertResponseStatus(200);
+        $this->assertSame(100, $this->decodeResponseJson()['meta']['pagination']['per_page']);
+
+        $this->seeJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total', 'count', 'per_page', 'current_page', 'links',
+                ],
+            ],
+        ]);
+    }
+
+    /**
      * Test for retrieving a nonexistent User
      * GET /users/_id/FAKE
      *


### PR DESCRIPTION
#### Changes
Teeny thing that occurred to me the other night. A malicious user could have entered like 9001 users per page and we would have been all like “ok” and chugged along to process a monstrous response. Instead, let's set a reasonable limit of 100 per page and save ourselves the trouble.

---
For review: @angaither @weerd @jonuy 