### PR TITLE
Fix verification when user includes a space in their email.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -60,7 +60,7 @@ class Registrar
     public function normalize($credentials)
     {
         if (! empty($credentials['email'])) {
-            $credentials['email'] = strtolower($credentials['email']);
+            $credentials['email'] = trim(strtolower($credentials['email']));
         }
 
         if (! empty($credentials['mobile'])) {

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -65,6 +65,7 @@ class AuthController extends Controller
      */
     public function verify(Request $request)
     {
+        $request = $this->registrar->normalize($request);
         $this->validate($request, [
             'email' => 'email|required_without:mobile',
             'mobile' => 'required_without:email',

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -107,6 +107,27 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test for logging in a user, but wildly!
+     * POST /auth/verify
+     *
+     * @return void
+     */
+    public function testNormalizedVerify()
+    {
+        $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
+            'email' => 'Test@dosomething.org ', // <-- a trailing space!? the nerve!
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'data' => [
+                'id',
+            ],
+        ]);
+    }
+
+    /**
      * Test for registering in a user
      * POST /auth/register
      *


### PR DESCRIPTION
#### Changes
Some users were being _SLOPPY_ and including a trailing space in their emails. The nerve! This normalizes those values before validating or checking for them in the database. :relieved: 

---
For review: @angaither @weerd 