### PR TITLE
Fix issue with upsert changing records that it shouldn't be.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -158,13 +158,12 @@ class Registrar
         if ($user) {
             $fields = array_merge($user->toArray(), $fields);
 
-            // Makes sure we can't "upsert" a record to have a changed email if set.
-            if ($request->has('email') && ! empty($user->email) && $fields['email'] !== $user->email) {
-                throw new HttpException(422, 'Cannot upsert a user to have a different email if already set.');
-            }
-
-            if ($request->has('mobile') && ! empty($user->mobile) && $fields['mobile'] !== $user->mobile) {
-                throw new HttpException(422, 'Cannot upsert a user to have a different email if already set.');
+            // Makes sure we can't "upsert" a record to have a changed index if set.
+            // @TODO: There must be a better way to do this...
+            foreach (User::$indexes as $index) {
+                if ($request->has($index) && ! empty($user->{$index}) && $fields[$index] !== $user->{$index}) {
+                    throw new HttpException(422, 'Cannot upsert a user to have a different email if already set.');
+                }
             }
         }
 

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -11,6 +11,7 @@ use Illuminate\Validation\ValidationException;
 use Northstar\Models\Token;
 use Northstar\Models\User;
 use Northstar\Services\Phoenix;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Registrar
@@ -156,6 +157,15 @@ class Registrar
         // the state of the "updated" document, rather than just the changes.
         if ($user) {
             $fields = array_merge($user->toArray(), $fields);
+
+            // Makes sure we can't "upsert" a record to have a changed email if set.
+            if ($request->has('email') && ! empty($user->email) && $fields['email'] !== $user->email) {
+                throw new HttpException(422, 'Cannot upsert a user to have a different email if already set.');
+            }
+
+            if ($request->has('mobile') && ! empty($user->mobile) && $fields['mobile'] !== $user->mobile) {
+                throw new HttpException(422, 'Cannot upsert a user to have a different email if already set.');
+            }
         }
 
         $validator = $this->validation->make($fields, array_merge($rules, $additionalRules));

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -83,7 +83,12 @@ curl -X GET \
 
 ## Create a User
 Create a new user. This is performed as an "[upsert](https://docs.mongodb.org/v2.6/reference/glossary/#term-upsert)", so
-if a user with a matching identifier is found, new/changed properties will be merged into the existing document. This means making the same request multiple times will _not_ create duplicate accounts.
+if a user with a matching identifier is found, new/changed properties will be merged into the existing document. This means
+making the same request multiple times will _not_ create duplicate accounts.
+
+Index fields (such as `email`, `mobile`, `drupal_id`) can _only_ be "upserted" if they are not already saved on the user's
+account. To change an existing value for one of these fields, you must explicitly update that user via the
+[update](#update-a-user) endpoint.
 
 This endpoint requires an API key with `admin` scope. For registering a user, consider using the
 [`auth/register`](#register-user) endpoint, which will also create and return a new authentication token.

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -204,7 +204,7 @@ class UserTest extends TestCase
             ],
             'meta' => [
                 'pagination' => [
-                   'total', 'count', 'per_page', 'current_page', 'links',
+                    'total', 'count', 'per_page', 'current_page', 'links',
                 ],
             ],
         ]);
@@ -524,6 +524,38 @@ class UserTest extends TestCase
                 // Ensure the `source` field is immutable (since we tried to update to 'phpunit'):
                 'source' => 'database',
             ],
+        ]);
+    }
+
+    /**
+     * Test for "upserting" an existing user can't change an existing
+     * user's account if *all* given credentials don't match.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testCantUpsertUserWithoutAllMatchingCredentials()
+    {
+        $user = User::create([
+            'email' => 'upsert-me@dosomething.org',
+            'mobile' => '5556667777',
+        ]);
+
+        // Post a "new" user object to merge into existing record
+        $this->withScopes(['admin'])->json('POST', 'v1/users', [
+            'email' => 'upsert-me+2@dosomething.org',
+            'mobile' => '5556667777',
+            'first_name' => 'Puppet',
+        ]);
+
+        // The response should indicate a validation conflict!
+        $this->assertResponseStatus(422);
+
+        // The existing record should be unchanged.
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'email' => 'upsert-me@dosomething.org',
+            'mobile' => '5556667777',
         ]);
     }
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -528,7 +528,7 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test for "upserting" an existing user can't change an existing
+     * Test that "upserting" an existing user can't change an existing
      * user's account if *all* given credentials don't match.
      * POST /users
      *
@@ -548,15 +548,15 @@ class UserTest extends TestCase
             'first_name' => 'Puppet',
         ]);
 
-        // The response should indicate a validation conflict!
-        $this->assertResponseStatus(422);
-
         // The existing record should be unchanged.
         $this->seeInDatabase('users', [
             '_id' => $user->id,
             'email' => 'upsert-me@dosomething.org',
             'mobile' => '5556667777',
         ]);
+
+        // The response should indicate a validation conflict!
+        $this->assertResponseStatus(422);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Fixes #345. This pull request addresses a bug with the `POST users/` endpoint. Currently, clients that use the endpoint can upsert an existing index for an account, which is probably _not_ expected behavior.

For example, when submitting `{email: 'test+1@dosomething.org', mobile: '5551234455'}`, it would make sense to upsert a user with only `{mobile: '5551234455'}` and no `email` set (so they become `{email: 'test+1@dosomething.org', mobile: '5551234455'}`).

BUT it would be confusing and unexpected to _change_ the user's email if it resolves to a user that already has a different email set... so when there's a user with `{email: 'test@dosomething.org', mobile: '5551234455'}`, submitting `{email: 'test+1@dosomething.org', mobile: '5551234455'}` would CHANGE that existing user's email to the provided `test+1@dosomething.org`. 😕 

Luckily, this can only occur from "admin" clients but we should definitely fix this as soon as possible.

#### How should this be reviewed?
Check the failing test case added in the first commit, and the changes made to fix it.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither 