### PR TITLE
Don't seed fake Drupal IDs or sources.

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -21,7 +21,6 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'addr_zip' => $faker->postcode,
         'country' => $faker->countryCode,
         'language' => $faker->languageCode,
-        'drupal_id' => $faker->numberBetween(1, 400000),
-        'source' => $faker->randomElement(['phoenix', 'cgg', 'agg', 'sms']),
+        'source' => 'factory',
     ];
 });


### PR DESCRIPTION
#### What's this PR do?
No longer create fake `drupal_id` or `source` values when seeding the database, since this just makes it confusing when those don't match up with real corresponding data in other services.

#### How should this be reviewed?
If you run the seeder, it shouldn't have errors & shouldn't seed random values for those fields. 💁 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither