### PR TITLE
Fix users getting duplicate Drupal IDs.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -150,6 +150,7 @@ class Registrar
         $rules = [
             'email' => 'email|max:60|unique:users,email,'.$existingId.',_id|required_without:mobile',
             'mobile' => 'unique:users,mobile,'.$existingId.',_id|required_without:email',
+            'drupal_id' => 'unique:users,drupal_id,'.$existingId.',_id',
         ];
 
         // If a user is provided, merge it into the request so we can validate

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -51,7 +51,7 @@ class AuthController extends Controller
 
         $this->transformer = new TokenTransformer();
 
-        $this->middleware('key:user');
+        $this->middleware('scope:user');
         $this->middleware('auth', ['only' => 'invalidateToken']);
         $this->middleware('guest', ['except' => 'invalidateToken']);
     }

--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -30,7 +30,7 @@ class AvatarController extends Controller
 
         $this->transformer = new UserTransformer();
 
-        $this->middleware('key:user');
+        $this->middleware('scope:user');
         $this->middleware('auth');
     }
 

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -19,7 +19,7 @@ class ClientController extends Controller
     {
         $this->transformer = $transformer;
 
-        $this->middleware('key:admin');
+        $this->middleware('scope:admin');
     }
 
     /**

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -33,7 +33,7 @@ class ProfileController extends Controller
 
         $this->transformer = new UserTransformer();
 
-        $this->middleware('key:user');
+        $this->middleware('scope:user');
         $this->middleware('auth');
     }
 

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -25,7 +25,7 @@ class ReportbackController extends Controller
     {
         $this->phoenix = $phoenix;
 
-        $this->middleware('key:user', ['only' => ['profile', 'store']]);
+        $this->middleware('scope:user', ['only' => ['profile', 'store']]);
         $this->middleware('auth', ['only' => ['profile', 'store']]);
     }
 

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -25,7 +25,7 @@ class SignupController extends Controller
     {
         $this->phoenix = $phoenix;
 
-        $this->middleware('key:user', ['only' => ['profile', 'store']]);
+        $this->middleware('scope:user', ['only' => ['profile', 'store']]);
         $this->middleware('auth', ['only' => ['profile', 'store']]);
     }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -75,7 +75,7 @@ class UserController extends Controller
     public function store(Request $request)
     {
         // This is an "upsert" endpoint (so it will either create a new user, or
-        // update a user if one with a matching email or mobile number is found).
+        // update a user if one with a matching index field is found).
         // So, does this user exist already?
         $user = $this->registrar->resolve($request->only('id', 'email', 'mobile', 'drupal_id'));
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -40,7 +40,7 @@ class UserController extends Controller
 
         $this->transformer = new UserTransformer();
 
-        $this->middleware('key:admin', ['except' => ['index', 'show']]);
+        $this->middleware('scope:admin', ['except' => ['index', 'show']]);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -77,7 +77,7 @@ class UserController extends Controller
         // This is an "upsert" endpoint (so it will either create a new user, or
         // update a user if one with a matching email or mobile number is found).
         // So, does this user exist already?
-        $user = $this->registrar->resolve($request->only('email', 'mobile'));
+        $user = $this->registrar->resolve($request->only('id', 'email', 'mobile', 'drupal_id'));
 
         // Normalize input and validate the request
         $request = $this->registrar->normalize($request);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -27,8 +27,5 @@ class Kernel extends HttpKernel
         'auth' => \Northstar\Http\Middleware\Authenticate::class,
         'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
         'scope' => \Northstar\Http\Middleware\RequireScope::class,
-
-        // @TODO: Remove this old alias for the scope middleware.
-        'key' => \Northstar\Http\Middleware\RequireScope::class,
     ];
 }

--- a/app/Http/Middleware/ParseOAuthHeader.php
+++ b/app/Http/Middleware/ParseOAuthHeader.php
@@ -9,7 +9,8 @@ use Psr\Http\Message\ServerRequestInterface;
 class ParseOAuthHeader
 {
     /**
-     * Authenticate constructor.
+     * Inject dependencies for the ParseOAuthHeader middleware.
+     *
      * @param OAuthServer $oauth
      * @param ServerRequestInterface $request
      */

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -445,7 +445,7 @@ class UserTest extends TestCase
             'source' => 'phpunit',
         ];
 
-        // This should upsert the existing user.
+        // This should cause a validation error.
         $this->withScopes(['admin'])->json('POST', 'v1/users', $payload);
         $this->assertResponseStatus(422);
     }
@@ -468,6 +468,30 @@ class UserTest extends TestCase
 
         $this->assertResponseStatus(200);
         $this->assertSame($this->decodeResponseJson()['data']['id'], $user->_id);
+    }
+
+    /**
+     * Test that we can't create a duplicate user.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testCreateDuplicateDrupalUser()
+    {
+        User::create([
+            'email' => 'existing-person@example.com',
+            'drupal_id' => '123123',
+        ]);
+
+        // Create a new user object
+        $payload = [
+            'email' => 'new-email@example.com',
+            'drupal_id' => '123123',
+        ];
+
+        // This should cause a validation error.
+        $this->withScopes(['admin'])->json('POST', 'v1/users', $payload);
+        $this->assertResponseStatus(422);
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -631,7 +631,7 @@ class UserTest extends TestCase
 
         $this->assertResponseStatus(422);
     }
-    
+
     /**
      * Test that we can't update a user's profile to have duplicate
      * identifiers with someone else.
@@ -649,7 +649,6 @@ class UserTest extends TestCase
 
         $this->assertResponseStatus(422);
     }
-    
 
     /**
      * Test for creating a user's profile image with a file

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -631,6 +631,25 @@ class UserTest extends TestCase
 
         $this->assertResponseStatus(422);
     }
+    
+    /**
+     * Test that we can't update a user's profile to have duplicate
+     * identifiers with someone else.
+     * PUT /users/_id/:id
+     */
+    public function testUpdateWithDrupalIDConflict()
+    {
+        User::create(['drupal_id' => '123456']);
+
+        $user = User::create(['email' => 'admiral.ackbar@example.com']);
+
+        $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
+            'drupal_id' => '123456', // the existing user account
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+    
 
     /**
      * Test for creating a user's profile image with a file


### PR DESCRIPTION
#### What's this PR do?
This PR fixes an issue where users with duplicate `drupal_id`s could be created (for example, when changing an email on an account in Phoenix) because we weren't using those fields to resolve and update existing accounts when POSTing to `users/`.

It also includes two clean-up commits: fixing an incorrect docblock (365af08), and removing the "key" alias to the renamed "scope" middleware (365af08).

References #334.

#### Before deploying this...
We'll want to manually clean up any duplicate `drupal_id`s before merging this, since otherwise those accounts would become "unwritable" since validation would always fail. ~~Probably a good idea to repurpose @chloealee's dedupe script?~~

__Update:__ I updated the dedupe script in 2e67a77, and tested it on a few fake "dupes" I had made before applying these fixes. Should be safe to run again on QA/production once this merges!

#### How should this be reviewed?
I'd recommend skimming the whole diff, since I ended up changing my approach a bit partway through. The changes made in 365af08 add a bit of noise, but otherwise it's all pretty straightforward.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd @chloealee 