### PR TITLE
Adds multi user support

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -43,16 +43,17 @@ class SignupController extends Controller
     {
         $options = $request->query();
 
-        // If a user is specified, turn Northstar ID into Drupal ID
+        // Transform user into users.
         if (! empty($options['user'])) {
-            if (strpos($options['user'], ',') > 0) {
-                $usersQuery = explode(',', $options['user']);
-                $options['user'] = User::drupalIDForNorthstarId($usersQuery);
-            } else {
-                $options['user'] = User::drupalIDForNorthstarId($options['user']);
-            }
+            $options['users'] = $options['user'];
         }
-        
+
+        // If a user is specified, turn Northstar ID into Drupal ID
+        if (! empty($options['users'])) {
+            $usersQuery = explode(',', $options['users']);
+            $options['users'] = User::drupalIDForNorthstarId($usersQuery);
+        }
+
         return $this->phoenix->getSignupIndex($options);
     }
 

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -45,7 +45,15 @@ class SignupController extends Controller
 
         // If a user is specified, turn Northstar ID into Drupal ID
         if (! empty($options['user'])) {
-            $options['user'] = User::drupalIDForNorthstarId($options['user']);
+            if (strpos($options['user'], ',') > 0) {
+                $usersQuery = explode(',', $options['user']);
+                $options['user'] = [];
+                foreach ($usersQuery as $user) {
+                    array_push($options['user'], User::drupalIDForNorthstarId($user));
+                }
+            } else {
+                $options['user'] = User::drupalIDForNorthstarId($options['user']);
+            }
         }
 
         return $this->phoenix->getSignupIndex($options);

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -52,9 +52,7 @@ class SignupController extends Controller
                 $options['user'] = User::drupalIDForNorthstarId($options['user']);
             }
         }
-
-        dd($options['user']);
-
+        
         return $this->phoenix->getSignupIndex($options);
     }
 

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -47,14 +47,13 @@ class SignupController extends Controller
         if (! empty($options['user'])) {
             if (strpos($options['user'], ',') > 0) {
                 $usersQuery = explode(',', $options['user']);
-                $options['user'] = [];
-                foreach ($usersQuery as $user) {
-                    array_push($options['user'], User::drupalIDForNorthstarId($user));
-                }
+                $options['user'] = User::drupalIDForNorthstarId($usersQuery);
             } else {
                 $options['user'] = User::drupalIDForNorthstarId($options['user']);
             }
         }
+
+        dd($options['user']);
 
         return $this->phoenix->getSignupIndex($options);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,9 +260,13 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public static function drupalIDForNorthstarId($northstar_id)
     {
-        $user = self::find($northstar_id);
+        $user = User::find($northstar_id);
 
         if ($user) {
+            if (is_array($northstar_id)) {
+                return $user->pluck('drupal_id');
+            }
+
             return $user->drupal_id;
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -260,7 +260,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public static function drupalIDForNorthstarId($northstar_id)
     {
-        $user = User::find($northstar_id);
+        $user = self::find($northstar_id);
 
         if ($user) {
             if (is_array($northstar_id)) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -264,7 +264,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         if ($user) {
             if (is_array($northstar_id)) {
-                return $user->pluck('drupal_id');
+                return array_column($user->toArray(), 'drupal_id');
             }
 
             return $user->drupal_id;

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -17,7 +17,7 @@ class SignupTest extends TestCase
         $user2 = User::create(['drupal_id' => '100002']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001','100002']])->once()->andReturn([
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
@@ -30,7 +30,7 @@ class SignupTest extends TestCase
             ],
         ]);
 
-        $this->asUser($user)->withScopes(['user'])->get('v1/signups?users=' . $user->_id . ',' . $user2->_id);
+        $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id.','.$user2->_id);
         $this->assertResponseStatus(200);
         $this->seeJson();
     }

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -14,9 +14,10 @@ class SignupTest extends TestCase
     public function testSignupIndex()
     {
         $user = User::create(['drupal_id' => '100001']);
+        $user2 = User::create(['drupal_id' => '100002']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['user' => '100001'])->once()->andReturn([
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => '100001,100002'])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
@@ -29,7 +30,7 @@ class SignupTest extends TestCase
             ],
         ]);
 
-        $this->asUser($user)->withScopes(['user'])->get('v1/signups?user='.$user->_id);
+        $this->asUser($user)->withScopes(['user'])->get('v1/signups?users=' . $user->_id . ',' . $user2->_id);
         $this->assertResponseStatus(200);
         $this->seeJson();
     }

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -17,7 +17,7 @@ class SignupTest extends TestCase
         $user2 = User::create(['drupal_id' => '100002']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => '100001,100002'])->once()->andReturn([
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001','100002']])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',


### PR DESCRIPTION
#### What's this PR do?
Adds multi user support to the signups index 

#### How should this be manually tested?
Well thats kinda tricky, I had problems getting my local DB to march my drupals. BUT we do seed a user by default in northstar, so I used that user twice in the URL. From a code/logic perspective it doesnt matter that we used them twice in the URL.

![screen shot 2016-04-01 at 2 42 18 pm](https://cloud.githubusercontent.com/assets/897368/14216808/bc78173e-f818-11e5-83e4-8e3e14107318.png)
`http://northstar.app/v1/signups?competition=1&user=5430e850dt8hbc541c37tt3d,5430e850dt8hbc541c37tt3d&campaigns=1485`