### PR TITLE
Fix bootstrap issue with conditionally enabling middleware.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -4,20 +4,17 @@ namespace Northstar\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Northstar\Http\Middleware\ParseOAuthHeader;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Routing\Router;
 
 class Kernel extends HttpKernel
 {
     /**
-     * Create a new HTTP kernel instance.
+     * Bootstrap the application for HTTP requests.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Routing\Router  $router
+     * @return void
      */
-    public function __construct(Application $app, Router $router)
+    public function bootstrap()
     {
-        parent::__construct($app, $router);
+        parent::bootstrap();
 
         // Conditionally apply OAuth middleware if feature flag is set.
         if (config('features.oauth')) {


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue introduced in #364: when checking the config object in the Kernel's constructor, the app hadn't been fully initialized yet. This _totally_ makes sense in hindsight, but didn't show up in the test suite (since then the tests bootstrap the app before any request is made). The more you know! 💫 

Aaaaaanyways... this moves that check to happen after the Kernel bootstraps the application.

#### How should this be reviewed?
This should not cause terrifying errors on every single request now.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither 