### PR TITLE
Add a test for unique constraint when creating users.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -3,9 +3,9 @@
 namespace Northstar\Auth;
 
 use Hash;
-use Illuminate\Contracts\Auth\Guard;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Contracts\Auth\Guard as Auth;
 use Illuminate\Validation\Factory as Validation;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Northstar\Models\Token;
@@ -16,29 +16,32 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 class Registrar
 {
     /**
-     * @var Guard
+     * The authentication guard.
+     * @var Auth
      */
-    protected $guard;
+    protected $auth;
 
     /**
+     * Phoenix Drupal API wrapper.
      * @var Phoenix
      */
     protected $phoenix;
 
     /**
+     * Laravel's validation factory.
      * @var Validation
      */
     protected $validation;
 
     /**
      * Registrar constructor.
-     * @param Guard $guard
+     * @param Auth $auth
      * @param Phoenix $phoenix
      * @param Validation $validation
      */
-    public function __construct(Guard $guard, Phoenix $phoenix, Validation $validation)
+    public function __construct(Auth $auth, Phoenix $phoenix, Validation $validation)
     {
-        $this->guard = $guard;
+        $this->auth = $auth;
         $this->phoenix = $phoenix;
         $this->validation = $validation;
     }
@@ -193,7 +196,7 @@ class Registrar
     {
         $token = $user->login();
 
-        $this->guard->setUser($user);
+        $this->auth->setUser($user);
 
         return $token;
     }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -122,11 +122,7 @@ class AuthController extends Controller
     public function register(Request $request)
     {
         $request = $this->registrar->normalize($request);
-        $this->validate($request, [
-            'email' => 'email|max:60|unique:users|required_without:mobile',
-            'mobile' => 'unique:users|required_without:email',
-            'password' => 'required',
-        ]);
+        $this->registrar->validate($request, null, ['password' => 'required']);
 
         $user = $this->registrar->register($request->all());
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -2,8 +2,7 @@
 
 namespace Northstar\Http\Controllers;
 
-use Auth;
-use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\Guard as Auth;
 use Northstar\Auth\Registrar;
 use Northstar\Http\Transformers\UserTransformer;
 use Illuminate\Http\Request;
@@ -11,23 +10,25 @@ use Illuminate\Http\Request;
 class ProfileController extends Controller
 {
     /**
+     * The registrar.
      * @var Registrar
      */
     protected $registrar;
 
     /**
-     * @var Guard
+     * The authentication guard.
+     * @var Auth
      */
-    protected $guard;
+    protected $auth;
 
     /**
      * @var UserTransformer
      */
     protected $transformer;
 
-    public function __construct(Guard $guard, Registrar $registrar)
+    public function __construct(Auth $auth, Registrar $registrar)
     {
-        $this->guard = $guard;
+        $this->auth = $auth;
         $this->registrar = $registrar;
 
         $this->transformer = new UserTransformer();
@@ -45,7 +46,7 @@ class ProfileController extends Controller
     public function show()
     {
         /** @var \Northstar\Models\User $user */
-        $user = $this->guard->user();
+        $user = $this->auth->user();
 
         return $this->item($user);
     }
@@ -60,7 +61,7 @@ class ProfileController extends Controller
     public function update(Request $request)
     {
         /** @var \Northstar\Models\User $user */
-        $user = $this->guard->user();
+        $user = $this->auth->user();
 
         // Normalize & validate the given request.
         $request = $this->registrar->normalize($request);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -76,13 +76,9 @@ class UserController extends Controller
         // So, does this user exist already?
         $user = $this->registrar->resolve($request->only('email', 'mobile'));
 
-        // Validate format & index uniqueness (excluding the profile being updated, if one exists)
-        $existingId = isset($user->id) ? $user->id : 'null';
+        // Normalize input and validate the request
         $request = $this->registrar->normalize($request);
-        $this->validate($request, [
-            'email' => 'email|max:60|unique:users,email,'.$existingId.',_id|required_without:mobile',
-            'mobile' => 'unique:users,mobile,'.$existingId.',_id|required_without:email',
-        ]);
+        $this->registrar->validate($request, $user);
 
         $user = $this->registrar->register($request->all(), $user);
 
@@ -140,20 +136,9 @@ class UserController extends Controller
             throw new NotFoundHttpException('The resource does not exist.');
         }
 
+        // Normalize input and validate the request
         $request = $this->registrar->normalize($request);
-
-        // HACK: Get the iterable properties on the user and merge them into the request for validation.
-        $filledRequest = $request;
-        foreach ($user->toArray() as $key => $value) {
-            if (! isset($request[$key])) {
-                $filledRequest[$key] = $value;
-            }
-        }
-
-        $this->validate($filledRequest, [
-            'email' => 'email|max:60|unique:users,email,'.$user->id.',_id|required_without:mobile',
-            'mobile' => 'unique:users,mobile,'.$user->id.',_id|required_without:email',
-        ]);
+        $this->registrar->validate($request, $user);
 
         $user = $this->registrar->register($request->all(), $user);
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -141,9 +141,18 @@ class UserController extends Controller
         }
 
         $request = $this->registrar->normalize($request);
-        $this->validate($request, [
-            'email' => 'email|max:60|unique:users,email,'.$user->id.',_id',
-            'mobile' => 'unique:users,mobile,'.$user->id.',_id',
+
+        // HACK: Get the iterable properties on the user and merge them into the request for validation.
+        $filledRequest = $request;
+        foreach ($user->toArray() as $key => $value) {
+            if (! isset($request[$key])) {
+                $filledRequest[$key] = $value;
+            }
+        }
+
+        $this->validate($filledRequest, [
+            'email' => 'email|max:60|unique:users,email,'.$user->id.',_id|required_without:mobile',
+            'mobile' => 'unique:users,mobile,'.$user->id.',_id|required_without:email',
         ]);
 
         $user = $this->registrar->register($request->all(), $user);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,7 +8,6 @@ use Jenssegers\Mongodb\Model;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
-use Hash;
 
 /**
  * The User model. (Fight for the user!)
@@ -218,7 +217,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setDrupalPasswordAttribute($value)
     {
         if (isset($this->password)) {
-            $this->unset('password');
+            $this->drop('password');
         }
 
         // The Drupal password is already hashed, don't do it again!
@@ -232,10 +231,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setPasswordAttribute($value)
     {
         if (isset($this->drupal_password)) {
-            $this->unset('drupal_password');
+            $this->drop('drupal_password');
         }
 
-        $this->attributes['password'] = Hash::make($value);
+        $this->attributes['password'] = bcrypt($value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -145,8 +145,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setEmailAttribute($value)
     {
-        // Skip mutator if attribute is null.
+        // Drop field if attribute is empty string null.
         if (empty($value)) {
+            $this->drop('email');
+
             return;
         }
 
@@ -173,8 +175,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setMobileAttribute($value)
     {
-        // Skip mutator if attribute is null.
+        // Drop field if attribute is empty string null.
         if (empty($value)) {
+            $this->drop('mobile');
+
             return;
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -144,7 +144,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setEmailAttribute($value)
     {
-        // Drop field if attribute is empty string null.
+        // Drop field if attribute is empty string or null.
         if (empty($value)) {
             $this->drop('email');
 
@@ -174,7 +174,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setMobileAttribute($value)
     {
-        // Drop field if attribute is empty string null.
+        // Drop field if attribute is empty string or null.
         if (empty($value)) {
             $this->drop('mobile');
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -137,6 +137,21 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test that you can't register a user without an email or mobile.
+     * POST /auth/register
+     *
+     * @return void
+     */
+    public function testIncompleteRegistration()
+    {
+        $this->withScopes(['user'])->json('POST', 'v1/auth/register', [
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /**
      * Test for registering in a user
      * POST /auth/register
      *

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Northstar\Models\User;
+
+class ProfileTest extends TestCase
+{
+    /**
+     * Test that a user can see their own profile.
+     * GET /profile
+     *
+     * @test
+     */
+    public function testGetProfile()
+    {
+        $user = User::create([
+            'email' => $this->faker->email,
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+        ]);
+
+        // Try to register an account that already exists, but with different capitalization
+        $this->asUser($user)->withScopes(['user'])->get('v1/profile');
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+                'email' => $user->email,
+                'first_name' => $user->first_name,
+                'last_name' => $user->last_name,
+            ],
+        ]);
+    }
+
+    /**
+     * Test that a user can modify their own profile.
+     * POST /profile
+     *
+     * @test
+     */
+    public function testUpdateProfile()
+    {
+        $user = User::create([
+            'email' => $this->faker->email,
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+        ]);
+
+        $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/profile', [
+            'mobile' => '(555) 123-4567',
+            'language' => 'en',
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+                'email' => $user->email,
+                'first_name' => $user->first_name,
+                'last_name' => $user->last_name,
+                'mobile' => '5551234567', // should be normalized!
+                'language' => 'en',
+            ],
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -99,6 +99,24 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     }
 
     /**
+     * Get the raw Mongo document for inspection.
+     *
+     * @param $collection - Mongo Collection name
+     * @param $id - The _id of the document to fetch
+     * @return array
+     */
+    public function getMongoDocument($collection, $id)
+    {
+        $document = $this->app->make('db')->collection($collection)->where(['_id' => $id])->first();
+
+        $this->assertNotNull($document, sprintf(
+            'Unable to find document in collection [%s] with _id [%s].', $collection, $id
+        ));
+
+        return $document;
+    }
+
+    /**
      * Creates the application.
      *
      * @return \Illuminate\Foundation\Application

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -262,6 +262,34 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test that creating multiple users won't trigger unique
+     * database constraint errors.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testCreateMultipleUsers()
+    {
+        // Create some new users
+        for ($i = 0; $i < 5; $i++) {
+            $this->withScopes(['admin'])->json('POST', 'v1/users', [
+                'email' => $this->faker->unique()->email,
+                'mobile' => '', // this should not save a `mobile` field on these users
+                'source' => 'phpunit',
+            ]);
+
+            $this->withScopes(['admin'])->json('POST', 'v1/users', [
+                'email' => '  ', // this should not save a `email` field on these users
+                'mobile' => $this->faker->unique()->phoneNumber,
+                'source' => 'phpunit',
+            ]);
+        }
+
+        $this->get('v1/users');
+        $this->assertCount(10, $this->decodeResponseJson()['data']);
+    }
+
+    /**
      * Test that we can't create a duplicate user.
      * POST /users
      *


### PR DESCRIPTION
#### Changes
Just making sure that we're not still creating the problem seen in #316...

:bug: Fix issue where indexed fields could be set to `null` or an empty string, which would cause the "unique" constraint violation added in #315 to trigger an error.

:beetle: Fix issue where a user could be updated to have _neither_ an email or mobile number.

:leaves: Moved user validation into the Registrar so we can use the same logic everywhere. 

:traffic_light: We didn't have tests for the profile endpoints. Whaaaa? Added some.

#### How should this be reviewed?
Is there anything I'm missing? Any other ways that you could possibly save a `null` or `''` value to an indexed field? Or otherwise get up to no good? :boom: :interrobang: 

---
For review: @angaither @weerd 