### PR TITLE
Fixes more dupe bugs...

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -144,6 +144,7 @@ class UserController extends Controller
             throw new NotFoundHttpException('The resource does not exist.');
         }
 
+        $request = $this->registrar->normalize($request);
         $this->validate($request, [
             'email' => 'email|max:60|unique:users,email,'.$user->id.',_id',
             'mobile' => 'unique:users,mobile,'.$user->id.',_id',

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -168,12 +168,12 @@ class UserController extends Controller
     {
         $user = User::where('_id', $id)->first();
 
-        if ($user instanceof User) {
-            $user->delete();
-
-            return $this->respond('No Content.');
-        } else {
+        if (! $user) {
             throw new NotFoundHttpException('The resource does not exist.');
         }
+
+        $user->delete();
+
+        return $this->respond('No Content.');
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -78,6 +78,7 @@ class UserController extends Controller
 
         // Validate format & index uniqueness (excluding the profile being updated, if one exists)
         $existingId = isset($user->id) ? $user->id : 'null';
+        $request = $this->registrar->normalize($request);
         $this->validate($request, [
             'email' => 'email|max:60|unique:users,email,'.$existingId.',_id|required_without:mobile',
             'mobile' => 'unique:users,mobile,'.$existingId.',_id|required_without:email',

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -46,7 +46,6 @@ class UserController extends Controller
     /**
      * Display a listing of the resource.
      * GET /users
-     * GET /users?attr1=value1&attr2=value2&...
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
@@ -73,8 +72,8 @@ class UserController extends Controller
     public function store(Request $request)
     {
         // This is an "upsert" endpoint (so it will either create a new user, or
-        // update a user if one with a matching email or mobile number is found.
-        // So... does this user exist already?
+        // update a user if one with a matching email or mobile number is found).
+        // So, does this user exist already?
         $user = $this->registrar->resolve($request->only('email', 'mobile'));
 
         // Validate format & index uniqueness (excluding the profile being updated, if one exists)
@@ -105,10 +104,8 @@ class UserController extends Controller
      * Display the specified resource.
      * GET /users/:term/:id
      *
-     * @param $term - string
-     *   term to search by (eg. mobile, drupal_id, id, email, etc)
-     * @param $id - string
-     *  the actual value to search for
+     * @param string $term - term to search by (eg. mobile, drupal_id, id, email, etc)
+     * @param string $id - the actual value to search for
      *
      * @return \Illuminate\Http\Response
      * @throws NotFoundHttpException
@@ -129,10 +126,8 @@ class UserController extends Controller
      * Update the specified resource in storage.
      * PUT /users/:term/:id
      *
-     * @param $term - string
-     *   term to search by (eg. drupal_id, _id)
-     * @param $id - string
-     *   the actual value to search for
+     * @param string $term - term to search by (eg. mobile, drupal_id, id, email, etc)
+     * @param string $id - the actual value to search for
      * @param Request $request
      *
      * @return \Illuminate\Http\Response

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -213,6 +213,28 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test that we can't create a duplicate user by saving a user
+     * with a different capitalization in their email.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testCantCreateDuplicateUserByIndexCapitalization()
+    {
+        $user = User::create([
+            'email' => 'existing-user@dosomething.org',
+        ]);
+
+        $this->withScopes(['admin'])->json('POST', 'v1/users', [
+            'email' => 'EXISTING-USER@dosomething.org',
+            'source' => 'phpunit',
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->assertSame($this->decodeResponseJson()['data']['id'], $user->_id);
+    }
+
+    /**
      * Test for creating a new user.
      * POST /users
      *

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -216,8 +216,6 @@ class UserTest extends TestCase
      * Test that we can't create a duplicate user by saving a user
      * with a different capitalization in their email.
      * POST /users
-     *
-     * @return void
      */
     public function testCantCreateDuplicateUserByIndexCapitalization()
     {
@@ -227,6 +225,27 @@ class UserTest extends TestCase
 
         $this->withScopes(['admin'])->json('POST', 'v1/users', [
             'email' => 'EXISTING-USER@dosomething.org',
+            'source' => 'phpunit',
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->assertSame($this->decodeResponseJson()['data']['id'], $user->_id);
+    }
+
+    /**
+     * Test that we can't create a duplicate user by "upserting" an existing
+     * user and adding a new index in that operation.
+     * POST /users
+     */
+    public function testCanUpsertWithAnAdditionalIndex()
+    {
+        $user = User::create([
+            'mobile' => '2035551238',
+        ]);
+
+        $this->withScopes(['admin'])->json('POST', 'v1/users', [
+            'email' => 'lalalala@dosomething.org',
+            'mobile' => '2035551238',
             'source' => 'phpunit',
         ]);
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -213,6 +213,29 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test for creating a new user.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testCreateUser()
+    {
+        // Create a new user object
+        $payload = [
+            'email' => 'new@dosomething.org',
+            'source' => 'phpunit',
+        ];
+
+        $this->withScopes(['admin'])->json('POST', 'v1/users', $payload);
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'data' => [
+                'id', 'email', 'source', 'created_at',
+            ],
+        ]);
+    }
+
+    /**
      * Test that we can't create a duplicate user.
      * POST /users
      *
@@ -274,29 +297,6 @@ class UserTest extends TestCase
 
         $this->assertResponseStatus(200);
         $this->assertSame($this->decodeResponseJson()['data']['id'], $user->_id);
-    }
-
-    /**
-     * Test for creating a new user.
-     * POST /users
-     *
-     * @return void
-     */
-    public function testCreateUser()
-    {
-        // Create a new user object
-        $payload = [
-            'email' => 'new@dosomething.org',
-            'source' => 'phpunit',
-        ];
-
-        $this->withScopes(['admin'])->json('POST', 'v1/users', $payload);
-        $this->assertResponseStatus(200);
-        $this->seeJsonStructure([
-            'data' => [
-                'id', 'email', 'source', 'created_at',
-            ],
-        ]);
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -322,7 +322,7 @@ class UserTest extends TestCase
     {
         // Create a new user object
         $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/5480c950bffebc651c8b456f', [
-            'email' => 'newemail@dosomething.org',
+            'email' => 'NewEmail@dosomething.org',
             'parse_installation_ids' => 'parse-abc123',
         ]);
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -213,6 +213,29 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test that we can't create a duplicate user.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testCreateDuplicateUser()
+    {
+        User::create(['mobile' => '1235557878']);
+        User::create(['email' => 'existing-person@example.com']);
+
+        // Create a new user object
+        $payload = [
+            'email' => 'Existing-Person@example.com',
+            'mobile' => '(123) 555-7878',
+            'source' => 'phpunit',
+        ];
+
+        // This should upsert the existing user.
+        $this->withScopes(['admin'])->json('POST', 'v1/users', $payload);
+        $this->assertResponseStatus(422);
+    }
+
+    /**
      * Test that we can't create a duplicate user by saving a user
      * with a different capitalization in their email.
      * POST /users

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -345,6 +345,23 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test that we can't update a user's profile to have duplicate
+     * identifiers with someone else.
+     * PUT /users/_id/:id
+     */
+    public function testUpdateWithConflict()
+    {
+        $user = User::create(['email' => 'admiral.ackbar@example.com']);
+        $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
+            'mobile' => '(555) 555-0101', // a different existing user account
+            'first_name' => 'Gial',
+            'last_name' => 'Ackbar',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /**
      * Test for creating a user's profile image with a file
      * POST /users/:user_id/avatar
      *


### PR DESCRIPTION
#### Changes
Found some more bugs that were allowing dupes to be created:

:bug: Fixes issue where you could create a duplicate user by "upserting" from the `POST users/` endpoint with one index that matched an existing user and one that did not.

:beetle: Fix issue where you could update a user's profile to have a duplicate ID if you used a non-normalized form of that index field (like with capital letters or symbols or stuff).

#### Test this, how do I?
Check 'em, commit-by-commit! Red ones are bugs I found, green ones are fixes or refactors. :traffic_light: 

---
For review: @angaither @weerd 