### PR TITLE
Quick fix on how arrays are handled in signup controller

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -50,7 +50,12 @@ class SignupController extends Controller
 
         // If a user is specified, turn Northstar ID into Drupal ID
         if (! empty($options['users'])) {
-            $usersQuery = explode(',', $options['users']);
+            if (is_array($options['users'])) {
+                $usersQuery = $options['users'];
+            } else {
+                $usersQuery = explode(',', $options['users']);
+            }
+
             $options['users'] = User::drupalIDForNorthstarId($usersQuery);
         }
 


### PR DESCRIPTION
#### What's this PR do?
When requesting this URL via Gladiator, for some reason Northstar gets it already as an array & thus doesn't need to be exploded(). However when requesting from the browser, its a string that does need to be exploded.

#### How should this be manually tested?
`http://northstar.app/v1/signups?competition=1&users=5571df42a59dbf3b7a8b456d,5575e568a59dbf3b7a8b4572&campaigns=1485`