### PR TITLE
Database updates for OAuth clients table.

### DIFF
--- a/app/Auth/Entities/ClientEntity.php
+++ b/app/Auth/Entities/ClientEntity.php
@@ -24,9 +24,9 @@ class ClientEntity implements ClientEntityInterface
      */
     public function __construct($client_id, $scopes)
     {
-        $this->name = $client_id;
+        $this->name = $client_id; // @TODO: If we store a human-readable client name, use here.
         $this->allowedScopes = $scopes;
-        $this->identifier = 'dosomething.org';
+        $this->identifier = $client_id;
 
         // @TODO: Will need this for authentication code flow. Save this per client!
         $this->redirectUri = '';

--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -20,8 +20,8 @@ class ClientRepository implements ClientRepositoryInterface
     {
         // Fetch client from the database & make OAuth2 entity
         $model = Client::where([
-            'app_id' => $clientIdentifier,
-            'api_key' => $clientSecret,
+            'client_id' => $clientIdentifier,
+            'client_secret' => $clientSecret,
         ])->first();
 
         if (! $model) {

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -46,8 +46,8 @@ class ClientController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
-            'app_id' => 'required|unique:api_keys,app_id',
-            'scope' => 'array|scope', // @see ApiKey::validateScopes
+            'app_id' => 'required|unique:clients,client_id',
+            'scope' => 'array|scope', // @see Scope::validateScopes
         ]);
 
         $key = Client::create($request->all());
@@ -57,51 +57,52 @@ class ClientController extends Controller
 
     /**
      * Display the specified resource.
-     * GET /keys/:api_key
+     * GET /keys/:client_secret
      *
      * @return \Illuminate\Http\Response
      * @throws NotFoundHttpException
      */
-    public function show($id)
+    public function show($client_secret)
     {
-        // Find the user.
-        $key = Client::where('api_key', $id)->first();
-        if (! $key) {
+        $client = Client::where('client_secret', $client_secret)->first();
+
+        if (! $client) {
             throw new NotFoundHttpException('The resource does not exist.');
         }
 
-        return $this->item($key);
+        return $this->item($client);
     }
 
     /**
      * Update the specified resource.
-     * PUT /keys/:api_key
+     * PUT /keys/:client_secret
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
      * @throws HttpException
      */
-    public function update($key, Request $request)
+    public function update($client_secret, Request $request)
     {
         $this->validate($request, [
-            'scope' => 'array|scope', // @see ApiKey::validateScopes
+            'scope' => 'array|scope', // @see Scope::validateScopes
         ]);
 
-        $key = Client::where('api_key', $key)->firstOrFail();
-        $key->update($request->all());
+        $client = Client::where('client_secret', $client_secret)->firstOrFail();
+        $client->update($request->all());
 
-        return $this->item($key);
+        return $this->item($client);
     }
 
     /**
      * Delete an API key resource.
+     * DELETE /keys/:client_secret
      *
      * @return \Illuminate\Http\Response
      */
-    public function destroy($key)
+    public function destroy($client_secret)
     {
-        $key = Client::where('api_key', $key)->firstOrFail();
-        $key->delete();
+        $client = Client::where('client_secret', $client_secret)->firstOrFail();
+        $client->delete();
 
         return $this->respond('Deleted key.', 200);
     }

--- a/app/Http/Transformers/ClientTransformer.php
+++ b/app/Http/Transformers/ClientTransformer.php
@@ -22,8 +22,8 @@ class ClientTransformer extends TransformerAbstract
             'created_at' => $client->created_at->toISO8601String(),
 
             // DEPRECATED:
-            'app_id' => $client->app_id,
-            'api_key' => $client->api_key,
+            'app_id' => $client->client_id,
+            'api_key' => $client->client_secret,
         ];
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -13,12 +13,6 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  * @property string client_id
  * @property string client_secret
  * @property array $scope
- *
- * Deprecated properties:
- * @property string $_id
- * @property string $id
- * @property string $app_id
- * @property string $api_key
  */
 class Client extends Model
 {
@@ -27,7 +21,7 @@ class Client extends Model
      *
      * @var string
      */
-    protected $primaryKey = 'api_key';
+    protected $primaryKey = 'client_id';
 
     /**
      * Indicates if the IDs are auto-incrementing.
@@ -71,8 +65,12 @@ class Client extends Model
      * @var array
      */
     protected $fillable = [
-        'app_id',
+        'client_id',
         'scope',
+
+        // For backwards compatibility...
+        'app_id',
+        'api_key',
     ];
 
     /**
@@ -88,41 +86,28 @@ class Client extends Model
         // Automatically set random API key. This field *may* be manually
         // set when seeding the database, so we first check if empty.
         static::creating(function (Client $client) {
-            if (empty($client->api_key)) {
-                do {
-                    $key = Str::random(32);
-                } while (static::where('api_key', $key)->exists());
-
-                $client->api_key = $key;
+            if (empty($client->client_secret)) {
+                $client->client_secret = Str::random(32);
             }
         });
     }
 
     /**
-     * Map 'app_id' to it's OAuth equivalent.
+     * Map legacy 'app_id' to it's OAuth equivalent.
      * @return string
      */
-    public function getClientIdAttribute()
+    public function setAppIdAttribute($value)
     {
-        return $this->attributes['app_id'];
+        $this->attributes['client_id'] = snake_case(str_replace(' ', '', $value));
     }
 
     /**
-     * Map 'api_key' to it's OAuth equivalent.
+     * Mutator for 'client_id' attribute.
      * @return string
      */
-    public function getClientSecretAttribute()
+    public function setClientIdAttribute($value)
     {
-        return $this->attributes['api_key'];
-    }
-
-    /**
-     * Mutator for 'app_id' attribute.
-     * @return string
-     */
-    public function setAppIdAttribute($app_id)
-    {
-        $this->attributes['app_id'] = snake_case(str_replace(' ', '', $app_id));
+        $this->attributes['client_id'] = snake_case(str_replace(' ', '', $value));
     }
 
     /**
@@ -181,9 +166,9 @@ class Client extends Model
      */
     public static function current()
     {
-        $api_key = request()->header('X-DS-REST-API-Key');
+        $client_secret = request()->header('X-DS-REST-API-Key');
 
-        return static::where('api_key', $api_key)->first();
+        return static::where('client_secret', $client_secret)->first();
     }
 
     /**

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -41,7 +41,7 @@ class Client extends Model
      *
      * @var string
      */
-    protected $collection = 'api_keys';
+    protected $collection = 'clients';
 
     /**
      * The model's default attributes.

--- a/database/migrations/2016_04_15_191743_AddIndexToRefreshTokens.php
+++ b/database/migrations/2016_04_15_191743_AddIndexToRefreshTokens.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToRefreshTokens extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('refresh_tokens', function (Blueprint $collection) {
+            $collection->unique('token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('refresh_tokens', function (Blueprint $collection) {
+            $collection->dropUnique('token');
+        });
+    }
+}

--- a/database/migrations/2016_04_15_192326_RenameClientTable.php
+++ b/database/migrations/2016_04_15_192326_RenameClientTable.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class RenameClientTable extends Migration
+{
+    /**
+     * The raw MongoDB interface.
+     * @var MongoDB
+     */
+    protected $mongodb;
+
+    public function __construct()
+    {
+        $this->mongodb = app('db')->getMongoDB();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // The 'jenssegers/laravel-mongodb' package doesn't support Schema::rename so...
+        $this->mongodb->execute('db.api_keys.renameCollection("clients");');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->mongodb->execute('db.clients.renameCollection("api_keys");');
+    }
+}

--- a/database/migrations/2016_04_15_192413_RenameClientFields.php
+++ b/database/migrations/2016_04_15_192413_RenameClientFields.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Jenssegers\Mongodb\Schema\Blueprint;
+
+class RenameClientFields extends Migration
+{
+    /**
+     * The raw MongoDB interface.
+     * @var MongoDB
+     */
+    protected $mongodb;
+
+    public function __construct()
+    {
+        $this->mongodb = app('db')->getMongoDB();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Remove the unique index on api_key
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->dropIndex('api_key');
+        });
+
+        // Rename 'app_id' column to 'client_id'
+        $this->mongodb->execute('db.clients.update({}, {$rename:{"app_id":"client_id"}}, { upsert:false, multi:true });');
+
+        // Rename 'api_key' column to 'client_secret'
+        $this->mongodb->execute('db.clients.update({}, {$rename:{"api_key":"client_secret"}}, { upsert:false, multi:true });');
+
+        // Add an index for querying by client_id & client_secret
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->index(['client_id', 'client_secret']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->dropIndex(['client_id', 'client_secret']);
+        });
+
+        $this->mongodb->execute(
+            'db.clients.update({}, {$rename:{"client_secret":"api_key"}}, { upsert:false, multi:true });'
+        );
+
+        $this->mongodb->execute(
+            'db.clients.update({}, {$rename:{"client_id":"app_id"}}, { upsert:false, multi:true });'
+        );
+
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->unique('api_key');
+        });
+    }
+}

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -15,14 +15,14 @@ class ApiKeyTableSeeder extends Seeder
         DB::table('client')->delete();
 
         Client::create([
-            'app_id' => '456',
-            'api_key' => 'abc4324',
+            'client_id' => '456',
+            'client_secret' => 'abc4324',
             'scope' => ['admin', 'user'],
         ]);
 
         Client::create([
-            'app_id' => '123',
-            'api_key' => '5464utyrs',
+            'client_id' => '123',
+            'client_secret' => '5464utyrs',
             'scope' => ['user'],
         ]);
     }

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Northstar\Models\ApiKey;
+use Northstar\Models\Client;
 
 class ApiKeyTableSeeder extends Seeder
 {
@@ -12,15 +12,15 @@ class ApiKeyTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('api_keys')->delete();
+        DB::table('client')->delete();
 
-        ApiKey::create([
+        Client::create([
             'app_id' => '456',
             'api_key' => 'abc4324',
             'scope' => ['admin', 'user'],
         ]);
 
-        ApiKey::create([
+        Client::create([
             'app_id' => '123',
             'api_key' => '5464utyrs',
             'scope' => ['user'],

--- a/tests/ApiKeyTest.php
+++ b/tests/ApiKeyTest.php
@@ -10,8 +10,8 @@ class ApiKeyTest extends TestCase
      */
     public function testIndex()
     {
-        Client::create(['app_id' => 'test']);
-        Client::create(['app_id' => 'testingz']);
+        Client::create(['client_id' => 'test']);
+        Client::create(['client_id' => 'testingz']);
 
         // Verify an admin key is able to view all keys
         $this->withScopes(['admin'])->get('v1/keys');
@@ -60,7 +60,7 @@ class ApiKeyTest extends TestCase
      */
     public function testShow()
     {
-        $client = Client::create(['app_id' => 'phpunit_key']);
+        $client = Client::create(['client_id' => 'phpunit_key']);
 
         // Verify a "user" scoped key is not able to see keys details
         $this->withScopes(['user'])->get('v1/keys/'.$client->client_secret);
@@ -71,13 +71,8 @@ class ApiKeyTest extends TestCase
         $this->assertResponseStatus(403);
 
         // Verify an admin key is able to view key details
-        $this->withScopes(['admin'])->get('v1/keys/'.$client->api_key);
+        $this->withScopes(['admin'])->get('v1/keys/'.$client->client_secret);
         $this->assertResponseStatus(200);
-        $this->seeJsonStructure([
-            'data' => [
-                'app_id', 'api_key', 'scope',
-            ],
-        ]);
     }
 
     /**
@@ -86,7 +81,7 @@ class ApiKeyTest extends TestCase
      */
     public function testUpdate()
     {
-        $client = Client::create(['app_id' => 'update_key']);
+        $client = Client::create(['client_id' => 'update_key']);
 
         $modifications = [
             'scope' => [
@@ -102,8 +97,8 @@ class ApiKeyTest extends TestCase
         // Verify an admin key is able to update a key
         $this->withScopes(['admin'])->json('PUT', 'v1/keys/'.$client->client_secret, $modifications);
         $this->assertResponseStatus(200);
-        $this->seeInDatabase('api_keys', [
-            'app_id' => 'update_key',
+        $this->seeInDatabase('clients', [
+            'client_id' => 'update_key',
             'scope' => ['admin', 'user'],
         ]);
     }
@@ -114,15 +109,16 @@ class ApiKeyTest extends TestCase
      */
     public function testDestroy()
     {
-        $client = Client::create(['app_id' => 'delete_me']);
+        $client = Client::create(['client_id' => 'delete_me']);
 
         // Verify a "user" scoped key is not able to delete keys
         $this->withScopes(['user'])->json('DELETE', 'v1/keys/'.$client->client_secret);
         $this->assertResponseStatus(403);
+        $this->seeInDatabase('clients', ['client_id' => 'delete_me']);
 
         // Verify an admin key is able to delete a key
-        $this->withScopes(['admin'])->json('DELETE', 'v1/keys/'.$client->api_key);
+        $this->withScopes(['admin'])->json('DELETE', 'v1/keys/'.$client->client_secret);
         $this->assertResponseStatus(200);
-        $this->dontSeeInDatabase('clients', ['app_id' => 'delete_me']);
+        $this->dontSeeInDatabase('clients', ['client_id' => 'delete_me']);
     }
 }

--- a/tests/ApiKeyTest.php
+++ b/tests/ApiKeyTest.php
@@ -123,6 +123,6 @@ class ApiKeyTest extends TestCase
         // Verify an admin key is able to delete a key
         $this->withScopes(['admin'])->json('DELETE', 'v1/keys/'.$client->api_key);
         $this->assertResponseStatus(200);
-        $this->dontSeeInDatabase('api_keys', ['app_id' => 'delete_me']);
+        $this->dontSeeInDatabase('clients', ['app_id' => 'delete_me']);
     }
 }

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -37,6 +37,12 @@ class OAuthTest extends TestCase
         // Check that the token has the expected user ID and scopes.
         $this->assertSame($user->id, $jwt->getClaim('sub'));
         $this->assertSame(['admin', 'user'], $jwt->getClaim('scopes'));
+
+        // Check that a refresh token was saved to the database.
+        $this->seeInDatabase('refresh_tokens', [
+            'user_id' => $user->id,
+            'client_id' => $client->client_id,
+        ]);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,7 +71,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function withScopes(array $scopes)
     {
         $client = Client::create([
-            'app_id' => 'testing'.$this->faker->uuid,
+            'client_id' => 'testing'.$this->faker->uuid,
             'scope' => $scopes,
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
This PR includes database updates for the changes made in #331 and #333.

It renames the `api_keys` table to `clients` since "API keys" are now being used as OAuth 2 clients, and renames the `app_id` and `api_key` fields on each of those documents to `client_id` and `client_secret` so that the corresponding database queries make more sense.

Since we need to maintain backwards compatibility for the "legacy" authentication flow, I added mutators to "map" the old `app_id` and `api_key` fields to the new database fields. I updated database calls (like seeding test clients and verifying database records) in the test suite, but otherwise left all the functional aspects of the tests unchanged.

#### How should this be reviewed?
I'd recommend checking things out commit-by-commit. There's a lot of little changes scattered about for renaming the database columns, but otherwise it's all small changes. 😇 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 