### PR TITLE
Everything and the kitchen sync

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -207,6 +207,21 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Mutator to remove any existing password if we migrate a hashed password.
+     * This is a one-time thing for syncing users from Phoenix and ensuring that
+     * we *only* keep their latest hashed Drupal password.
+     */
+    public function setDrupalPasswordAttribute($value)
+    {
+        if (isset($this->password)) {
+            $this->unset('password');
+        }
+
+        // The Drupal password is already hashed, don't do it again!
+        $this->attributes['drupal_password'] = $value;
+    }
+
+    /**
      * Mutator to automatically hash any value saved to the password field,
      * and remove the hashed Drupal password if one exists.
      */

--- a/database/migrations/2016_03_16_181119_AddUniqueIndexes.php
+++ b/database/migrations/2016_03_16_181119_AddUniqueIndexes.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUniqueIndexes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('email');
+            $collection->index('email', ['sparse' => true, 'unique' => true]);
+
+            $collection->dropIndex('mobile');
+            $collection->index('mobile', ['sparse' => true, 'unique' => true]);
+        });
+
+        Schema::table('tokens', function (Blueprint $collection) {
+            $collection->dropIndex('key');
+            $collection->unique('key');
+        });
+
+        Schema::table('api_keys', function (Blueprint $collection) {
+            $collection->dropIndex('api_key');
+            $collection->unique('api_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropUnique('email');
+            $collection->index('email');
+
+            $collection->dropUnique('mobile');
+            $collection->index('mobile');
+        });
+
+        Schema::table('tokens', function (Blueprint $collection) {
+            $collection->dropUnique('key');
+            $collection->index('key');
+        });
+
+        Schema::table('api_keys', function (Blueprint $collection) {
+            $collection->dropUnique('api_key');
+            $collection->index('api_key');
+        });
+    }
+}


### PR DESCRIPTION
#### Changes
Two things before we [re-sync from Phoenix](https://github.com/DoSomething/phoenix/pull/6282): 

 - When a `drupal_password` is added to an account, remove their existing `password` so we don't continue trying to authenticate against that. These two fields should be mutually exclusive.
 - Closes #312 by adding unique indexes to... y'know, unique fields! Computer science. Great win.

#### Hmm, how are we gonna deploy this?
This is probably gonna be another bummer to deploy because it will need to delete and recreate two massive indexes, so I think we may have to manually run these migrations to get this in production.

---
For review: @angaither @weerd 