### PR TITLE
adds all information for user

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -56,21 +56,16 @@ class SignupController extends Controller
 
         $results = $this->phoenix->getSignupIndex($options);
 
-        foreach (array_slice($results, 1) as $result) {
-            $northstar_id = $result[0]['user']['id'];
-            $user = User::where('_id', $northstar_id)->first();
-            $last_initial = substr(($user->last_name), 0, 1);
+        foreach ($results['data'] as $key => $result) {
+            $drupal_id = $result['user']['drupal_id'];
+            $user = User::where('drupal_id', $drupal_id)->first();
 
-            if ($last_initial === false) {
-                $last_initial = null;
-            }
-
-            $result[0]['user'] = [
-                'first_name' => $user->first_name,
-                'last_initial' => $last_initial,
-                'photo' => isset($user) ? $user->photo : null,
-                'country' => $user->country,
-                'test' => 'test',
+            $results['data'][$key]['user'] = [
+                'id' => $user ? $user->id : null,
+                'first_name' => $user ? $user->first_name : null,
+                'last_initial' => $user ? $user->last_initial : null,
+                'photo' => $user ? $user->photo : null,
+                'country' => $user ? $user->country : null,
             ];
         }
 

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -57,7 +57,7 @@ class SignupController extends Controller
             $options['users'] = User::drupalIDForNorthstarId($usersQuery);
 
             $query = $this->newQuery(User::class);
-            
+
             // For the first `where` query, we want to limit results... from then on,
             // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
             $firstWhere = true;
@@ -71,11 +71,11 @@ class SignupController extends Controller
         }
 
         $results = $this->phoenix->getSignupIndex($options);
-        
+
         foreach ($results['data'] as $key => $result) {
             $drupal_id = array_get($result, 'user.drupal_id');
             $user = $users->get($drupal_id);
-            
+
             // If Phoenix gave the expected drupal_id in the user response, replace it with our own data.
             if (! empty($user)) {
                 $results['data'][$key]['user'] = [
@@ -86,7 +86,6 @@ class SignupController extends Controller
                     'country' => $user->country,
                 ];
             }
-            
         }
 
         return $results;

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -54,7 +54,27 @@ class SignupController extends Controller
             $options['users'] = User::drupalIDForNorthstarId($usersQuery);
         }
 
-        return $this->phoenix->getSignupIndex($options);
+        $results = $this->phoenix->getSignupIndex($options);
+
+        foreach (array_slice($results, 1) as $result) {
+            $northstar_id = $result[0]['user']['id'];
+            $user = User::where('_id', $northstar_id)->first();
+            $last_initial = substr(($user->last_name), 0, 1);
+
+            if ($last_initial === false) {
+                $last_initial = null;
+            }
+
+            $result[0]['user'] = [
+                'first_name' => $user->first_name,
+                'last_initial' => $last_initial,
+                'photo' => isset($user) ? $user->photo : null,
+                'country' => $user->country,
+                'test' => 'test',
+            ];
+        }
+
+        return $results;
     }
 
     /**

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -193,6 +193,8 @@ class SignupController extends Controller
     }
 
     /**
+     * Queries for all specified drupal users at once.
+     *
      * @param array $drupalIds
      * @return User
      */

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -80,7 +80,7 @@ class SignupController extends Controller
 
         foreach ($results['data'] as $key => $result) {
             $drupal_id = array_get($result, 'user.drupal_id');
-            $user = $users->get($drupal_id);
+            $user = User::where('drupal_id', $drupal_id)->first();
 
             // If Phoenix gave the expected drupal_id in the user response, replace it with our own data.
             if (! empty($user)) {

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -48,40 +48,30 @@ class SignupController extends Controller
             $options['users'] = $options['user'];
         }
 
+        
+
         // If a user is specified, turn Northstar ID into Drupal ID
         if (! empty($options['users'])) {
             // Update the '?users=xxx,xxx,xxx' option to be based on Drupal ID, rather than Northstar ID
             $usersQuery = explode(',', $options['users']);
             $options['users'] = User::drupalIDForNorthstarId($usersQuery);
 
-            $query = $this->newQuery(User::class);
-
-            // For the first `where` query, we want to limit results... from then on,
-            // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
-            $firstWhere = true;
-            foreach ($options['users'] as $drupal_id) {
-                $query->where('drupal_id', '=', $drupal_id, ($firstWhere ? 'and' : 'or'));
-                $firstWhere = false;
-            }
+            $users = $this->usersForDrupalIds($options['users']);
 
             $results = $this->phoenix->getSignupIndex($options);
         } else {
             // Since we are not specifying a NS user, grab results from Phoenix first and get Drupal ID from response to use in query below to find user. 
             $results = $this->phoenix->getSignupIndex($options);
-            $query = $this->newQuery(User::class);
-            $users = collect($results['data'])->pluck('user.drupal_id');
 
-            foreach ($users as $key => $drupal_id) {
-                $query->where('drupal_id', '=', $drupal_id);
-            }
+            $drupalIds = collect($results['data'])->pluck('user.drupal_id');
+
+            $users = $this->usersForDrupalIds($drupalIds);
         }
 
-        // Make an array keyed by the Drupal ID... e.g. ['100010' => {User}, '10002' => {User}]
-        $users = $query->get()->keyBy('drupal_id');
-
+        // Now, fill in the 'user' object on the response before returning it.
         foreach ($results['data'] as $key => $result) {
             $drupal_id = array_get($result, 'user.drupal_id');
-            $user = User::where('drupal_id', $drupal_id)->first();
+            $user = $users->where('drupal_id', $drupal_id)->first();
 
             // If Phoenix gave the expected drupal_id in the user response, replace it with our own data.
             if (! empty($user)) {
@@ -187,5 +177,24 @@ class SignupController extends Controller
 
         // If we successfully created signup, return "show" response w/ 201
         return response()->json($signupResponse, 201);
+    }
+
+    /**
+     *
+     * @param array $drupalIds
+     * @return User
+     */
+    protected function usersForDrupalIds($drupalIds) {
+            $query = $this->newQuery(User::class);
+
+            // For the first `where` query, we want to limit results... from then on,
+            // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
+            $firstWhere = true;
+            foreach ($drupalIds as $drupalId) {
+                $query->where('drupal_id', '=', $drupalId, ($firstWhere ? 'and' : 'or'));
+                $firstWhere = false;
+            }
+
+            return $query->get();
     }
 }

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -48,8 +48,6 @@ class SignupController extends Controller
             $options['users'] = $options['user'];
         }
 
-        
-
         // If a user is specified, turn Northstar ID into Drupal ID
         if (! empty($options['users'])) {
             // Update the '?users=xxx,xxx,xxx' option to be based on Drupal ID, rather than Northstar ID
@@ -60,7 +58,7 @@ class SignupController extends Controller
 
             $results = $this->phoenix->getSignupIndex($options);
         } else {
-            // Since we are not specifying a NS user, grab results from Phoenix first and get Drupal ID from response to use in query below to find user. 
+            // Since we are not specifying a NS user, grab results from Phoenix first and get Drupal ID from response to use in query below to find user.
             $results = $this->phoenix->getSignupIndex($options);
 
             $drupalIds = collect($results['data'])->pluck('user.drupal_id');
@@ -195,21 +193,21 @@ class SignupController extends Controller
     }
 
     /**
-     *
      * @param array $drupalIds
      * @return User
      */
-    protected function usersForDrupalIds($drupalIds) {
-            $query = $this->newQuery(User::class);
+    protected function usersForDrupalIds($drupalIds)
+    {
+        $query = $this->newQuery(User::class);
 
-            // For the first `where` query, we want to limit results... from then on,
-            // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
-            $firstWhere = true;
-            foreach ($drupalIds as $drupalId) {
-                $query->where('drupal_id', '=', $drupalId, ($firstWhere ? 'and' : 'or'));
-                $firstWhere = false;
-            }
+        // For the first `where` query, we want to limit results... from then on,
+        // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
+        $firstWhere = true;
+        foreach ($drupalIds as $drupalId) {
+            $query->where('drupal_id', '=', $drupalId, ($firstWhere ? 'and' : 'or'));
+            $firstWhere = false;
+        }
 
-            return $query->get();
+        return $query->get();
     }
 }

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -75,8 +75,7 @@ class SignupController extends Controller
         foreach ($results['data'] as $key => $result) {
             if ($users) {
                 $user = $users->get($drupal_id);
-            }
-            else {
+            } else {
                 $drupal_id = array_get($result, 'user.drupal_id');
                 $user = User::where('drupal_id', $drupal_id)->first();
             }

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -66,6 +66,7 @@ class SignupController extends Controller
 
             $results = $this->phoenix->getSignupIndex($options);
         } else {
+            // Since we are not specifying a NS user, grab results from Phoenix first and get Drupal ID from response to use in query below to find user. 
             $results = $this->phoenix->getSignupIndex($options);
             $query = $this->newQuery(User::class);
             $users = collect($results['data'])->pluck('user.drupal_id');

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -58,7 +58,7 @@ class SignupController extends Controller
 
         foreach ($results['data'] as $key => $result) {
             $drupal_id = array_get($result, 'user.drupal_id');
-            $user = User::where('drupal_id', $drupal_id)->first();    
+            $user = User::where('drupal_id', $drupal_id)->first();
 
             $results['data'][$key]['user'] = [
                 'id' => $user ? $user->id : null,

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -73,8 +73,13 @@ class SignupController extends Controller
         $results = $this->phoenix->getSignupIndex($options);
 
         foreach ($results['data'] as $key => $result) {
-            $drupal_id = array_get($result, 'user.drupal_id');
-            $user = $users->get($drupal_id);
+            if ($users) {
+                $user = $users->get($drupal_id);
+            }
+            else {
+                $drupal_id = array_get($result, 'user.drupal_id');
+                $user = User::where('drupal_id', $drupal_id)->first();
+            }
 
             // If Phoenix gave the expected drupal_id in the user response, replace it with our own data.
             if (! empty($user)) {

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -68,17 +68,17 @@ class SignupController extends Controller
 
             // Make an array keyed by the Drupal ID... e.g. ['100010' => {User}, '10002' => {User}]
             $users = $query->get()->keyBy('drupal_id');
+        } else {
+            // Get all drupal ids at once for index
+            $query = $this->newQuery(User::class);
+            $users = $query->select('drupal_id')->get()->keyBy('drupal_id');
         }
 
         $results = $this->phoenix->getSignupIndex($options);
 
         foreach ($results['data'] as $key => $result) {
-            if ($users) {
-                $user = $users->get($drupal_id);
-            } else {
-                $drupal_id = array_get($result, 'user.drupal_id');
-                $user = User::where('drupal_id', $drupal_id)->first();
-            }
+            $drupal_id = array_get($result, 'user.drupal_id');
+            $user = $users->get($drupal_id);
 
             // If Phoenix gave the expected drupal_id in the user response, replace it with our own data.
             if (! empty($user)) {

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -57,8 +57,8 @@ class SignupController extends Controller
         $results = $this->phoenix->getSignupIndex($options);
 
         foreach ($results['data'] as $key => $result) {
-            $drupal_id = $result['user']['drupal_id'];
-            $user = User::where('drupal_id', $drupal_id)->first();
+            $drupal_id = array_get($result, 'user.drupal_id');
+            $user = User::where('drupal_id', $drupal_id)->first();    
 
             $results['data'][$key]['user'] = [
                 'id' => $user ? $user->id : null,

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -126,7 +126,22 @@ class SignupController extends Controller
      */
     public function show($signup_id)
     {
-        return $this->phoenix->getSignup($signup_id);
+        $result = $this->phoenix->getSignup($signup_id);
+
+        $user = User::where('drupal_id', $result['data']['user']['drupal_id'])->first();
+
+        // If Phoenix gave the expected drupal_id in the user response, replace it with our own data.
+        if (! empty($user)) {
+            $result['data']['user'] = [
+                'id' => $user->id,
+                'first_name' => $user->first_name,
+                'last_initial' => $user->last_initial,
+                'photo' => $user->photo,
+                'country' => $user->country,
+            ];
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -103,9 +103,8 @@ class SignupTest extends TestCase
         $response = $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id);
         $this->assertResponseStatus(200);
         $this->seeJson();
-        $json_decoded_response = $this->decodeResponseJson();
 
-        $this->assertEquals('Name', $json_decoded_response['data'][0]['user']['first_name']);
+        $this->assertEquals('Name', $this->decodeResponseJson()['data'][0]['user']['first_name']);
     }
 
     /**

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -13,24 +13,29 @@ class SignupTest extends TestCase
      */
     public function testSignupIndex()
     {
-        $user = User::create(['drupal_id' => '100001']);
-        $user2 = User::create(['drupal_id' => '100002']);
+        $user = User::create(['drupal_id' => '100001', 'first_name' => 'Chloe']);
+        $user2 = User::create(['drupal_id' => '100002', 'first_name' => 'Dave']);
 
         // For testing, we'll mock a successful Phoenix API response.
         $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
-                    // ...
+                    'user' => [
+                        'drupal_id' => '100001',
+                    ]
                 ],
                 [
                     'id' => '44',
-                    // ...
+                    'user' => [
+                        'drupal_id' => '100002',
+                    ]
                 ],
             ],
         ]);
 
         $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id.','.$user2->_id);
+
         $this->assertResponseStatus(200);
         $this->seeJson();
 
@@ -43,6 +48,35 @@ class SignupTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Test for retrieving a user's campaigns
+     * GET /:signups
+     *
+     * @return void
+     */
+    public function testSignupIndexWherePhoenixDoesntGiveDrupalId()
+    {
+        $user = User::create(['drupal_id' => '100001', 'first_name' => 'Chloe']);
+        $user2 = User::create(['drupal_id' => '100002', 'first_name' => 'Dave']);
+
+        // For testing, we'll mock a successful Phoenix API response.
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
+            'data' => [
+                [
+                    'id' => '243',
+                    // See! It doesn't give us that thing we expected it to! >:(
+                ],
+                [
+                    'id' => '44',
+                ],
+            ],
+        ]);
+
+        // Let's just ensure it doesn't crash.
+        $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id.','.$user2->_id);
+        $this->assertResponseStatus(200);
     }
 
     /**

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -20,19 +20,20 @@ class SignupTest extends TestCase
         $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
             'data' => [
                 [
-                    'id' => '1',
+                    'id' => '243',
+                    // ...
                 ],
                 [
-                    'id' => '2',
+                    'id' => '44',
+                    // ...
                 ],
             ],
         ]);
 
-
         $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id.','.$user2->_id);
         $this->assertResponseStatus(200);
         $this->seeJson();
-        
+
         $this->seeJsonStructure([
             'data' => [
                 '*' => [
@@ -42,6 +43,35 @@ class SignupTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Test to make sure user information is populated and returned correctly on index.
+     * GET /:signups
+     *
+     * @return void
+     */
+    public function testSignupIndexUserInfo()
+    {
+        $user = User::create(['drupal_id' => '100003', 'first_name' => 'Name']);
+
+        // For testing, we'll mock a successful Phoenix API response.
+        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100003']])->once()->andReturn([
+            'data' => [
+                [
+                    'user' => [
+                        'drupal_id' => '100003',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id);
+        $this->assertResponseStatus(200);
+        $this->seeJson();
+        $json_decoded_response = $this->decodeResponseJson();
+
+        $this->assertEquals('Name', $json_decoded_response['data'][0]['user']['first_name']);
     }
 
     /**

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -20,19 +20,28 @@ class SignupTest extends TestCase
         $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
             'data' => [
                 [
-                    'id' => '243',
-                    // ...
+                    'id' => '1',
                 ],
                 [
-                    'id' => '44',
-                    // ...
+                    'id' => '2',
                 ],
             ],
         ]);
 
+
         $this->asUser($user)->withScopes(['user'])->get('v1/signups?users='.$user->_id.','.$user2->_id);
         $this->assertResponseStatus(200);
         $this->seeJson();
+        
+        $this->seeJsonStructure([
+            'data' => [
+                '*' => [
+                    'user' => [
+                        'id', 'first_name', 'last_initial', 'photo', 'country',
+                    ],
+                ],
+            ],
+        ]);
     }
 
     /**

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -23,13 +23,13 @@ class SignupTest extends TestCase
                     'id' => '243',
                     'user' => [
                         'drupal_id' => '100001',
-                    ]
+                    ],
                 ],
                 [
                     'id' => '44',
                     'user' => [
                         'drupal_id' => '100002',
-                    ]
+                    ],
                 ],
             ],
         ]);

--- a/tests/SignupTest.php
+++ b/tests/SignupTest.php
@@ -119,7 +119,9 @@ class SignupTest extends TestCase
         $this->mock(Phoenix::class)->shouldReceive('getSignup')->once()->andReturn([
             'data' => [
                 'id' => '42',
-                // ...
+                'user' => [
+                    'drupal_id' => '100001',
+                ],
             ],
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
Adds the user property in the Northstar signup proxy, in order to remove user properties (besides `id`) in [$this->user business in the phoenix](https://github.com/DoSomething/phoenix/blob/dev/lib/modules/dosomething/dosomething_signup/includes/Signup.php#L111-L115) and then "append" it to each signup in the result in the Northstar proxy method (since then it could happen as a single database query, rather than multiple HTTP requests).

Refs phoenix updates [here](https://github.com/DoSomething/phoenix/pull/6381). 

#### How should this be tested? 
On my local, added an extra line to test, and all information was returned as expected. 
```
        foreach ($results['data'] as $key => $result) {
            $drupal_id = array_get($result, 'user.drupal_id');
            $user = User::where('drupal_id', $drupal_id)->first();

            $results['data'][$key]['user'] = [
                'id' => $user ? $user->id : null,
                'first_name' => $user ? $user->first_name : null,
                'last_initial' => $user ? $user->last_initial : null,
                'photo' => $user ? $user->photo : null,
                'country' => $user ? $user->country : null,
                'test' => 'test',
            ];
        }
        print_r($results);
        die();
```
![screen shot 2016-04-25 at 12 04 07 pm](https://cloud.githubusercontent.com/assets/9019452/14790110/d172d106-0add-11e6-97db-b158cd1e5ada.png)


All tests should pass when running `vendor/bin/phpunit`

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

Do we need the above @DFurnes ?

Fixes #340 