### PR TITLE
Toggle off upsert

### DIFF
--- a/app/Exceptions/NorthstarValidationException.php
+++ b/app/Exceptions/NorthstarValidationException.php
@@ -2,8 +2,11 @@
 
 namespace Northstar\Exceptions;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\JsonResponse;
 use Exception;
+use Northstar\Http\Transformers\UserTransformer;
+use Northstar\Models\User;
 
 class NorthstarValidationException extends Exception
 {
@@ -26,7 +29,7 @@ class NorthstarValidationException extends Exception
      *
      * @param array $errors
      */
-    public function __construct($errors)
+    public function __construct($errors, $context = null)
     {
         parent::__construct('The given data failed to pass validation.');
 
@@ -38,6 +41,13 @@ class NorthstarValidationException extends Exception
                 'fields' => $errors,
             ],
         ];
+
+        // @TODO: We should have a central place to handle transformations like this...
+        if ($context instanceof User) {
+            $this->response['error']['context'] = (new UserTransformer())->transform($context);
+        } elseif (is_array($context) || $context instanceof Arrayable) {
+            $this->response['error']['context'] = $context;
+        }
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -77,10 +77,14 @@ class UserController extends Controller
      */
     public function store(Request $request)
     {
-        // This is an "upsert" endpoint (so it will either create a new user, or
+        // This endpoint will upsert by default (so it will either create a new user, or
         // update a user if one with a matching index field is found).
-        // So, does this user exist already?
         $existing = $this->registrar->resolve($request->only('id', 'email', 'mobile', 'drupal_id'));
+
+        // If `?upsert=false` and a record already exists, return a custom validation error.
+        if (! filter_var($request->query('upsert', 'true'), FILTER_VALIDATE_BOOLEAN) && $existing) {
+            throw new NorthstarValidationException(['id' => ['A record matching one of the given indexes already exists.']], $existing);
+        }
 
         // Normalize input and validate the request
         $request = $this->registrar->normalize($request);

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -82,8 +82,8 @@ curl -X GET \
 ```
 
 ## Create a User
-Create a new user. This is performed as an "[upsert](https://docs.mongodb.org/v2.6/reference/glossary/#term-upsert)", so
-if a user with a matching identifier is found, new/changed properties will be merged into the existing document. This means
+Create a new user. This is performed as an "[upsert](https://docs.mongodb.org/v2.6/reference/glossary/#term-upsert)" by default,
+so if a user with a matching identifier is found, new/changed properties will be merged into the existing document. This means
 making the same request multiple times will _not_ create duplicate accounts.
 
 Index fields (such as `email`, `mobile`, `drupal_id`) can _only_ be "upserted" if they are not already saved on the user's
@@ -148,6 +148,7 @@ Either a mobile number or email is required.
 **Additional Query Parameters:**
 
 - `create_drupal_user`: Will send a request to create a drupal user in the main DS app.
+- `upsert`: Should this request upsert an existing account, if matched? Defaults to `true`.
 
 **Example Request:**  
 


### PR DESCRIPTION
#### What's this PR do?
This PR adds an optional `?upsert=` parameter that allows clients to opt-out of the "upsert" functionality in the `POST v1/users/` endpoint. References #361.

If an existing user is found, it will be returned in the `context` object of the error. For example:

```js
// 422 Unprocessable Entity

{
  "error": {
    "code": 422,
    "message": "Failed validation.",
    "fields": {
      "id": [
        "A record matching one of the given indexes already exists."
      ]
    },
    "context": {
      "id": "575859099a892003e8586dd3",
      "_id": "575859099a892003e8586dd3",
      "first_name": "Dave",
      "last_name": null,
      "last_initial": "",
      "photo": null,
      "email": "dfurnes@dosomething.org",
      "mobile": null,
      "interests": null,
      "birthdate": null,
      "addr_street1": null,
      "addr_street2": null,
      "addr_city": null,
      "addr_state": null,
      "addr_zip": null,
      "source": null,
      "mobilecommons_id": null,
      "parse_installation_ids": null,
      "mobilecommons_status": null,
      "language": null,
      "country": null,
      "drupal_id": null,
      "updated_at": "2016-06-08T17:42:45+0000",
      "created_at": "2016-06-08T17:42:33+0000"
    }
  }
}
```

#### How should this be reviewed?
Check out the changes, and the updated tests! 👀 

There's a little hackery around transforming `User` models in the validation error response... I'll make an issue, but I think that highlights a need for some sort of central `transform()` helper that can transform something outside of a controller (especially once we have a `v1` and `v2` of different transformers! 😱).

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd @DeeZone 