### PR TITLE
Remove more fields from public profiles.

### DIFF
--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -41,20 +41,21 @@ class UserTransformer extends TransformerAbstract
             $response['addr_city'] = $user->addr_city;
             $response['addr_state'] = $user->addr_state;
             $response['addr_zip'] = $user->addr_zip;
+
+            // Signup source (e.g. drupal, cgg, mobile...)
+            $response['source'] = $user->source;
+
+            // Internal & third-party service IDs:
+            $response['mobilecommons_id'] = $user->mobilecommons_id;
+            $response['parse_installation_ids'] = $user->parse_installation_ids;
+            $response['mobilecommons_status'] = $user->mobilecommons_status;
         }
 
         $response['language'] = $user->language;
         $response['country'] = $user->country;
 
-        // Signup source (e.g. drupal, cgg, mobile...)
-        $response['source'] = $user->source;
-
-        // Internal & third-party service IDs:
+        // Drupal ID for this user. Used in the mobile app.
         $response['drupal_id'] = $user->drupal_id;
-        $response['mobilecommons_id'] = $user->mobilecommons_id;
-        $response['parse_installation_ids'] = $user->parse_installation_ids;
-
-        $response['mobilecommons_status'] = $user->mobilecommons_status;
 
         $response['updated_at'] = $user->updated_at->toISO8601String();
         $response['created_at'] = $user->created_at->toISO8601String();

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -57,8 +57,8 @@ class UserTransformer extends TransformerAbstract
         // Drupal ID for this user. Used in the mobile app.
         $response['drupal_id'] = $user->drupal_id;
 
-        $response['updated_at'] = $user->updated_at->toISO8601String();
-        $response['created_at'] = $user->created_at->toISO8601String();
+        $response['updated_at'] = $user->updated_at->toIso8601String();
+        $response['created_at'] = $user->created_at->toIso8601String();
 
         return $response;
     }


### PR DESCRIPTION
#### What's this PR do?
Follow-up to #349. Removes `source`, `mobilecommons_id`, `mobilecommons_status`, and `parse_installation_ids` from public profile responses. These fields are still included for `admin` keys or when a user loads their own profile.

Also fixes silly capitalization in a method call.

#### How should this be reviewed?
Take a peek at the changes! 👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 