### PR TITLE
Oauth Middleware

### DIFF
--- a/app/Auth/Repositories/ScopeRepository.php
+++ b/app/Auth/Repositories/ScopeRepository.php
@@ -6,7 +6,7 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use Northstar\Auth\Entities\ScopeEntity;
-use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 
 class ScopeRepository implements ScopeRepositoryInterface
 {
@@ -18,7 +18,7 @@ class ScopeRepository implements ScopeRepositoryInterface
      */
     public function getScopeEntityByIdentifier($identifier)
     {
-        $scopes = Client::scopes();
+        $scopes = Scope::all();
 
         if (array_key_exists($identifier, $scopes) === false) {
             return null;

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Northstar\Auth;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Northstar\Models\Client;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class Scope
+{
+    /**
+     * Available API Key scopes.
+     * @var array
+     */
+    protected static $scopes = [
+        'admin' => [
+            'description' => 'Allows "administrative" actions that should not be user-accessible, like deleting user records.',
+        ],
+        'user' => [
+            'description' => 'Allows actions to be made on a user\'s behalf.',
+        ],
+    ];
+
+    /**
+     * Return a list of all scopes & their descriptions.
+     *
+     * @return array
+     */
+    public static function all()
+    {
+        return static::$scopes;
+    }
+
+    /**
+     * Validate if all the given scopes are valid.
+     *
+     * @param $scopes
+     * @return bool
+     */
+    public static function validateScopes($scopes)
+    {
+        if (! is_array($scopes)) {
+            return false;
+        }
+
+        return ! array_diff($scopes, array_keys(static::$scopes));
+    }
+
+    /**
+     * Return whether a properly scoped API key is provided
+     * with the current request.
+     *
+     * @param $scope - Required scope
+     * @return bool
+     */
+    public static function allows($scope)
+    {
+        $oauthScopes = request()->attributes->get('oauth_scopes');
+
+        // If scopes have been parsed from a provided JWT access token, check against
+        // those. Otherwise, check the Client specified by the `X-DS-REST-API-Key` header.
+        if (! is_null($oauthScopes)) {
+            return in_array($scope, $oauthScopes);
+        }
+
+        $key = Client::current();
+
+        return $key && $key->hasScope($scope);
+    }
+
+    /**
+     * Throw an exception if a properly scoped API key is not
+     * provided with the current request.
+     *
+     * @param $scope - Required scope
+     * @throws OAuthServerException
+     */
+    public static function gate($scope)
+    {
+        if (! static::allows($scope)) {
+            app('stathat')->ezCount('invalid API key error');
+
+            // If scopes have been parsed from a provided JWT access token, use OAuth access
+            // denied exception to return a 401 error.
+            if (request()->attributes->has('oauth_scopes')) {
+                throw OAuthServerException::accessDenied('Requires the `'.$scope.'` scope.');
+            }
+
+            // ...if we're using a legacy API key, return the expected 403 error.
+            throw new AccessDeniedHttpException('You must be using an API key with "'.$scope.'" scope to do that.');
+        }
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -55,6 +55,7 @@ class Handler extends ExceptionHandler
         // convert it to a standard Symfony HttpFoundation response and return.
         if ($e instanceof OAuthServerException) {
             $psrResponse = $e->generateHttpResponse(app(ResponseInterface::class));
+
             return (new HttpFoundationFactory())->createResponse($psrResponse);
         }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -9,6 +9,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Validation\ValidationException as LegacyValidationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Psr\Http\Message\ResponseInterface;
 use Exception;
 
@@ -50,10 +51,11 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
-        $psrResponse = app(ResponseInterface::class);
-
+        // If we receive a OAuth exception, get the included PSR-7 response,
+        // convert it to a standard Symfony HttpFoundation response and return.
         if ($e instanceof OAuthServerException) {
-            return $e->generateHttpResponse($psrResponse);
+            $psrResponse = $e->generateHttpResponse(app(ResponseInterface::class));
+            return (new HttpFoundationFactory())->createResponse($psrResponse);
         }
 
         // If client requests it, render exception as JSON object

--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -3,7 +3,7 @@
 namespace Northstar\Http\Controllers;
 
 use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 use Northstar\Services\AWS;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
@@ -56,7 +56,7 @@ class AvatarController extends Controller
 
         // Only the currently authorized user to edit their own profile
         // or, if using an `admin` scoped API key, any profile.
-        $allowed = Client::allows('admin') || Gate::allows('edit-profile', $user);
+        $allowed = Scope::allows('admin') || Gate::allows('edit-profile', $user);
         if (! $allowed) {
             throw new UnauthorizedHttpException('auth/token', 'You are not authorized to edit that user\'s avatar.');
         }

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -2,7 +2,7 @@
 
 namespace Northstar\Http\Controllers\Traits;
 
-use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 
 trait FiltersRequests
 {
@@ -67,7 +67,7 @@ trait FiltersRequests
         }
 
         // Only "admin" keys should be able to search
-        Client::gate('admin');
+        Scope::gate('admin');
 
         // Searches may only be performed on indexed fields.
         $searches = array_intersect_key($searches, array_flip($indexes));

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -13,7 +13,9 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
-        \Northstar\Http\Middleware\ParseOAuthHeader::class,
+
+        // @TODO: Enable this once we've updated PHP version.
+        //  \Northstar\Http\Middleware\ParseOAuthHeader::class,
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -23,6 +23,9 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'auth' => \Northstar\Http\Middleware\Authenticate::class,
         'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
-        'key' => \Northstar\Http\Middleware\AuthenticateAPIKey::class,
+        'scope' => \Northstar\Http\Middleware\RequireScope::class,
+
+        // @TODO: Remove this old alias for the scope middleware.
+        'key' => \Northstar\Http\Middleware\RequireScope::class,
     ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -13,6 +13,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Northstar\Http\Middleware\ParseOAuthHeader::class,
     ];
 
     /**

--- a/app/Http/Middleware/ParseOAuthHeader.php
+++ b/app/Http/Middleware/ParseOAuthHeader.php
@@ -3,7 +3,6 @@
 namespace Northstar\Http\Middleware;
 
 use League\OAuth2\Server\Server as OAuthServer;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class ParseOAuthHeader
@@ -12,13 +11,11 @@ class ParseOAuthHeader
      * Authenticate constructor.
      * @param OAuthServer $oauth
      * @param ServerRequestInterface $request
-     * @param ResponseInterface $response
      */
-    public function __construct(OAuthServer $oauth, ServerRequestInterface $request, ResponseInterface $response)
+    public function __construct(OAuthServer $oauth, ServerRequestInterface $request)
     {
         $this->oauth = $oauth;
         $this->request = $request;
-        $this->response = $response;
     }
 
     /**

--- a/app/Http/Middleware/ParseOAuthHeader.php
+++ b/app/Http/Middleware/ParseOAuthHeader.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Server as OAuthServer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ParseOAuthHeader
+{
+    /**
+     * Authenticate constructor.
+     * @param OAuthServer $oauth
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     */
+    public function __construct(OAuthServer $oauth, ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $this->oauth = $oauth;
+        $this->request = $request;
+        $this->response = $response;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($request, \Closure $next)
+    {
+        $header = $request->header('Authorization');
+
+        // If the 'Authorization' header is set, and it's not the legacy
+        // 32 character key (with the "Bearer " prefix = 39 characters)...
+        if (! empty($header) && strlen($header) !== 39) {
+            $this->request = $this->oauth->validateAuthenticatedRequest($this->request);
+
+            // Add the parsed attributes (oauth_access_token_id, oauth_client_id,
+            // oauth_user_id, & oauth_scopes) to the request.
+            $request->attributes->add($this->request->getAttributes());
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ParseOAuthHeader.php
+++ b/app/Http/Middleware/ParseOAuthHeader.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Http\Middleware;
 
-use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Server as OAuthServer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/app/Http/Middleware/RequireScope.php
+++ b/app/Http/Middleware/RequireScope.php
@@ -5,7 +5,7 @@ namespace Northstar\Http\Middleware;
 use Northstar\Models\Client;
 use Closure;
 
-class AuthenticateAPIKey
+class RequireScope
 {
     /**
      * Handle an incoming request.

--- a/app/Http/Middleware/RequireScope.php
+++ b/app/Http/Middleware/RequireScope.php
@@ -2,7 +2,7 @@
 
 namespace Northstar\Http\Middleware;
 
-use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 use Closure;
 
 class RequireScope
@@ -17,7 +17,7 @@ class RequireScope
      */
     public function handle($request, Closure $next, $scope = 'user')
     {
-        Client::gate($scope);
+        Scope::gate($scope);
 
         return $next($request);
     }

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Northstar\Http\Transformers;
 
-use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 use Northstar\Models\User;
 use League\Fractal\TransformerAbstract;
 use Gate;
@@ -24,7 +24,7 @@ class UserTransformer extends TransformerAbstract
             'first_name' => $user->first_name,
         ];
 
-        if (Client::allows('admin') || Gate::allows('view-full-profile', $user)) {
+        if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['last_name'] = $user->last_name;
         }
 
@@ -33,7 +33,7 @@ class UserTransformer extends TransformerAbstract
         $response['photo'] = $user->photo;
         $response['interests'] = $user->interests;
 
-        if (Client::allows('admin') || Gate::allows('view-full-profile', $user)) {
+        if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['birthdate'] = $user->birthdate;
 
             $response['addr_street1'] = $user->addr_street1;

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -36,6 +36,11 @@ $router->group(['prefix' => 'v2'], function () use ($router) {
 
     // OAuth Clients
     $router->resource('clients', 'ClientController');
+
+    // Scopes
+    $router->get('scopes', function () {
+        return \Northstar\Models\Client::scopes();
+    });
 });
 
 // https://northstar.dosomething.org/v1/
@@ -66,6 +71,11 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
     $router->resource('keys', 'ClientController');
 
     $router->get('scopes', function () {
-        return \Northstar\Models\Client::scopes();
+        $scopes = \Northstar\Models\Client::scopes();
+
+        // Format as a single key-value array to keep compatibility.
+        return collect($scopes)->map(function ($scope) {
+            return $scope['description'];
+        });
     });
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -39,7 +39,7 @@ $router->group(['prefix' => 'v2'], function () use ($router) {
 
     // Scopes
     $router->get('scopes', function () {
-        return \Northstar\Models\Client::scopes();
+        return \Northstar\Auth\Scope::all();
     });
 });
 
@@ -71,7 +71,7 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
     $router->resource('keys', 'ClientController');
 
     $router->get('scopes', function () {
-        $scopes = \Northstar\Models\Client::scopes();
+        $scopes = \Northstar\Auth\Scope::all();
 
         // Format as a single key-value array to keep compatibility.
         return collect($scopes)->map(function ($scope) {

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -4,7 +4,6 @@ namespace Northstar\Models;
 
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Model;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * The Client model. These identify the "client application" making
@@ -50,19 +49,6 @@ class Client extends Model
      */
     protected $attributes = [
         'scope' => [],
-    ];
-
-    /**
-     * Available API Key scopes.
-     * @var array
-     */
-    protected static $scopes = [
-        'admin' => [
-            'description' => 'Allows "administrative" actions that should not be user-accessible, like deleting user records.',
-        ],
-        'user' => [
-            'description' => 'Allows actions to be made on a user\'s behalf.',
-        ],
     ];
 
     /**
@@ -150,67 +136,14 @@ class Client extends Model
     }
 
     /**
-     * Validate if all the given scopes are valid.
-     *
-     * @param $scopes
-     * @return bool
-     */
-    public static function validateScopes($scopes)
-    {
-        if (! is_array($scopes)) {
-            return false;
-        }
-
-        return ! array_diff($scopes, array_keys(static::$scopes));
-    }
-
-    /**
-     * Return a list of all scopes & their descriptions.
-     *
-     * @return array
-     */
-    public static function scopes()
-    {
-        return static::$scopes;
-    }
-
-    /**
      * Get the API key specified for the current request.
      *
-     * @return \Northstar\Models\ApiKey
+     * @return \Northstar\Models\Client
      */
     public static function current()
     {
         $api_key = request()->header('X-DS-REST-API-Key');
 
         return static::where('api_key', $api_key)->first();
-    }
-
-    /**
-     * Return whether a properly scoped API key is provided
-     * with the current request.
-     *
-     * @param $scope - Required scope
-     * @return bool
-     */
-    public static function allows($scope)
-    {
-        $key = self::current();
-
-        return $key && $key->hasScope($scope);
-    }
-
-    /**
-     * Throw an exception if a properly scoped API key is not
-     * provided with the current request.
-     *
-     * @param $scope - Required scope
-     */
-    public static function gate($scope)
-    {
-        if (! static::allows($scope)) {
-            app('stathat')->ezCount('invalid API key error');
-            throw new AccessDeniedHttpException('You must be using an API key with "'.$scope.'" scope to do that.');
-        }
     }
 }

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Northstar\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 
 class ValidationServiceProvider extends ServiceProvider
 {
@@ -25,7 +25,7 @@ class ValidationServiceProvider extends ServiceProvider
 
         // Add custom validator for localized date (e.g. `MM/DD/YYYY` or `DD/MM/YYYY`).
         $this->validator->extend('scope', function ($attribute, $value, $parameters) {
-            return Client::validateScopes($value);
+            return Scope::validateScopes($value);
         }, 'Invalid scope(s) provided.');
     }
 


### PR DESCRIPTION
#### What's this PR do?
This PR updates our custom Guard and scope middleware to accept new OAuth JWT tokens as well as our old database tokens. This will allow any protected route to be accessed using either form of token.

It also includes a tiny fix to maintain backwards compatibility with how the `v1/scopes` response is structured (since the backend array storing those was modified to support the OAuth implementation).

__Note:__ The `\Northstar\Http\Middleware\ParseOAuthHeader` middleware is commented out because it causes issues on PHP < 5.6 (see original comments below). Since this just means the request attributes will be unset, everything will continue to only check the for the "legacy" auth tokens.

#### How should this be reviewed?
I'd recommend taking a look commit-by-commit. Most of the changes are very small, although there are some bigger "re-shuffling" changes like moving scope methods/property into it's own class in cfdc684.

I'll add tests once the middleware can be uncommented (since right now it'd just fail fail fail).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 