### PR TITLE
Don't enforce arbitrary max-length for email.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -147,7 +147,7 @@ class Registrar
 
         $existingId = isset($user->id) ? $user->id : 'null';
         $rules = [
-            'email' => 'email|max:60|unique:users,email,'.$existingId.',_id|required_without:mobile',
+            'email' => 'email|unique:users,email,'.$existingId.',_id|required_without:mobile',
             'mobile' => 'unique:users,mobile,'.$existingId.',_id|required_without:email',
             'drupal_id' => 'unique:users,drupal_id,'.$existingId.',_id',
         ];

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -243,6 +243,19 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test that we can register a user with a crazy long email.
+     */
+    public function testRegisterLongEmail()
+    {
+        $this->withScopes(['user'])->json('POST', 'v1/auth/register', [
+            'email' => 'loremipsumdolorsitametconsecteturadipiscingelitduisut1234567890b@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(200);
+    }
+
+    /**
      * Test for logging out a user
      * POST /logout
      *


### PR DESCRIPTION
#### What's this PR do?
Fixes #355. We were arbitrarily limiting emails to 60 characters, even though it turns out Drupal uses the exact same email validation logic as Laravel. This PR removes that restriction so we can once again sync users who have really long emails.

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither 
