### PR TITLE
Fix some more issues with updating indexes...

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -5,9 +5,8 @@ namespace Northstar\Auth;
 use Hash;
 use Illuminate\Contracts\Auth\Guard as Auth;
 use Illuminate\Validation\Factory as Validation;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
+use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Models\Token;
 use Northstar\Models\User;
 use Northstar\Services\Phoenix;
@@ -140,7 +139,7 @@ class Registrar
      * @param Request $request
      * @param User $user
      * @param array $additionalRules
-     * @throws ValidationException
+     * @throws NorthstarValidationException
      */
     public function validate(Request $request, User $user = null, array $additionalRules = [])
     {
@@ -162,15 +161,7 @@ class Registrar
         $validator = $this->validation->make($fields, array_merge($rules, $additionalRules));
 
         if ($validator->fails()) {
-            $response = [
-                'error' => [
-                    'code' => 422,
-                    'message' => 'Failed validation.',
-                    'fields' => $validator->errors()->getMessages(),
-                ],
-            ];
-
-            throw new ValidationException($validator, new JsonResponse($response, 422));
+            throw new NorthstarValidationException($validator->errors()->getMessages());
         }
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -64,15 +64,11 @@ class Handler extends ExceptionHandler
 
             // If reporting a validation exception, use the prepared response
             // @see \Northstar\Http\Controller@buildFailedValidationResponse
-            if ($e instanceof ValidationException) {
-                return $e->response;
+            if ($e instanceof ValidationException || $e instanceof NorthstarValidationException) {
+                return $e->getResponse();
             }
 
-            $code = 500;
-            if ($this->isHttpException($e)) {
-                $code = $e->getStatusCode();
-            }
-
+            $code = $e instanceof HttpException ? $e->getStatusCode() : 500;
             $response = [
                 'error' => [
                     'code' => $code,

--- a/app/Exceptions/NorthstarValidationException.php
+++ b/app/Exceptions/NorthstarValidationException.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Northstar\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use Exception;
+
+class NorthstarValidationException extends Exception
+{
+    /**
+     * The errors from the validator.
+     *
+     * @var array
+     */
+    protected $errors;
+
+    /**
+     * The formatted response for this exception.
+     *
+     * @var array
+     */
+    protected $response;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param array $errors
+     */
+    public function __construct($errors)
+    {
+        parent::__construct('The given data failed to pass validation.');
+
+        $this->errors = $errors;
+        $this->response = [
+            'error' => [
+                'code' => 422,
+                'message' => 'Failed validation.',
+                'fields' => $errors,
+            ],
+        ];
+    }
+
+    /**
+     * Get the key-value array of errors.
+     *
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Get the formatted JSON response.
+     *
+     * @return JsonResponse
+     */
+    public function getResponse()
+    {
+        return new JsonResponse($this->response, 422);
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -5,6 +5,7 @@ namespace Northstar\Http\Controllers;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Http\Controllers\Traits\FiltersRequests;
 use Northstar\Http\Controllers\Traits\TransformsResponses;
 use Illuminate\Http\Request;
@@ -14,23 +15,15 @@ abstract class Controller extends BaseController
     use DispatchesJobs, ValidatesRequests, FiltersRequests, TransformsResponses;
 
     /**
-     * Create the response for when a request fails validation. Overrides the
-     * `buildFailedValidationResponse` method from the `ValidatesRequests` trait.
+     * Throw the failed validation exception with our custom formatting. Overrides the
+     * `throwValidationException` method from the `ValidatesRequests` trait.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  array  $errors
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Illuminate\Contracts\Validation\Validator $validator
+     * @throws NorthstarValidationException
      */
-    protected function buildFailedValidationResponse(Request $request, array $errors)
+    protected function throwValidationException(Request $request, $validator)
     {
-        $response = [
-            'error' => [
-                'code' => 422,
-                'message' => 'Failed validation.',
-                'fields' => $errors,
-            ],
-        ];
-
-        return response()->json($response, 422);
+        throw new NorthstarValidationException($this->formatValidationErrors($validator));
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,12 +2,12 @@
 
 namespace Northstar\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
 use Northstar\Http\Transformers\UserTransformer;
 use Northstar\Services\Phoenix;
 use Northstar\Models\User;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UserController extends Controller
@@ -95,7 +95,13 @@ class UserController extends Controller
                     'existing' => $user->{$index},
                 ]);
 
-                throw new HttpException(422, 'Cannot upsert a user to have a different email if already set.');
+                return new JsonResponse([
+                    'error' => [
+                        'code' => 422,
+                        'message' => 'Failed validation.',
+                        'fields' => [$index => 'Cannot upsert an existing index.'],
+                    ],
+                ], 422);
             }
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -96,7 +96,7 @@ class UserController extends Controller
                     'existing' => $user->{$index},
                 ]);
 
-                throw new NorthstarValidationException([$index => 'Cannot upsert an existing index.']);
+                throw new NorthstarValidationException([$index => ['Cannot upsert an existing index.']]);
             }
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,9 +2,9 @@
 
 namespace Northstar\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
+use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Http\Transformers\UserTransformer;
 use Northstar\Services\Phoenix;
 use Northstar\Models\User;
@@ -72,6 +72,7 @@ class UserController extends Controller
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
+     * @throws NorthstarValidationException
      */
     public function store(Request $request)
     {
@@ -95,13 +96,7 @@ class UserController extends Controller
                     'existing' => $user->{$index},
                 ]);
 
-                return new JsonResponse([
-                    'error' => [
-                        'code' => 422,
-                        'message' => 'Failed validation.',
-                        'fields' => [$index => 'Cannot upsert an existing index.'],
-                    ],
-                ], 422);
+                throw new NorthstarValidationException([$index => 'Cannot upsert an existing index.']);
             }
         }
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -645,6 +645,30 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test for updating an existing user's index.
+     * PUT /users/_id/:id
+     *
+     * @return void
+     */
+    public function testUpdateUserIndex()
+    {
+        $user = User::create(['email' => 'email@dosomething.org']);
+
+        // Update an existing user
+        $this->withScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
+            'email' => 'new-email@dosomething.org',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // Verify user data got updated
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'email' => 'new-email@dosomething.org',
+        ]);
+    }
+
+    /**
      * Test that we can't update a user's profile to have duplicate
      * identifiers with someone else.
      * PUT /users/_id/:id

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -608,6 +608,15 @@ class UserTest extends TestCase
 
         // The response should indicate a validation conflict!
         $this->assertResponseStatus(422);
+        $this->seeJsonSubset([
+            'error' => [
+                'code' => 422,
+                'message' => 'Failed validation.',
+                'fields' => [
+                    'email' => 'Cannot upsert an existing index.',
+                ],
+            ],
+        ]);
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -613,7 +613,7 @@ class UserTest extends TestCase
                 'code' => 422,
                 'message' => 'Failed validation.',
                 'fields' => [
-                    'email' => 'Cannot upsert an existing index.',
+                    'email' => ['Cannot upsert an existing index.'],
                 ],
             ],
         ]);


### PR DESCRIPTION
#### What's this PR do?
The changes made in #345 made it so indexes could never be changed once set, which was not the intended behavior. 😞 This PR adds a test to ensure we _can_ change an index when explicitly updating a record via `PUT users/:term/:id`, and then makes the test pass by moving that validation check into the `POST users/` controller endpoint so it only applies to the "upsert" action.

This PR also cleans up how we format _422 Unprocessable Entity_ responses because this was happening all over the place! Now anytime we want to report a validation error, we just create a `NorthstarValidationException` which then gets returned as a HTTP response in the `Handler`.

#### How should this be reviewed?
These are all relatively small independent changes, so I'd recommend reviewing things commit-by-commit for this pull request! 👓 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 