### PR TITLE
Allow username field when normalizing credentials.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -80,40 +80,14 @@ class Registrar
         }
 
         if (! empty($credentials['email'])) {
-            $credentials['email'] = $this->normalizeEmail($credentials['email']);
+            $credentials['email'] = trim(strtolower($credentials['email']));
         }
 
         if (! empty($credentials['mobile'])) {
-            $credentials ['mobile'] = $this->normalizeMobile($credentials['mobile']);
+            $credentials ['mobile'] = preg_replace('/[^0-9]/', '', $credentials['mobile']);
         }
 
         return $credentials;
-    }
-
-    /**
-     * Sanitize an email address before verifying or saving to the database.
-     * This method will likely be called multiple times per user, so it *must*
-     * provide the same result if so.
-     *
-     * @param string $email
-     * @return string
-     */
-    public function normalizeEmail($email)
-    {
-        return trim(strtolower($email));
-    }
-
-    /**
-     * Sanitize a mobile number before verifying or saving to the database.
-     * This method will likely be called multiple times per user, so it *must*
-     * provide the same result if so.
-     *
-     * @param string $mobile
-     * @return string
-     */
-    public function normalizeMobile($mobile)
-    {
-        return preg_replace('/[^0-9]/', '', $mobile);
     }
 
     /**

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -73,7 +73,14 @@ class Registrar
      */
     public function normalize($credentials)
     {
-        // Map id to Mongo's _id ObjectID field
+        // If a username is given, figure out whether it's an email or mobile number.
+        if (! empty($credentials['username'])) {
+            $type = $this->isEmail($credentials['username']) ? 'email' : 'mobile';
+            $credentials[$type] = $credentials['username'];
+            unset($credentials['username']);
+        }
+
+        // Map id to Mongo's _id ObjectID field.
         if (! empty($credentials['id'])) {
             $credentials['_id'] = $credentials['id'];
             unset($credentials['id']);
@@ -114,6 +121,17 @@ class Registrar
     public function normalizeMobile($mobile)
     {
         return preg_replace('/[^0-9]/', '', $mobile);
+    }
+
+    /**
+     * Confirm that the given value is an e-mail address.
+     *
+     * @param string $value
+     * @return bool
+     */
+    protected function isEmail($value)
+    {
+        return filter_var(trim($value), FILTER_VALIDATE_EMAIL) !== false;
     }
 
     /**

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -80,14 +80,40 @@ class Registrar
         }
 
         if (! empty($credentials['email'])) {
-            $credentials['email'] = trim(strtolower($credentials['email']));
+            $credentials['email'] = $this->normalizeEmail($credentials['email']);
         }
 
         if (! empty($credentials['mobile'])) {
-            $credentials ['mobile'] = preg_replace('/[^0-9]/', '', $credentials['mobile']);
+            $credentials ['mobile'] = $this->normalizeMobile($credentials['mobile']);
         }
 
         return $credentials;
+    }
+
+    /**
+     * Sanitize an email address before verifying or saving to the database.
+     * This method will likely be called multiple times per user, so it *must*
+     * provide the same result if so.
+     *
+     * @param string $email
+     * @return string
+     */
+    public function normalizeEmail($email)
+    {
+        return trim(strtolower($email));
+    }
+
+    /**
+     * Sanitize a mobile number before verifying or saving to the database.
+     * This method will likely be called multiple times per user, so it *must*
+     * provide the same result if so.
+     *
+     * @param string $mobile
+     * @return string
+     */
+    public function normalizeMobile($mobile)
+    {
+        return preg_replace('/[^0-9]/', '', $mobile);
     }
 
     /**

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -7,11 +7,17 @@ use Northstar\Http\Transformers\TokenTransformer;
 use Northstar\Http\Transformers\UserTransformer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Illuminate\Contracts\Auth\Guard as Auth;
 use Northstar\Auth\Registrar;
-use Auth;
 
 class AuthController extends Controller
 {
+    /**
+     * The authentication guard.
+     * @var \Northstar\Auth\NorthstarTokenGuard
+     */
+    protected $auth;
+
     /**
      * The registrar.
      * @var Registrar
@@ -23,18 +29,24 @@ class AuthController extends Controller
      */
     protected $transformer;
 
+    /**
+     * Validation rules for login routes.
+     * @var array
+     */
     protected $loginRules = [
         'email' => 'email|required_without:mobile',
         'mobile' => 'required_without:email',
         'password' => 'required',
     ];
-    
+
     /**
      * AuthController constructor.
+     * @param Auth $auth
      * @param Registrar $registrar
      */
-    public function __construct(Registrar $registrar)
+    public function __construct(Auth $auth, Registrar $registrar)
     {
+        $this->auth = $auth;
         $this->registrar = $registrar;
 
         $this->transformer = new TokenTransformer();
@@ -95,7 +107,7 @@ class AuthController extends Controller
      */
     public function invalidateToken(Request $request)
     {
-        $token = Auth::token();
+        $token = $this->auth->token();
 
         // Attempt to delete token.
         $deleted = $token->delete();

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -54,6 +54,7 @@ class AuthController extends Controller
      */
     public function createToken(Request $request)
     {
+        $request = $this->registrar->normalize($request);
         $this->validate($request, $this->loginRules);
 
         $credentials = $request->only('email', 'mobile', 'password');

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -23,6 +23,16 @@ class AuthController extends Controller
      */
     protected $transformer;
 
+    protected $loginRules = [
+        'email' => 'email|required_without:mobile',
+        'mobile' => 'required_without:email',
+        'password' => 'required',
+    ];
+    
+    /**
+     * AuthController constructor.
+     * @param Registrar $registrar
+     */
     public function __construct(Registrar $registrar)
     {
         $this->registrar = $registrar;
@@ -44,11 +54,7 @@ class AuthController extends Controller
      */
     public function createToken(Request $request)
     {
-        $this->validate($request, [
-            'email' => 'email|required_without:mobile',
-            'mobile' => 'required_without:email',
-            'password' => 'required',
-        ]);
+        $this->validate($request, $this->loginRules);
 
         $credentials = $request->only('email', 'mobile', 'password');
         $token = $this->registrar->login($credentials);
@@ -66,11 +72,7 @@ class AuthController extends Controller
     public function verify(Request $request)
     {
         $request = $this->registrar->normalize($request);
-        $this->validate($request, [
-            'email' => 'email|required_without:mobile',
-            'mobile' => 'required_without:email',
-            'password' => 'required',
-        ]);
+        $this->validate($request, $this->loginRules);
 
         $credentials = $request->only('email', 'mobile', 'password');
         $user = $this->registrar->resolve($credentials);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Jenssegers\Mongodb\Model;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Northstar\Auth\Registrar;
 
 /**
  * The User model. (Fight for the user!)
@@ -151,7 +152,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             return;
         }
 
-        $this->attributes['email'] = strtolower($value);
+        /**
+         * Otherwise, we'll ask the Registrar to normalize this field for us.
+         * @var $registrar \Northstar\Auth\Registrar
+         */
+        $registrar = app(Registrar::class);
+        $this->attributes['email'] = $registrar->normalizeEmail($value);
     }
 
     /**
@@ -181,8 +187,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             return;
         }
 
-        // Otherwise, remove all non-numeric characters.
-        $this->attributes['mobile'] = preg_replace('/[^0-9]/', '', $value);
+        /**
+         * Otherwise, we'll ask the Registrar to normalize this field for us.
+         * @var $registrar \Northstar\Auth\Registrar
+         */
+        $registrar = app(Registrar::class);
+        $this->attributes['mobile'] = $registrar->normalizeMobile($value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,7 +8,6 @@ use Jenssegers\Mongodb\Model;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
-use Northstar\Auth\Registrar;
 
 /**
  * The User model. (Fight for the user!)
@@ -152,12 +151,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             return;
         }
 
-        /**
-         * Otherwise, we'll ask the Registrar to normalize this field for us.
-         * @var $registrar \Northstar\Auth\Registrar
-         */
-        $registrar = app(Registrar::class);
-        $this->attributes['email'] = $registrar->normalizeEmail($value);
+        $this->attributes['email'] = strtolower($value);
     }
 
     /**
@@ -187,12 +181,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             return;
         }
 
-        /**
-         * Otherwise, we'll ask the Registrar to normalize this field for us.
-         * @var $registrar \Northstar\Auth\Registrar
-         */
-        $registrar = app(Registrar::class);
-        $this->attributes['mobile'] = $registrar->normalizeMobile($value);
+        // Otherwise, remove all non-numeric characters.
+        $this->attributes['mobile'] = preg_replace('/[^0-9]/', '', $value);
     }
 
     /**

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -47,7 +47,7 @@ class AuthTest extends TestCase
             'key' => $this->decodeResponseJson()['data']['key'],
         ]);
     }
-    
+
     /**
      * Test for logging in a user by email.
      * POST /auth/token

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -5,6 +5,50 @@ use Northstar\Models\User;
 class AuthTest extends TestCase
 {
     /**
+     * Test for logging in a user by username.
+     * POST /auth/token
+     *
+     * @return void
+     */
+    public function testLoginByUsername()
+    {
+        // Create user to attempt to log in as.
+        User::create([
+            'email' => 'login-test@dosomething.org',
+            'password' => 'secret',
+        ]);
+
+        // Test logging in with bogus info
+        $this->withScopes(['user'])->json('POST', 'v1/auth/token', [
+            'username' => 'login-test@dosomething.org',
+            'password' => 'letmein',
+        ]);
+        $this->assertResponseStatus(401);
+
+        // Test with the right credentials
+        $this->withScopes(['user'])->json('POST', 'v1/auth/token', [
+            'username' => 'login-test@dosomething.org',
+            'password' => 'secret',
+        ]);
+        $this->assertResponseStatus(201);
+        $this->seeJsonStructure([
+            'data' => [
+                'key',
+                'user' => [
+                    'data' => [
+                        'id',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Assert token given in the response also exists in database
+        $this->seeInDatabase('tokens', [
+            'key' => $this->decodeResponseJson()['data']['key'],
+        ]);
+    }
+    
+    /**
      * Test for logging in a user by email.
      * POST /auth/token
      *

--- a/tests/RegistrarTest.php
+++ b/tests/RegistrarTest.php
@@ -63,6 +63,40 @@ class RegistrarTest extends TestCase
     }
 
     /**
+     * Test that we can normalize an email provided in the 'username' field.
+     */
+    public function testNormalizeEmailAsUsername()
+    {
+        $credentials = [
+            'username' => 'Kamala.Khan@marvel.com ',
+        ];
+
+        $normalized = $this->registrar->normalize($credentials);
+
+        $this->assertArrayNotHasKey('username', $normalized);
+        $this->assertArrayNotHasKey('mobile', $normalized);
+        
+        $this->assertSame('kamala.khan@marvel.com', $normalized['email']);
+    }
+
+    /**
+     * Test that we can normalize an email provided in the 'username' field.
+     */
+    public function testNormalizeMobileAsUsername()
+    {
+        $credentials = [
+            'username' => '1 (555) 123-4567',
+        ];
+
+        $normalized = $this->registrar->normalize($credentials);
+
+        $this->assertArrayNotHasKey('username', $normalized);
+        $this->assertArrayNotHasKey('email', $normalized);
+
+        $this->assertSame('15551234567', $normalized['mobile']);
+    }
+
+    /**
      * Test that we can normalize multiple fields.
      */
     public function testNormalizeMultipleFields()

--- a/tests/RegistrarTest.php
+++ b/tests/RegistrarTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Northstar\Auth\Registrar;
+
+class RegistrarTest extends TestCase
+{
+    /**
+     * The registrar to be tested.
+     * @var Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Create a new Registrar before each test.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->registrar = app(Registrar::class);
+    }
+
+    /**
+     * Test that we can normalize the ID field name.
+     */
+    public function testNormalizeId()
+    {
+        $credentials = [
+            'id' => $this->faker->uuid,
+        ];
+
+        $normalized = $this->registrar->normalize($credentials);
+
+        $this->assertArrayHasKey('_id', $normalized);
+        $this->assertArrayNotHasKey('id', $normalized);
+        $this->assertSame($credentials['id'], $normalized['_id']);
+    }
+
+    /**
+     * Test that we can normalize email addresses.
+     */
+    public function testNormalizeEmail()
+    {
+        $normalized = $this->registrar->normalize([
+            'email' => 'Kamala.Khan@marvel.com ',
+        ]);
+
+        $this->assertSame('kamala.khan@marvel.com', $normalized['email']);
+    }
+
+    /**
+     * Test that we can normalize mobile phone numbers.
+     */
+    public function testNormalizeMobile()
+    {
+        $normalized = $this->registrar->normalize([
+            'mobile' => '1 (555) 123-4567',
+        ]);
+
+        $this->assertSame('15551234567', $normalized['mobile']);
+    }
+
+    /**
+     * Test that we can normalize multiple fields.
+     */
+    public function testNormalizeMultipleFields()
+    {
+        $normalized = $this->registrar->normalize([
+            '_id' => $this->faker->uuid,
+            'mobile' => $this->faker->phoneNumber,
+        ]);
+
+        $this->assertArrayHasKey('_id', $normalized);
+        $this->assertArrayHasKey('mobile', $normalized);
+        $this->assertArrayNotHasKey('email', $normalized);
+    }
+}

--- a/tests/RegistrarTest.php
+++ b/tests/RegistrarTest.php
@@ -75,7 +75,7 @@ class RegistrarTest extends TestCase
 
         $this->assertArrayNotHasKey('username', $normalized);
         $this->assertArrayNotHasKey('mobile', $normalized);
-        
+
         $this->assertSame('kamala.khan@marvel.com', $normalized['email']);
     }
 


### PR DESCRIPTION
#### Changes
Closes #322. Since the OAuth 2 password grant also [requires a username field](https://tools.ietf.org/html/rfc6749#section-4.3.2) (rather than `email` or `mobile` like we currently provide), this is also a pre-requisite to implementing #202.

#### How should this be reviewed?
I did a bit of cleanup along the way, but the important changes are at the top of the `normalize` method of the Registrar, which now checks for a "username" field in the user's credentials and transforms it into either an "email" or "mobile" if found.

---
For review: @angaither @weerd 