### PR TITLE
Speed up test suite & expose Faker to test cases.

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -6,6 +6,16 @@ use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Model;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
+/**
+ * The API key model. These identify the "client application" making
+ * a request, and their associated privileges.
+ *
+ * @property string $id
+ * @property string $_id
+ * @property string $app_id
+ * @property string $api_key
+ * @property array $scope
+ */
 class ApiKey extends Model
 {
     /**

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -5,6 +5,15 @@ namespace Northstar\Models;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Model;
 
+/**
+ * The Authentication Token model. These are used to make
+ * requests on behalf of an authenticated user account.
+ *
+ * @property string $id
+ * @property string $_id
+ * @property string $key
+ * @property string $user_id
+ */
 class Token extends Model
 {
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Models;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Jenssegers\Mongodb\Model;
 use Illuminate\Auth\Authenticatable;
@@ -9,6 +10,54 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Hash;
 
+/**
+ * The User model. (Fight for the user!)
+ *
+ * @property string $_id - The MongoDB ObjectID
+ * @property string $id - Aliased to _id by laravel-mongodb
+ * @property string $email
+ * @property string $mobile
+ * @property string $password
+ * @property string $drupal_password - Hashed password imported from Phoenix
+ * @property string $first_name
+ * @property string $last_name
+ * @property string $birthdate
+ * @property string $photo
+ * @property array  $interests
+ * @property string $source
+ *
+ * @property string $addr_street1
+ * @property string $addr_street2
+ * @property string $addr_city
+ * @property string $addr_state
+ * @property string $addr_zip
+ * @property string $country
+ * @property string $language
+ *
+ * We also collect a bunch of fields from Niche.com users:
+ * @property string $race
+ * @property string $religion
+ * @property string $school_id
+ * @property string $college_name
+ * @property string $degree_type
+ * @property string $major_name
+ * @property string $hs_gradyear
+ * @property string $hs_name
+ * @property int $sat_math
+ * @property int $sat_verbal
+ * @property int $sat_writing
+ *
+ * And we store some external service IDs for hooking things together:
+ * @property string $mobilecommons_id
+ * @property string $mobilecommons_status
+ * @property string $cgg_id
+ * @property string $drupal_id
+ * @property string $agg_id
+ * @property array  $parse_installation_ids
+ *
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
 class User extends Model implements AuthenticatableContract, AuthorizableContract
 {
     use Authenticatable, Authorizable;
@@ -46,7 +95,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * Attributes that can be queried as unique identifiers.
      *
      * This array is manually maintained. It does not necessarily mean that
-     * they are actual indexes on the database.
+     * any of these are actual indexes on the database... but they should be!
      *
      * @var array
      */
@@ -55,7 +104,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
-     * The attributes excluded from the model's JSON form.
+     * The attributes that should be hidden for arrays.
      *
      * @var array
      */

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Define all of our model factories. Model factories give
+ * you a convenient way to create models for testing and seeding your
+ * database. Just tell the factory how a default model should look.
+ *
+ * @var \Illuminate\Database\Eloquent\Factory $factory
+ */
+$factory->define(Northstar\Models\User::class, function (Faker\Generator $faker) {
+    return [
+        'first_name' => $faker->firstName,
+        'last_name' => $faker->optional(0.5)->lastName,
+        'email' => $faker->unique()->safeEmail,
+        'mobile' => $faker->unique()->phoneNumber,
+        'password' => $faker->password,
+        'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),
+        'addr_street1' => $faker->streetAddress,
+        'city' => $faker->city,
+        'addr_state' => $faker->stateAbbr,
+        'addr_zip' => $faker->postcode,
+        'country' => $faker->countryCode,
+        'language' => $faker->languageCode,
+        'drupal_id' => $faker->numberBetween(1, 400000),
+        'source' => $faker->randomElement(['phoenix', 'cgg', 'agg', 'sms']),
+    ];
+});

--- a/database/seeds/TokenTableSeeder.php
+++ b/database/seeds/TokenTableSeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Northstar\Models\Token;
 
 class TokenTableSeeder extends Seeder
 {

--- a/database/seeds/TokenTableSeeder.php
+++ b/database/seeds/TokenTableSeeder.php
@@ -13,20 +13,5 @@ class TokenTableSeeder extends Seeder
     public function run()
     {
         DB::table('tokens')->delete();
-
-        Token::create([
-            'key' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz0=',
-            'user_id' => '5480c950bffebc651c8b456f',
-        ]);
-
-        Token::create([
-            'key' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz1=',
-            'user_id' => 'bf1039b0271bcc636aa5477c',
-        ]);
-
-        Token::create([
-            'key' => 'S0FyZmlRNmVpMzVsSzJMNUFreEFWa3g0RHBMWlJRd0tiQmhSRUNxWXh6cz2=',
-            'user_id' => 'bf1039b0271bcc636aa5477c',
-        ]);
     }
 }

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -16,7 +16,6 @@ class UserTableSeeder extends Seeder
         // Without this line, the unit tests fail.
         DB::table('users')->delete();
 
-        // Non-signed up user
         User::create([
             '_id' => '5430e850dt8hbc541c37tt3d',
             'email' => 'test@dosomething.org',
@@ -34,7 +33,6 @@ class UserTableSeeder extends Seeder
             'last_name' => 'Last',
         ]);
 
-        // Signed up user
         User::create([
             '_id' => '5480c950bffebc651c8b456f',
             'email' => 'test1@dosomething.org',
@@ -51,142 +49,9 @@ class UserTableSeeder extends Seeder
             'first_name' => 'First',
             'last_name' => 'Last',
             'parse_installation_ids' => 'parse-abc123',
-            'campaigns' => [
-                [
-                    '_id' => '5480c950bffebc651c8b456e',
-                    'drupal_id' => '123',
-                    'signup_id' => '100',
-                    'signup_source' => 'android',
-                ],
-            ],
         ]);
 
-        // Reported back user
-        User::create([
-            '_id' => 'bf1039b0271bcc636aa5477a',
-            'email' => 'test2@dosomething.org',
-            'mobile' => '5555550102',
-            'password' => 'secret',
-            'drupal_id' => '100003',
-            'addr_street1' => '123',
-            'addr_street2' => '456',
-            'addr_city' => 'Paris',
-            'addr_state' => 'Florida',
-            'addr_zip' => '555555',
-            'country' => 'US',
-            'birthdate' => '12/17/91',
-            'first_name' => 'First',
-            'last_name' => 'Last',
-            'campaigns' => [
-                [
-                    '_id' => '3f10c910251bcc636aa5477a',
-                    'drupal_id' => '123',
-                    'signup_id' => '101',
-                    'signup_source' => 'ios',
-                    'reportback_id' => '125',
-                ],
-            ],
-        ]);
-
-        // User invited to campaign
-        User::create([
-            '_id' => 'bf1039b0271bcc636aa5477b',
-            'email' => 'test3@dosomething.org',
-            'mobile' => '5555550102',
-            'password' => 'secret',
-            'drupal_id' => '100004',
-            'birthdate' => '12/17/91',
-            'campaigns' => [
-                [
-                    '_id' => '3f10c910251bcc636aa5477b',
-                    'drupal_id' => '123',
-                    'signup_id' => '102',
-                    'signup_source' => 'test',
-                    'signup_group' => '100',
-                ],
-            ],
-        ]);
-
-        // Parse user to be logged out
-        User::create([
-            '_id' => 'bf1039b0271bcc636aa5477c',
-            'parse_installation_ids' => 'parse-abc123',
-        ]);
-
-        // User 1 for push notification tests
-        User::create([
-            '_id' => 'bf1039b0271bcc636aa5477d',
-            'drupal_id' => '100005',
-            'parse_installation_ids' => 'parse-100',
-            'campaigns' => [
-                [
-                    'drupal_id' => '123',
-                    'signup_id' => '200',
-                    'signup_source' => 'test',
-                    'signup_group' => '200',
-                ],
-            ],
-        ]);
-
-        // User 2 for push notification tests
-        User::create([
-            '_id' => 'bf1039b0271bcc636aa5477e',
-            'drupal_id' => '100006',
-            'first_name' => 'Push',
-            'last_name' => 'User',
-            'parse_installation_ids' => 'parse-101',
-            'campaigns' => [
-                [
-                    'drupal_id' => '123',
-                    'signup_id' => '201',
-                    'signup_source' => 'test',
-                    'signup_group' => '200',
-                    'reportback_id' => '1000',
-                ],
-            ],
-        ]);
-
-        User::create([
-            'email' => 'info@dosomething.org',
-            'mobile' => '5555550104',
-            'password' => 'secret',
-            'drupal_id' => '456788',
-            'addr_street1' => '456',
-            'addr_street2' => '33',
-            'addr_city' => 'Example',
-            'addr_state' => 'Testing',
-            'addr_zip' => '555555',
-            'country' => 'US',
-            'birthdate' => '12/17/91',
-            'first_name' => 'John',
-            'last_name' => 'Doe',
-        ]);
-
-        User::create([
-            '_id' => '5480c950bffebc651c8b4570',
-            'email' => 'delete-test@ds.org',
-            'password' => 'secret',
-        ]);
-
-        // User with a drupal_password but no password
-        User::create([
-            '_id' => '5430e850dt8hbc541c37cal3',
-            'email' => 'test4@dosomething.org',
-            'mobile' => '5555550103',
-            'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
-            'drupal_id' => '100007',
-            'addr_street1' => '123',
-            'addr_street2' => '456',
-            'addr_city' => 'Paris',
-            'addr_state' => 'Florida',
-            'addr_zip' => '555555',
-            'country' => 'US',
-            'birthdate' => '12/17/91',
-            'first_name' => 'First',
-            'last_name' => 'Last',
-        ]);
-
-        if (App::environment('local')) {
+        if (app()->environment('local')) {
             $faker = Faker\Factory::create();
             foreach (range(1, 50) as $index) {
                 User::create([

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -12,10 +12,10 @@ class UserTableSeeder extends Seeder
      */
     public function run()
     {
-        // @TODO: Why is this being called... it's called for each unit test.
-        // Without this line, the unit tests fail.
+        // Clear the database.
         DB::table('users')->delete();
 
+        // Create a user with a predetermined ID to use when manually testing endpoints.
         User::create([
             '_id' => '5430e850dt8hbc541c37tt3d',
             'email' => 'test@dosomething.org',
@@ -31,46 +31,10 @@ class UserTableSeeder extends Seeder
             'birthdate' => '12/17/91',
             'first_name' => 'First',
             'last_name' => 'Last',
-        ]);
-
-        User::create([
-            '_id' => '5480c950bffebc651c8b456f',
-            'email' => 'test1@dosomething.org',
-            'mobile' => '5555550101',
-            'password' => 'secret',
-            'drupal_id' => '100002',
-            'addr_street1' => '123',
-            'addr_street2' => '456',
-            'addr_city' => 'Paris',
-            'addr_state' => 'Florida',
-            'addr_zip' => '555555',
-            'country' => 'US',
-            'birthdate' => '12/17/91',
-            'first_name' => 'First',
-            'last_name' => 'Last',
             'parse_installation_ids' => 'parse-abc123',
         ]);
 
-        if (app()->environment('local')) {
-            $faker = Faker\Factory::create();
-            foreach (range(1, 50) as $index) {
-                User::create([
-                    'first_name' => $faker->firstName,
-                    'last_name' => $faker->lastName,
-                    'email' => $faker->unique()->safeEmail,
-                    'mobile' => $faker->unique()->phoneNumber,
-                    'password' => 'secret',
-                    'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),
-                    'addr_street1' => $faker->streetAddress,
-                    'addr_street2' => $faker->secondaryAddress,
-                    'city' => $faker->city,
-                    'addr_state' => $faker->state,
-                    'addr_zip' => $faker->postcode,
-                    'country' => $faker->country,
-                    'cgg_id' => $index,
-                    'source' => $faker->randomElement(['cgg', 'drupal', 'agg', 'services']),
-                ]);
-            }
-        }
+        // Then create a bunch of randomly-generated test data!
+        factory(User::class, 250)->create();
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,7 @@
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="DB_NAME" value="northstar-test"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Northstar\Models\Token;
 use Northstar\Models\User;
 
 class AuthTest extends TestCase
@@ -93,8 +92,13 @@ class AuthTest extends TestCase
      */
     public function testVerify()
     {
+        User::create([
+            'email' => 'verify-test@dosomething.org',
+            'password' => 'secret',
+        ]);
+
         $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
-            'email' => 'test@dosomething.org',
+            'email' => 'verify-test@dosomething.org',
             'password' => 'secret',
         ]);
 
@@ -114,8 +118,13 @@ class AuthTest extends TestCase
      */
     public function testNormalizedVerify()
     {
+        User::create([
+            'email' => 'normalized-verify@dosomething.org',
+            'password' => 'secret',
+        ]);
+
         $this->withScopes(['user'])->json('POST', 'v1/auth/verify', [
-            'email' => 'Test@dosomething.org ', // <-- a trailing space!? the nerve!
+            'email' => 'Normalized-Verify@dosomething.org ', // <-- a trailing space!? the nerve!
             'password' => 'secret',
         ]);
 
@@ -161,9 +170,13 @@ class AuthTest extends TestCase
      */
     public function testRegisterDuplicate()
     {
+        User::create([
+            'email' => 'fn-2187@first-order.mil',
+        ]);
+
         // Try to register an account that already exists, but with different capitalization
         $this->withScopes(['user'])->json('POST', 'v1/auth/register', [
-            'email' => 'TEST@dosomething.org',
+            'email' => 'FN-2187@First-Order.mil',
             'password' => 'secret',
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,7 +71,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function withScopes(array $scopes)
     {
         $key = ApiKey::create([
-            'app_id' => 'testing'.time(),
+            'app_id' => 'testing'.$this->faker->uuid,
             'scope' => $scopes,
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,9 +22,25 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
         'HTTP_Accept' => 'application/json',
     ];
 
+    /**
+     * The Faker generator, for creating test data.
+     *
+     * @var \Faker\Generator
+     */
+    protected $faker;
+
+    /**
+     * Setup the test environment. This is run before *every* single
+     * test method, so avoid doing anything that takes too much time!
+     *
+     * @return void
+     */
     public function setUp()
     {
         parent::setUp();
+
+        // Get a new Faker generator from Laravel.
+        $this->faker = app(\Faker\Generator::class);
 
         // Reset the testing database & run migrations.
         $this->app->make('db')->getMongoDB()->drop();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,9 +26,9 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     {
         parent::setUp();
 
-        // Migrate & seed a fresh copy of the database before each test case.
+        // Reset the testing database & run migrations.
+        $this->app->make('db')->getMongoDB()->drop();
         $this->artisan('migrate');
-        $this->seed();
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -12,12 +12,18 @@ class UserTest extends TestCase
      */
     public function testGetPublicDataFromUser()
     {
-        // Test that we can view public profile of a seeded user.
-        $this->withScopes(['user'])->get('v1/users/email/test@dosomething.org');
+        $user = User::create([
+            'email' => $this->faker->unique()->email,
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+        ]);
+
+        // Test that we can view public profile of the user.
+        $this->withScopes(['user'])->get('v1/users/_id/'.$user->id);
         $this->assertResponseStatus(200);
         $this->seeJsonStructure([
             'data' => [
-                'id', 'email',
+                'id', 'email', 'first_name',
             ],
         ]);
 
@@ -33,13 +39,19 @@ class UserTest extends TestCase
      */
     public function testGetAllDataFromUser()
     {
-        $this->withScopes(['user', 'admin'])->get('v1/users/email/test@dosomething.org');
+        $user = User::create([
+            'email' => $this->faker->unique()->email,
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+        ]);
+
+        $this->withScopes(['user', 'admin'])->get('v1/users/_id/'.$user->id);
         $this->assertResponseStatus(200);
 
         // Check that public & private profile fields are visible
         $this->seeJsonStructure([
             'data' => [
-                'id', 'email', 'last_name',
+                'id', 'email', 'first_name', 'last_name',
             ],
         ]);
     }
@@ -52,9 +64,11 @@ class UserTest extends TestCase
      */
     public function testIndex()
     {
+        // Make some test users to see in the index.
+        factory(User::class, 5)->create();
+
         $this->get('v1/users');
         $this->assertResponseStatus(200);
-
         $this->seeJsonStructure([
             'data' => [
                 '*' => [
@@ -77,6 +91,9 @@ class UserTest extends TestCase
      */
     public function testIndexPagination()
     {
+        // Make some test users to see in the index.
+        factory(User::class, 5)->create();
+
         $this->get('v1/users?limit=200'); // set a "per page" above the allowed max
         $this->assertResponseStatus(200);
         $this->assertSame(100, $this->decodeResponseJson()['meta']['pagination']['per_page']);
@@ -114,9 +131,9 @@ class UserTest extends TestCase
      */
     public function testFilterUsersById()
     {
-        $user1 = User::create(['email' => '123142512@example.com', 'drupal_id' => '123411']);
-        $user2 = User::create(['email' => '123513511@example.com', 'drupal_id' => '123412']);
-        $user3 = User::create(['drupal_id' => '123413']);
+        $user1 = User::create(['email' => $this->faker->unique()->email, 'drupal_id' => '123411']);
+        $user2 = User::create(['email' => $this->faker->unique()->email, 'drupal_id' => '123412']);
+        $user3 = User::create(['mobile' => $this->faker->unique()->phoneNumber, 'drupal_id' => '123413']);
 
         // Retrieve multiple users by _id
         $this->get('v1/users?filter[_id]='.$user1->id.','.$user2->id.',FAKE_ID');
@@ -147,13 +164,18 @@ class UserTest extends TestCase
      */
     public function testSearchUsers()
     {
+        // Make a test user to search for.
+        User::create([
+            'email' => 'search-result@dosomething.org',
+        ]);
+
         // Search should be limited to `admin` scoped keys.
-        $this->get('v1/users?search[email]=test@dosomething.org');
+        $this->get('v1/users?search[email]=search-result@dosomething.org');
         $this->assertResponseStatus(403);
 
         // Query by a "known" search term
         $this->withScopes(['admin'])
-            ->get('v1/users?search[_id]=test@dosomething.org&search[email]=test@dosomething.org');
+            ->get('v1/users?search[_id]=search-result@dosomething.org&search[email]=search-result@dosomething.org');
         $this->assertResponseStatus(200);
 
         // There should be one match (a user with the provided email)
@@ -347,8 +369,10 @@ class UserTest extends TestCase
      */
     public function testUpdateUser()
     {
-        // Create a new user object
-        $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/5480c950bffebc651c8b456f', [
+        $user = User::create(['mobile' => $this->faker->unique()->phoneNumber]);
+
+        // Update an existing user
+        $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
             'email' => 'NewEmail@dosomething.org',
             'parse_installation_ids' => 'parse-abc123',
         ]);
@@ -358,16 +382,16 @@ class UserTest extends TestCase
             'data' => [
                 'email' => 'newemail@dosomething.org',
                 'parse_installation_ids' => ['parse-abc123'],
-                'mobile' => '5555550101', // unchanged user values should remain unchanged
+                'mobile' => $user->mobile, // unchanged user values should remain unchanged
             ],
         ]);
 
         // Verify user data got updated
         $this->seeInDatabase('users', [
-            '_id' => '5480c950bffebc651c8b456f',
+            '_id' => $user->id,
+            'mobile' => $user->mobile,
             'email' => 'newemail@dosomething.org',
             'parse_installation_ids' => ['parse-abc123'],
-            'mobile' => '5555550101',
         ]);
     }
 
@@ -378,9 +402,12 @@ class UserTest extends TestCase
      */
     public function testUpdateWithConflict()
     {
+        User::create(['mobile' => '5555550101']);
+
         $user = User::create(['email' => 'admiral.ackbar@example.com']);
+
         $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
-            'mobile' => '(555) 555-0101', // a different existing user account
+            'mobile' => '(555) 555-0101', // the existing user account
             'first_name' => 'Gial',
             'last_name' => 'Ackbar',
         ]);
@@ -396,19 +423,19 @@ class UserTest extends TestCase
      */
     public function testCreateUserAvatarWithFile()
     {
-        $user = User::find('5480c950bffebc651c8b456f');
+        $user = User::create();
 
         // Mock successful response from AWS API
-        $this->mock('Northstar\Services\AWS')->shouldReceive('storeImage')->once()->andReturn('http://bucket.s3.amazonaws.com/5480c950bffebc651c8b456f-1234567.jpg');
+        $this->mock('Northstar\Services\AWS')->shouldReceive('storeImage')->once()->andReturn('http://bucket.s3.amazonaws.com/'.$user->id.'-1234567.jpg');
 
-        $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/users/5480c950bffebc651c8b456f/avatar', [
+        $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/users/'.$user->id.'/avatar', [
             'photo' => 'example.jpeg',
         ]);
 
         $this->assertResponseStatus(200);
         $this->seeJsonSubset([
             'data' => [
-                'photo' => 'http://bucket.s3.amazonaws.com/5480c950bffebc651c8b456f-1234567.jpg',
+                'photo' => 'http://bucket.s3.amazonaws.com/'.$user->id.'-1234567.jpg',
             ],
         ]);
     }
@@ -421,19 +448,19 @@ class UserTest extends TestCase
      */
     public function testCreateUserAvatarWithBase64()
     {
-        $user = User::find('5480c950bffebc651c8b456f');
+        $user = User::create();
 
         // Mock successful response from AWS API
-        $this->mock('Northstar\Services\AWS')->shouldReceive('storeImage')->once()->andReturn('http://bucket.s3.amazonaws.com/5480c950bffebc651c8b456f-123415.jpg');
+        $this->mock('Northstar\Services\AWS')->shouldReceive('storeImage')->once()->andReturn('http://bucket.s3.amazonaws.com/'.$user->id.'-123415.jpg');
 
-        $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/users/5480c950bffebc651c8b456f/avatar', [
+        $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/users/'.$user->id.'/avatar', [
             'photo' => '123456789',
         ]);
 
         $this->assertResponseStatus(200);
         $this->seeJsonSubset([
             'data' => [
-                'photo' => 'http://bucket.s3.amazonaws.com/5480c950bffebc651c8b456f-123415.jpg',
+                'photo' => 'http://bucket.s3.amazonaws.com/'.$user->id.'-123415.jpg',
             ],
         ]);
     }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -114,8 +114,12 @@ class UserTest extends TestCase
      */
     public function testFilterUsersById()
     {
+        $user1 = User::create(['email' => '123142512@example.com', 'drupal_id' => '123411']);
+        $user2 = User::create(['email' => '123513511@example.com', 'drupal_id' => '123412']);
+        $user3 = User::create(['drupal_id' => '123413']);
+
         // Retrieve multiple users by _id
-        $this->get('v1/users?filter[_id]=5430e850dt8hbc541c37tt3d,5480c950bffebc651c8b456f,FAKE_ID');
+        $this->get('v1/users?filter[_id]='.$user1->id.','.$user2->id.',FAKE_ID');
         $this->assertCount(2, $this->decodeResponseJson()['data']);
         $this->seeJsonStructure([
             'data' => [
@@ -129,11 +133,11 @@ class UserTest extends TestCase
         ]);
 
         // Retrieve multiple users by drupal_id
-        $this->get('v1/users?filter[drupal_id]=FAKE_ID,100001,100002,100003');
+        $this->get('v1/users?filter[drupal_id]=FAKE_ID,'.$user1->drupal_id.','.$user2->drupal_id.','.$user3->drupal_id);
         $this->assertCount(3, $this->decodeResponseJson()['data']);
 
         // Test compound queries
-        $this->get('v1/users?filter[drupal_id]=FAKE_ID,100001,100002,100003&filter[mobile]=5555550100');
+        $this->get('v1/users?filter[drupal_id]=FAKE_ID,'.$user1->drupal_id.','.$user2->drupal_id.','.$user3->drupal_id.'&filter[_id]='.$user1->id);
         $this->assertCount(1, $this->decodeResponseJson()['data']);
     }
 
@@ -442,11 +446,13 @@ class UserTest extends TestCase
      */
     public function testDelete()
     {
+        $user = User::create(['email' => 'delete-me@example.com']);
+
         // Only 'admin' scoped keys should be able to delete users.
-        $this->delete('v1/users/5480c950bffebc651c8b4570');
+        $this->delete('v1/users/'.$user->id);
         $this->assertResponseStatus(403);
 
-        $this->withScopes(['admin'])->delete('v1/users/5480c950bffebc651c8b4570');
+        $this->withScopes(['admin'])->delete('v1/users/'.$user->id);
         $this->assertResponseStatus(200);
     }
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -22,8 +22,6 @@ build:
         name: phpunit
         code: |-
           cp .env.example .env
-          php artisan migrate
-          php artisan db:seed
           vendor/bin/phpunit
 
 deploy:


### PR DESCRIPTION
#### Changes
One last round of touch-ups to the test suite: Speed Demon Edition™. :racehorse: 

* Reset the database between each test, without running the database seeders. This speeds things up considerably (like 2x faster!) and is nice because it makes each test completely self-contained (rather than relying on a seed user that could break the test if changed later). 
* Run tests on a separate `northstar-test` database. This means that running the test suite will no longer wipe your local environment and make manual testing harder! :innocent: 
* Adds a Faker instance to the base test case: this lets us easily generate dummy data within tests, e.g. `$this->faker->unique()->email`. This instance is reset between every test.
* Adds annotations to each model with the "magic" database properties. This silences PHPStorm warnings from magically resolved properties (and thus silences my OCD), but it’s also a nice place for documentation for each field!

---

For review: @angaither @weerd 