### PR TITLE
Pass query param to opt-out of forwarding users back to ourselves.

### DIFF
--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -119,6 +119,9 @@ class Phoenix
         $payload['password'] = $password;
 
         $response = $this->client->post('users', [
+            'query' => [
+                'forward' => false,
+            ],
             'body' => json_encode($payload),
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
Since DoSomething/phoenix#6510, users created via the Services user endpoint are now automatically forwarded to Northstar unless the `?forward=false` query parameter is passed. This adds that query parameter to Northstar's Phoenix API call, so we don't make an extra "trip" back.

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 
