### PR TITLE
Resolve users from the Registrar for show endpoint.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -144,7 +144,7 @@ class Registrar
         // For the first `where` query, we want to limit results... from then on,
         // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
         $firstWhere = true;
-        foreach (['id', '_id', 'email', 'mobile', 'drupal_id'] as $type) {
+        foreach (User::$indexes as $type) {
             if (isset($credentials[$type])) {
                 $matches = $matches->where($type, '=', $credentials[$type], ($firstWhere ? 'and' : 'or'));
                 $firstWhere = false;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -73,6 +73,12 @@ class Registrar
      */
     public function normalize($credentials)
     {
+        // Map id to Mongo's _id ObjectID field
+        if (! empty($credentials['id'])) {
+            $credentials['_id'] = $credentials['id'];
+            unset($credentials['id']);
+        }
+
         if (! empty($credentials['email'])) {
             $credentials['email'] = trim(strtolower($credentials['email']));
         }
@@ -140,10 +146,7 @@ class Registrar
         $firstWhere = true;
         foreach (['id', '_id', 'email', 'mobile', 'drupal_id'] as $type) {
             if (isset($credentials[$type])) {
-                // Use 'id' as an alias for Mongo's _id field.
-                $databaseColumn = ($type == 'id') ? '_id' : $type;
-
-                $matches = $matches->where($databaseColumn, '=', $credentials[$type], ($firstWhere ? 'and' : 'or'));
+                $matches = $matches->where($type, '=', $credentials[$type], ($firstWhere ? 'and' : 'or'));
                 $firstWhere = false;
             }
         }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -138,11 +138,19 @@ class Registrar
         // For the first `where` query, we want to limit results... from then on,
         // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
         $firstWhere = true;
-        foreach (['email', 'mobile'] as $type) {
+        foreach (['id', '_id', 'email', 'mobile', 'drupal_id'] as $type) {
             if (isset($credentials[$type])) {
-                $matches = $matches->where($type, '=', $credentials[$type], ($firstWhere ? 'and' : 'or'));
+                // Use 'id' as an alias for Mongo's _id field.
+                $databaseColumn = ($type == 'id') ? '_id' : $type;
+
+                $matches = $matches->where($databaseColumn, '=', $credentials[$type], ($firstWhere ? 'and' : 'or'));
                 $firstWhere = false;
             }
+        }
+
+        // If we did not query by any fields, return null.
+        if ($firstWhere) {
+            return null;
         }
 
         // If we found one user, return it.

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -110,7 +110,7 @@ class UserController extends Controller
     public function show($term, $id)
     {
         // Find the user.
-        $user = User::where($term, $id)->first();
+        $user = $this->registrar->resolve([$term => $id]);
 
         if (! $user) {
             throw new NotFoundHttpException('The resource does not exist.');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -56,8 +56,11 @@ class UserController extends Controller
         // or paginate to retrieve all user records.
         $query = $this->newQuery(User::class);
 
-        $query = $this->filter($query, $request->query('filter'), User::$indexes);
-        $query = $this->search($query, $request->query('search'), User::$indexes);
+        $filters = $request->query('filter');
+        $query = $this->filter($query, $this->registrar->normalize($filters), User::$indexes);
+
+        $searches = $request->query('search');
+        $query = $this->search($query, $this->registrar->normalize($searches), User::$indexes);
 
         return $this->paginatedCollection($query, $request);
     }

--- a/documentation/endpoints/keys.md
+++ b/documentation/endpoints/keys.md
@@ -21,23 +21,23 @@ curl -X GET \
 {
   "data": [
     {
-      "_id": "555b5afcbffebc150b8b45ab",
       "app_id": "appid1",
       "api_key": "apikey1",
+      "scope": ["admin", "user"],
       "updated_at": "2015-05-19 15:47:08",
       "created_at": "2015-05-19 15:47:08"
     },
     {
-      "_id": "555b5afcbffebc150b8b45ac",
       "app_id": "appid2",
       "api_key": "apikey2",
+      "scope": ["user"],
       "updated_at": "2015-05-19 15:47:08",
       "created_at": "2015-05-19 15:47:08"
     },
     {
-      "_id": "555b6e8dbffebc30068b456a",
       "app_id": "appid3",
       "api_key": "apikey3",
+      scope: [],
       "updated_at": "2015-05-19 17:10:37",
       "created_at": "2015-05-19 17:10:37"
     }
@@ -83,9 +83,9 @@ curl -X POST \
   "data": {
     "app_id": "testapplication",
     "api_key": "1laEQhhKtQEaPK0qpESdXHm2EbdLu5sRIRLcRtF8",
+    "scope": [],
     "updated_at": "2015-05-19 17:10:37",
     "created_at": "2015-05-19 17:10:37",
-    "_id": "555b6e8dbffebc30068b456a"
   }
 }
 ```
@@ -115,9 +115,12 @@ curl -X GET\
   "data": {
     "app_id": "testapplication",
     "api_key": "1laEQhhKtQEaPK0qpESdXHm2EbdLu5sRIRLcRtF8",
+    "scope": [
+      "admin",
+      "user"
+    ],
     "updated_at": "2015-05-19 17:10:37",
     "created_at": "2015-05-19 17:10:37",
-    "_id": "555b6e8dbffebc30068b456a"
   }
 }
 ```
@@ -166,7 +169,6 @@ curl -X PUT \
     ],
     "updated_at": "2015-05-19 17:10:37",
     "created_at": "2015-05-19 17:10:37",
-    "_id": "555b6e8dbffebc30068b456a"
   }
 }
 ```

--- a/documentation/endpoints/keys.md
+++ b/documentation/endpoints/keys.md
@@ -23,21 +23,26 @@ curl -X GET \
     {
       "app_id": "appid1",
       "api_key": "apikey1",
-      "scope": ["admin", "user"],
+      "scope": [
+        "admin",
+        "user"
+      ],
       "updated_at": "2015-05-19 15:47:08",
       "created_at": "2015-05-19 15:47:08"
     },
     {
       "app_id": "appid2",
       "api_key": "apikey2",
-      "scope": ["user"],
+      "scope": [
+        "user"
+      ],
       "updated_at": "2015-05-19 15:47:08",
       "created_at": "2015-05-19 15:47:08"
     },
     {
       "app_id": "appid3",
       "api_key": "apikey3",
-      scope: [],
+      "scope": [],
       "updated_at": "2015-05-19 17:10:37",
       "created_at": "2015-05-19 17:10:37"
     }

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -11,7 +11,7 @@ GET /users
 - `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v1/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.
-- `search`: Search the collection for users with fields whose value match the query. For example, `/v1/users?search[_id]=test@example.com&search[email]=test@example.org` would return all users with either an ID or email address matching `test@example.org`. You can search by one or more indexed fields. This is limited to admin-scoped API keys!
+- `search`: Search the collection for users with fields whose value match the query. For example, `/v1/users?search[id]=test@example.com&search[email]=test@example.org` would return all users with either an ID or email address matching `test@example.org`. You can search by one or more indexed fields. This is limited to admin-scoped API keys!
 
 **Example Request:**
 
@@ -182,7 +182,7 @@ Get profile data for a specific user. This can be retrieved with either the user
 generated when a new database record is created), a mobile phone number, an email address, or the user's Drupal ID.
 
 ```
-GET /users/_id/<user_id>
+GET /users/id/<user_id>
 GET /users/mobile/<mobile>
 GET /users/email/<email>
 GET /users/drupal_id/<drupal_id>

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -253,7 +253,7 @@ class UserTest extends TestCase
 
     /**
      * Tests retrieving multiple users by their id
-     * GET /users?filter[_id]=:id_1,...,:id_N
+     * GET /users?filter[id]=:id_1,...,:id_N
      * GET /users?filter[drupal_id]=:id_1,...,:id_N
      */
     public function testFilterUsersById()
@@ -263,7 +263,7 @@ class UserTest extends TestCase
         $user3 = User::create(['mobile' => $this->faker->unique()->phoneNumber, 'drupal_id' => '123413']);
 
         // Retrieve multiple users by _id
-        $this->get('v1/users?filter[_id]='.$user1->id.','.$user2->id.',FAKE_ID');
+        $this->get('v1/users?filter[id]='.$user1->id.','.$user2->id.',FAKE_ID');
         $this->assertCount(2, $this->decodeResponseJson()['data']);
         $this->seeJsonStructure([
             'data' => [

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -5,6 +5,133 @@ use Northstar\Models\User;
 class UserTest extends TestCase
 {
     /**
+     * Test for retrieving a user by their ID.
+     * GET /users/id/:id
+     *
+     * @return void
+     */
+    public function testGetUserById()
+    {
+        $user = User::create([
+            'email' => 'jbeaubier@xavier.edu',
+            'first_name' => 'Jean-Paul',
+        ]);
+
+        $this->withScopes(['user'])->get('v1/users/id/'.$user->id);
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+            ],
+        ]);
+    }
+
+    /**
+     * Test for retrieving a user by their Mongo _id, for backwards compatibility.
+     * GET /users/_id/:id
+     *
+     * @return void
+     */
+    public function testGetUserByMongoId()
+    {
+        $user = User::create([
+            'email' => 'jbeaubier@xavier.edu',
+            'first_name' => 'Jean-Paul',
+        ]);
+
+        $this->withScopes(['user'])->get('v1/users/_id/'.$user->id);
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+            ],
+        ]);
+    }
+
+    /**
+     * Test for retrieving a user by their email.
+     * GET /users/email/:email
+     *
+     * @return void
+     */
+    public function testGetUserByEmail()
+    {
+        $user = User::create([
+            'email' => 'jbeaubier@xavier.edu',
+            'first_name' => 'Jean-Paul',
+        ]);
+
+        $this->withScopes(['user'])->get('v1/users/email/JBeaubier@Xavier.edu');
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+            ],
+        ]);
+    }
+
+    /**
+     * Test for retrieving a user by their mobile number.
+     * GET /users/email/:email
+     *
+     * @return void
+     */
+    public function testGetUserByMobile()
+    {
+        $user = User::create([
+            'mobile' => $this->faker->phoneNumber,
+            'first_name' => $this->faker->firstName,
+        ]);
+
+        $this->withScopes(['user'])->get('v1/users/mobile/'.$user->mobile);
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+            ],
+        ]);
+    }
+
+    /**
+     * Test we can't retrieve a user by a non-indexed field.
+     * GET /users/email/:email
+     *
+     * @return void
+     */
+    public function testCantGetUserByNonIndexedField()
+    {
+        User::create([
+            'mobile' => $this->faker->phoneNumber,
+            'first_name' => 'Bobby',
+        ]);
+
+        // Test that we return 404 when retrieving by a non-indexed field.
+        $this->withScopes(['user'])->get('v1/users/first_name/Bobby');
+        $this->assertResponseStatus(404);
+    }
+
+    /**
+     * Tests retrieving a user by their Drupal ID.
+     * GET /users/drupal_id/{id}
+     */
+    public function testRetrieveUser()
+    {
+        $user = User::create([
+            'drupal_id' => '100010',
+        ]);
+
+        // GET /users/drupal_id/<drupal_id>
+        $this->get('v1/users/drupal_id/100010');
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'id' => $user->id,
+                'drupal_id' => $user->drupal_id,
+            ],
+        ]);
+    }
+
+    /**
      * Test for retrieving a user with a non-admin key.
      * GET /users/:term/:id
      *
@@ -180,62 +307,6 @@ class UserTest extends TestCase
 
         // There should be one match (a user with the provided email)
         $this->assertCount(1, $this->decodeResponseJson()['data']);
-    }
-
-    /**
-     * Tests retrieving a user
-     * GET /users/{term}/{id}
-     */
-    public function testRetrieveUser()
-    {
-        // User info
-        $user = User::create([
-            'email' => 'sterling.archer@example.com',
-            'mobile' => '5551231245',
-            'drupal_id' => '4567890',
-        ]);
-
-        // GET /users/_id/<user_id>
-        $this->get('v1/users/_id/'.$user->_id);
-
-        // Assert response is 200 and has expected data
-        $this->assertResponseStatus(200);
-        $this->seeJsonSubset([
-            'data' => [
-                'id' => $user->_id,
-                'email' => $user->email,
-            ],
-        ]);
-
-        // GET /users/mobile/<mobile>
-        $this->get('v1/users/mobile/'.$user->mobile);
-        $this->assertResponseStatus(200);
-        $this->seeJsonSubset([
-            'data' => [
-                'id' => $user->_id,
-                'mobile' => $user->mobile,
-            ],
-        ]);
-
-        // GET /users/email/<email>
-        $this->get('v1/users/email/'.$user->email);
-        $this->assertResponseStatus(200);
-        $this->seeJsonSubset([
-            'data' => [
-                'id' => $user->_id,
-                'email' => $user->email,
-            ],
-        ]);
-
-        // GET /users/drupal_id/<drupal_id>
-        $this->get('v1/users/drupal_id/'.$user->drupal_id);
-        $this->assertResponseStatus(200);
-        $this->seeJsonSubset([
-            'data' => [
-                'id' => $user->_id,
-                'drupal_id' => $user->drupal_id,
-            ],
-        ]);
     }
 
     /**


### PR DESCRIPTION
#### Changes

:bug: Fixes #318. Resolve users from the Registrar when querying for the "show" endpoint. This lets us normalize fields before querying, and prevents querying by a non-indexed field.

:rocket: Because we're running all queries through the Registrar, we can now also easily map "id" to the `_id` Mongo field, so we don't need to expose database implementation details as part of our API. Yay! 

:relieved: No plans to remove the ability to query by `_id` anytime soon, by the way. But I am removing it from the documentation since we might remove it with a v2 down the line.

:dancer: Also runs filters and searches through the Registrar's normalization function, so they're no longer case-sensitive and also take advantage of the "id" to `_id` mapping.

---
For review: @angaither @weerd 