### PR TITLE
Revoke those tokens

### DIFF
--- a/app/Auth/Encrypter.php
+++ b/app/Auth/Encrypter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Northstar\Auth;
+
+use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptTrait;
+
+class Encrypter
+{
+    use CryptTrait;
+
+    public function __construct()
+    {
+        $publicKey = base_path('storage/keys/public.key');
+        $this->setPublicKey(new CryptKey($publicKey));
+    }
+
+    public function decryptData($encryptedData)
+    {
+        return json_decode($this->decrypt($encryptedData), true);
+    }
+}

--- a/app/Auth/NorthstarTokenGuard.php
+++ b/app/Auth/NorthstarTokenGuard.php
@@ -43,10 +43,7 @@ class NorthstarTokenGuard extends TokenGuard implements Guard
         $user = null;
 
         $token = $this->getTokenForRequest();
-
-        if (! empty($token)) {
-            $user = $this->getUserForToken($token);
-        }
+        $user = $this->getUserForToken($token);
 
         return $this->user = $user;
     }
@@ -57,7 +54,7 @@ class NorthstarTokenGuard extends TokenGuard implements Guard
      * @param string $tokenKey
      * @return \Northstar\Models\User|null
      */
-    public function getUserForToken($tokenKey)
+    public function getUserForToken($tokenKey = '')
     {
         // If the provided token is 32 characters long, it's a legacy
         // database token. Otherwise, it must be a JWT access token.

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -2,6 +2,11 @@
 
 namespace Northstar\Http\Controllers;
 
+use Illuminate\Http\Request;
+use Illuminate\Contracts\Auth\Guard as Auth;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Northstar\Auth\Encrypter;
+use Northstar\Models\RefreshToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use League\OAuth2\Server\AuthorizationServer;
@@ -15,19 +20,40 @@ class OAuthController extends Controller
     protected $oauth;
 
     /**
+     * The authentication guard.
+     * @var \Northstar\Auth\NorthstarTokenGuard
+     */
+    protected $auth;
+
+    /**
+     * The encrypter/decrypter.
+     * @var Encrypter
+     */
+    protected $encrypter;
+
+    /**
      * Make a new OAuthController, inject dependencies,
      * and set middleware for this controller's methods.
      *
      * @param AuthorizationServer $oauth
+     * @param Auth $auth
+     * @param Encrypter $encrypter
      */
-    public function __construct(AuthorizationServer $oauth)
+    public function __construct(AuthorizationServer $oauth, Auth $auth, Encrypter $encrypter)
     {
         $this->oauth = $oauth;
+        $this->auth = $auth;
+        $this->encrypter = $encrypter;
+
+        $this->middleware('auth', ['only' => 'invalidateToken']);
     }
 
     /**
      * Authenticate a registered user using one of the supported OAuth
      * grants and return token details.
+     *
+     * @see RFC6749 OAuth 2.0 <https://tools.ietf.org/html/rfc6749>
+     *      RFC7519 JSON Web Token <https://tools.ietf.org/html/rfc7519>
      *
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
@@ -39,13 +65,42 @@ class OAuthController extends Controller
     }
 
     /**
-     * Logout the current user by invalidating their refresh token.
+     * Invalidate the provided refresh token, preventing it from being used
+     * to generate new access tokens in the future. This is roughly equivalent
+     * to "logging out" the user.
      *
+     * @see RFC7009 OAuth2 Token Revocation <https://tools.ietf.org/html/rfc7009>
+     *
+     * @param Request $request
      * @return \Illuminate\Http\Response
+     * @throws OAuthServerException
      */
-    public function invalidateToken()
+    public function invalidateToken(Request $request)
     {
-        // @TODO: Implement this!
-        return response('Not yet implemented.', 501);
+        $this->validate($request, [
+            'token' => 'required',
+            'token_type_hint' => 'in:refresh_token', // Since we cannot revoke access tokens, refuse to try.
+        ]);
+
+        try {
+            $refreshToken = $this->encrypter->decryptData($request->input('token'));
+        } catch (\LogicException $e) {
+            // Per RFC7009, invalid tokens do _not_ trigger an error response.
+            return $this->respond('That refresh token has been successfully revoked.', 200);
+        }
+
+        // Make sure that the authenticated user is allowed to do this.
+        if ($this->auth->user()->getAuthIdentifier() !== $refreshToken['user_id']) {
+            throw OAuthServerException::accessDenied('That refresh token does not belong to the currently authorized user.');
+        }
+
+        $token = RefreshToken::where('token', $refreshToken['refresh_token_id'])->first();
+
+        // Delete the refresh token, if it exists.
+        if ($token) {
+            $token->delete();
+        }
+
+        return $this->respond('That refresh token has been successfully revoked.', 200);
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -3,7 +3,6 @@
 namespace Northstar\Models;
 
 use Illuminate\Support\Str;
-use Jenssegers\Mongodb\Model;
 
 /**
  * The Client model. These identify the "client application" making

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Northstar\Models;
+
+use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
+
+/**
+ * Base model class
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder where(string $field, string $comparison = '=', string $value)
+ */
+class Model extends BaseModel
+{
+    // ...
+}

--- a/app/Models/RefreshToken.php
+++ b/app/Models/RefreshToken.php
@@ -2,8 +2,6 @@
 
 namespace Northstar\Models;
 
-use Jenssegers\Mongodb\Model;
-
 /**
  * The OAuth refresh token model.
  *
@@ -11,6 +9,8 @@ use Jenssegers\Mongodb\Model;
  * @property string $_id
  * @property string $token
  * @property string $user_id
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder where(string $field, string $comparison = '=', string $value)
  */
 class RefreshToken extends Model
 {
@@ -22,12 +22,10 @@ class RefreshToken extends Model
     protected $collection = 'refresh_tokens';
 
     /**
-     * Indicates if the IDs are auto-incrementing.
+     * The attributes that should be cast to native types.
      *
-     * @var bool
+     * @var array
      */
-    public $incrementing = false;
-
     protected $casts = [
         'scopes' => 'array',
     ];

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -3,7 +3,6 @@
 namespace Northstar\Models;
 
 use Illuminate\Support\Str;
-use Jenssegers\Mongodb\Model;
 
 /**
  * The Authentication Token model. These are used to make

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,7 +4,6 @@ namespace Northstar\Models;
 
 use Carbon\Carbon;
 use Illuminate\Foundation\Auth\Access\Authorizable;
-use Jenssegers\Mongodb\Model;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;

--- a/documentation/endpoints/oauth.md
+++ b/documentation/endpoints/oauth.md
@@ -165,3 +165,44 @@ curl -X POST \
   "refresh_token": "EytNzc1CJrA0fn1ymUutcg8FzOM7yUER5F+31oP/eRJdXwwaII6Lw4yS/PrC/orThdot4+7o81d/VXdUDBre6NDsMbEtTjk9fJVPDFSU74focg3N0zXKiPziBRvegv4DLrM2RkAfYYfxTK5nM1uMT2pCNBobrA8qHahgmw2XgoSE4J/xco/lmHKP393KMwn0nziKDr0YeqPRi+PAvtdsNPKpydyc0JbAFEevZ2UYXz4bRIaS4nUP+IyB6cYSdnok3OCJr8lDUp/OHA0JlOk9ra7YBFXNB8ZvlR1GEL2qQBlIWCqxPL9xrUBTIWUst7/+imx8LmBqevmGY1UFBXAm7n0p1Ih3Qxj0dx9u5woBdCwLYxAlEL70LaSDbx3qdhF+6uhrZTCnpOPE/tZSImpbmashh/SLtFEMpVP+ifISnLYSnQTvyL4XvWU/8azrFGmDmxYB63kuR4D+4QcqptPyA8JC5sOnn1CpDwzTcn93WMbhtWdIUCBTgF2R8rYNVki5"
 }
 ```
+
+## Revoke Token
+
+This will revoke the provided refresh token, if the user is authorized to do so.
+
+```
+POST /v2/auth/token
+```
+
+**Parameters:**
+
+```js
+// Content-Type: application/json
+ 
+{
+  token: String
+}
+```
+
+**Example Request:**
+
+```
+curl -X DELETE \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{"token": "${REFRESH_TOKEN}"}'
+  https://northstar.dosomething.org/v2/auth/token
+```
+
+**Example Response:**
+
+```js
+// 200 OK
+
+{
+  "success": {
+    "code": 200,
+    "message": "That refresh token has been successfully revoked."
+  }
+}
+```

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -297,4 +297,46 @@ class OAuthTest extends TestCase
         ]);
         $this->assertResponseStatus(400);
     }
+
+    /**
+     * Test that a made up refresh token does not cause an error.
+     */
+    public function testCantRevokeAnotherUsersRefreshToken()
+    {
+        $user1 = User::create(['email' => 'login-test@dosomething.org', 'password' => 'secret']);
+        $user2 = User::create(['email' => 'evil-user@dosomething.org', 'password' => 'secret']);
+        $client = Client::create(['app_id' => 'phpunit', 'scope' => ['admin', 'user']]);
+
+        // Make token for user #1.
+        $jwt1 = $this->post('v2/auth/token', [
+            'grant_type' => 'password',
+            'client_id' => $client->client_id,
+            'client_secret' => $client->client_secret,
+            'username' => $user1->email,
+            'password' => 'secret',
+            'scope' => 'admin user',
+        ])->decodeResponseJson();
+
+        // Hacks. OAuth server seems to get mad if more than one request is made per request.
+        $this->refreshApplication();
+
+        // Make token for user #2.
+        $jwt2 = $this->post('v2/auth/token', [
+            'grant_type' => 'password',
+            'client_id' => $client->client_id,
+            'client_secret' => $client->client_secret,
+            'username' => $user2->email,
+            'password' => 'secret',
+            'scope' => 'admin user',
+        ])->decodeResponseJson();
+
+        // Now, try to delete User #1's refresh token w/ User #2's access token.
+        $this->delete('v2/auth/token', [
+            'token' => $jwt1['refresh_token'], // <--- User #1's refresh token
+        ], [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'Authorization' => 'Bearer '.$jwt2['access_token'], // <-- but User #2's access token!
+        ]);
+        $this->assertResponseStatus(401);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR implements the `DELETE v2/auth/token` endpoint as a way to invalidate refresh tokens, for example when logging a user out of an application.

#### How should this be reviewed?
I'd recommend going commit-by-commit for context on each change.

Two functional tests are added in 067aa5f & d7ac2ad, and documentation in 80ed44b.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither 