### PR TITLE
Un-revert the reverted migration commits. :arrows_counterclockwise:

### DIFF
--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -20,8 +20,8 @@ class ClientRepository implements ClientRepositoryInterface
     {
         // Fetch client from the database & make OAuth2 entity
         $model = Client::where([
-            'app_id' => $clientIdentifier,
-            'api_key' => $clientSecret,
+            'client_id' => $clientIdentifier,
+            'client_secret' => $clientSecret,
         ])->first();
 
         if (! $model) {

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -46,8 +46,8 @@ class ClientController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
-            'app_id' => 'required|unique:api_keys,app_id',
-            'scope' => 'array|scope', // @see ApiKey::validateScopes
+            'app_id' => 'required|unique:clients,client_id',
+            'scope' => 'array|scope', // @see Scope::validateScopes
         ]);
 
         $key = Client::create($request->all());
@@ -57,51 +57,52 @@ class ClientController extends Controller
 
     /**
      * Display the specified resource.
-     * GET /keys/:api_key
+     * GET /keys/:client_secret
      *
      * @return \Illuminate\Http\Response
      * @throws NotFoundHttpException
      */
-    public function show($id)
+    public function show($client_secret)
     {
-        // Find the user.
-        $key = Client::where('api_key', $id)->first();
-        if (! $key) {
+        $client = Client::where('client_secret', $client_secret)->first();
+
+        if (! $client) {
             throw new NotFoundHttpException('The resource does not exist.');
         }
 
-        return $this->item($key);
+        return $this->item($client);
     }
 
     /**
      * Update the specified resource.
-     * PUT /keys/:api_key
+     * PUT /keys/:client_secret
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
      * @throws HttpException
      */
-    public function update($key, Request $request)
+    public function update($client_secret, Request $request)
     {
         $this->validate($request, [
-            'scope' => 'array|scope', // @see ApiKey::validateScopes
+            'scope' => 'array|scope', // @see Scope::validateScopes
         ]);
 
-        $key = Client::where('api_key', $key)->firstOrFail();
-        $key->update($request->all());
+        $client = Client::where('client_secret', $client_secret)->firstOrFail();
+        $client->update($request->all());
 
-        return $this->item($key);
+        return $this->item($client);
     }
 
     /**
      * Delete an API key resource.
+     * DELETE /keys/:client_secret
      *
      * @return \Illuminate\Http\Response
      */
-    public function destroy($key)
+    public function destroy($client_secret)
     {
-        $key = Client::where('api_key', $key)->firstOrFail();
-        $key->delete();
+        $client = Client::where('client_secret', $client_secret)->firstOrFail();
+        $client->delete();
 
         return $this->respond('Deleted key.', 200);
     }

--- a/app/Http/Transformers/ClientTransformer.php
+++ b/app/Http/Transformers/ClientTransformer.php
@@ -22,8 +22,8 @@ class ClientTransformer extends TransformerAbstract
             'created_at' => $client->created_at->toISO8601String(),
 
             // DEPRECATED:
-            'app_id' => $client->app_id,
-            'api_key' => $client->api_key,
+            'app_id' => $client->client_id,
+            'api_key' => $client->client_secret,
         ];
     }
 }

--- a/database/migrations/2016_04_15_192326_RenameClientTable.php
+++ b/database/migrations/2016_04_15_192326_RenameClientTable.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class RenameClientTable extends Migration
+{
+    /**
+     * The raw MongoDB interface.
+     * @var MongoDB
+     */
+    protected $mongodb;
+
+    public function __construct()
+    {
+        $this->mongodb = app('db')->getMongoDB();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // The 'jenssegers/laravel-mongodb' package doesn't support Schema::rename so...
+        $this->mongodb->execute('db.api_keys.renameCollection("clients");');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->mongodb->execute('db.clients.renameCollection("api_keys");');
+    }
+}

--- a/database/migrations/2016_04_15_192326_RenameClientTable.php
+++ b/database/migrations/2016_04_15_192326_RenameClientTable.php
@@ -23,7 +23,7 @@ class RenameClientTable extends Migration
     public function up()
     {
         // The 'jenssegers/laravel-mongodb' package doesn't support Schema::rename so...
-        $this->mongodb->execute('db.api_keys.renameCollection("clients");');
+        $this->mongodb->execute('db.api_keys.renameCollection("clients", true);');
     }
 
     /**
@@ -33,6 +33,6 @@ class RenameClientTable extends Migration
      */
     public function down()
     {
-        $this->mongodb->execute('db.clients.renameCollection("api_keys");');
+        $this->mongodb->execute('db.clients.renameCollection("api_keys", true);');
     }
 }

--- a/database/migrations/2016_04_15_192413_RenameClientFields.php
+++ b/database/migrations/2016_04_15_192413_RenameClientFields.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Jenssegers\Mongodb\Schema\Blueprint;
+
+class RenameClientFields extends Migration
+{
+    /**
+     * The raw MongoDB interface.
+     * @var MongoDB
+     */
+    protected $mongodb;
+
+    public function __construct()
+    {
+        $this->mongodb = app('db')->getMongoDB();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Remove the unique index on api_key
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->dropIndex('api_key');
+        });
+
+        // Rename 'app_id' column to 'client_id'
+        $this->mongodb->execute('db.clients.update({}, {$rename:{"app_id":"client_id"}}, { upsert:false, multi:true });');
+
+        // Rename 'api_key' column to 'client_secret'
+        $this->mongodb->execute('db.clients.update({}, {$rename:{"api_key":"client_secret"}}, { upsert:false, multi:true });');
+
+        // Add an index for querying by client_id & client_secret
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->index(['client_id', 'client_secret']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->dropIndex(['client_id', 'client_secret']);
+        });
+
+        $this->mongodb->execute(
+            'db.clients.update({}, {$rename:{"client_secret":"api_key"}}, { upsert:false, multi:true });'
+        );
+
+        $this->mongodb->execute(
+            'db.clients.update({}, {$rename:{"client_id":"app_id"}}, { upsert:false, multi:true });'
+        );
+
+        Schema::table('clients', function (Blueprint $collection) {
+            $collection->unique('api_key');
+        });
+    }
+}

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Northstar\Models\ApiKey;
+use Northstar\Models\Client;
 
 class ApiKeyTableSeeder extends Seeder
 {
@@ -12,17 +12,17 @@ class ApiKeyTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('api_keys')->delete();
+        DB::table('client')->delete();
 
-        ApiKey::create([
-            'app_id' => '456',
-            'api_key' => 'abc4324',
+        Client::create([
+            'client_id' => '456',
+            'client_secret' => 'abc4324',
             'scope' => ['admin', 'user'],
         ]);
 
-        ApiKey::create([
-            'app_id' => '123',
-            'api_key' => '5464utyrs',
+        Client::create([
+            'client_id' => '123',
+            'client_secret' => '5464utyrs',
             'scope' => ['user'],
         ]);
     }

--- a/tests/ApiKeyTest.php
+++ b/tests/ApiKeyTest.php
@@ -10,8 +10,8 @@ class ApiKeyTest extends TestCase
      */
     public function testIndex()
     {
-        Client::create(['app_id' => 'test']);
-        Client::create(['app_id' => 'testingz']);
+        Client::create(['client_id' => 'test']);
+        Client::create(['client_id' => 'testingz']);
 
         // Verify an admin key is able to view all keys
         $this->withScopes(['admin'])->get('v1/keys');
@@ -60,7 +60,7 @@ class ApiKeyTest extends TestCase
      */
     public function testShow()
     {
-        $client = Client::create(['app_id' => 'phpunit_key']);
+        $client = Client::create(['client_id' => 'phpunit_key']);
 
         // Verify a "user" scoped key is not able to see keys details
         $this->withScopes(['user'])->get('v1/keys/'.$client->client_secret);
@@ -71,13 +71,8 @@ class ApiKeyTest extends TestCase
         $this->assertResponseStatus(403);
 
         // Verify an admin key is able to view key details
-        $this->withScopes(['admin'])->get('v1/keys/'.$client->api_key);
+        $this->withScopes(['admin'])->get('v1/keys/'.$client->client_secret);
         $this->assertResponseStatus(200);
-        $this->seeJsonStructure([
-            'data' => [
-                'app_id', 'api_key', 'scope',
-            ],
-        ]);
     }
 
     /**
@@ -86,7 +81,7 @@ class ApiKeyTest extends TestCase
      */
     public function testUpdate()
     {
-        $client = Client::create(['app_id' => 'update_key']);
+        $client = Client::create(['client_id' => 'update_key']);
 
         $modifications = [
             'scope' => [
@@ -102,8 +97,8 @@ class ApiKeyTest extends TestCase
         // Verify an admin key is able to update a key
         $this->withScopes(['admin'])->json('PUT', 'v1/keys/'.$client->client_secret, $modifications);
         $this->assertResponseStatus(200);
-        $this->seeInDatabase('api_keys', [
-            'app_id' => 'update_key',
+        $this->seeInDatabase('clients', [
+            'client_id' => 'update_key',
             'scope' => ['admin', 'user'],
         ]);
     }
@@ -114,15 +109,16 @@ class ApiKeyTest extends TestCase
      */
     public function testDestroy()
     {
-        $client = Client::create(['app_id' => 'delete_me']);
+        $client = Client::create(['client_id' => 'delete_me']);
 
         // Verify a "user" scoped key is not able to delete keys
         $this->withScopes(['user'])->json('DELETE', 'v1/keys/'.$client->client_secret);
         $this->assertResponseStatus(403);
+        $this->seeInDatabase('clients', ['client_id' => 'delete_me']);
 
         // Verify an admin key is able to delete a key
-        $this->withScopes(['admin'])->json('DELETE', 'v1/keys/'.$client->api_key);
+        $this->withScopes(['admin'])->json('DELETE', 'v1/keys/'.$client->client_secret);
         $this->assertResponseStatus(200);
-        $this->dontSeeInDatabase('api_keys', ['app_id' => 'delete_me']);
+        $this->dontSeeInDatabase('clients', ['client_id' => 'delete_me']);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,7 +71,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function withScopes(array $scopes)
     {
         $client = Client::create([
-            'app_id' => 'testing'.$this->faker->uuid,
+            'client_id' => 'testing'.$this->faker->uuid,
             'scope' => $scopes,
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
~~Thinking it might be worth trying this again on Thor, and manually attempting the migrations if they fail again. If it doesn't work, we can always "re-clone" Thor from the production database.~~ 

A ha!! 😲 I think the rename table migration was failing because the `clients` table already existed in the database (perhaps because a request made during the deploy was making a query against the table and therefore creating it...?). When I updated the `renameCollection` call to set the [`dropTarget` parameter](https://docs.mongodb.org/manual/reference/method/db.collection.renameCollection/) to `true` and ran each line of the migrations by hand, everything worked as expected!

#### How should this be reviewed?
Take a look, does it seem reasonable (again)?

If merged in to `dev`, this will be automatically deployed to QA & Thor. Since the migrations already ran on my "test deploy" to Thor (and then were successfully "re-run" by hand), they won't run there but _should_ run and correctly update tables on QA.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither 