### PR TITLE
Prevent editing internal fields from profile endpoint.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -5,6 +5,7 @@ namespace Northstar\Http\Controllers;
 use Illuminate\Http\Request;
 use Northstar\Http\Transformers\TokenTransformer;
 use Northstar\Http\Transformers\UserTransformer;
+use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Illuminate\Contracts\Auth\Guard as Auth;
@@ -148,7 +149,7 @@ class AuthController extends Controller
 
         $this->registrar->validate($request, $existing, ['password' => 'required']);
 
-        $user = $this->registrar->register($request->all(), $existing);
+        $user = $this->registrar->register($request->except(User::$internal), $existing);
 
         // Should we try to make a Drupal account for this user?
         if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\Guard as Auth;
 use Northstar\Auth\Registrar;
 use Northstar\Http\Transformers\UserTransformer;
 use Illuminate\Http\Request;
+use Northstar\Models\User;
 
 class ProfileController extends Controller
 {
@@ -67,7 +68,7 @@ class ProfileController extends Controller
         $request = $this->registrar->normalize($request);
         $this->registrar->validate($request, $user);
 
-        $user->fill($request->all());
+        $user->fill($request->except(User::$internal));
         $user->save();
 
         return $this->item($user);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -91,6 +91,16 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
+     * These fields are reserved for "internal" use only, and should not be
+     * editable directly by end-users (e.g. from the profile endpoint).
+     *
+     * @var array
+     */
+    public static $internal = [
+        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'drupal_password',
+    ];
+
+    /**
      * Attributes that can be queried as unique identifiers.
      *
      * This array is manually maintained. It does not necessarily mean that

--- a/documentation/endpoints/profile.md
+++ b/documentation/endpoints/profile.md
@@ -67,9 +67,6 @@ POST /profile
   addr_zip: String
   country: String // two character country code
   language: String
-  agg_id: Number
-  cgg_id: Number
-  drupal_id: String
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -222,6 +222,26 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test that a user can't set "internal" fields when registering.
+     * POST /auth/register
+     *
+     * @return void
+     */
+    public function testRegisterIgnoresInternalFields()
+    {
+        $this->withScopes(['user'])->json('POST', 'v1/auth/register', [
+            'email' => 'test-registration@dosomething.org',
+            'drupal_id' => '123456', // <-- we should ignore this!
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The provided `drupal_id` should have been ignored.
+        $this->assertEquals(null, $this->decodeResponseJson()['data']['user']['data']['drupal_id']);
+    }
+
+    /**
      * Test that you can "register" to complete the registration
      * flow for a user who has an email/mobile account but no
      * password stored.

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -352,7 +352,7 @@ class AuthTest extends TestCase
         $this->assertResponseStatus(200);
 
         // Verify parse_installation_ids got removed from the user
-        $this->notSeeIndatabase('users', [
+        $this->notSeeInDatabase('users', [
             '_id' => $user->_id,
             'parse_installation_ids' => ['parse-abc123'],
         ]);

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -43,11 +43,13 @@ class ProfileTest extends TestCase
             'email' => $this->faker->email,
             'first_name' => $this->faker->firstName,
             'last_name' => $this->faker->lastName,
+            'drupal_id' => 123456,
         ]);
 
         $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/profile', [
             'mobile' => '(555) 123-4567',
             'language' => 'en',
+            'drupal_id' => 666666,
         ]);
 
         $this->assertResponseStatus(200);
@@ -57,6 +59,7 @@ class ProfileTest extends TestCase
                 'email' => $user->email,
                 'first_name' => $user->first_name,
                 'last_name' => $user->last_name,
+                'drupal_id' => 123456, // shouldn't have changed, field is read-only for users!
                 'mobile' => '5551234567', // should be normalized!
                 'language' => 'en',
             ],


### PR DESCRIPTION
#### What's this PR do?
This pull request prevents users from being able to edit "internal" fields on their profile, such as Drupal ID or Mobile Commons ID. These fields can now only be edited by "trusted" internal applications via the `users/` endpoints.

#### How should this be reviewed?
Review the code & updated test case.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither 

