### PR TITLE
Should be able to register if a user has no password.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -252,6 +252,16 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Does this user have a password set?
+     *
+     * @return bool
+     */
+    public function hasPassword()
+    {
+        return ! (empty($this->password) && empty($this->drupal_password));
+    }
+
+    /**
      * Get the corresponding Drupal ID for the given Northstar ID,
      * if it exists.
      *

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -155,7 +155,9 @@ curl -X POST \
 
 ## Register User
 
-This will register a new user account and create an authentication token, which can be used to sign future requests on the user's behalf.
+This will register a new user account and create an authentication token, which can be used to sign future requests
+on the user's behalf. If an account exists but _doesn't_ have a password, a user can complete their registration by
+setting a password via this endpoint.
 
 ```
 POST /auth/register


### PR DESCRIPTION
#### What's this PR do?
References #323. This allows users who have been created through Voting App (or any other registration source where they're not given a password) to "register" to claim an existing passwordless account.

#### How should this be reviewed?
Check out the test cases and see if there's anything I'm missing!

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd