### PR TITLE
Add magic login endpoint.

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -47,6 +47,7 @@ $router->group(['prefix' => 'v1'], function () use ($router) {
     $router->post('auth/invalidate', 'AuthController@invalidateToken');
     $router->post('auth/verify', 'AuthController@verify');
     $router->post('auth/register', 'AuthController@register');
+    $router->post('auth/phoenix', 'AuthController@phoenix');
 
     // Users
     $router->resource('users', 'UserController', ['except' => ['show', 'update']]);

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -320,4 +320,25 @@ class Phoenix
 
         return $response->json();
     }
+
+    /**
+     * Get a magic login link for the given user ID.
+     * @see: https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/users.md#create-magic-login-url
+     *
+     * @param string $user_id - UID of user on the Drupal site
+     *
+     * @return array - API response
+     * @throws Exception
+     */
+    public function createMagicLogin($user_id)
+    {
+        $response = $this->client->post('users/'.$user_id.'/magic_login_url', [
+            'cookies' => $this->getAuthenticationCookie(),
+            'headers' => [
+                'X-CSRF-Token' => $this->getAuthenticationToken(),
+            ],
+        ]);
+
+        return $response->json();
+    }
 }

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,12 +9,13 @@ See [Authentication](authentication.md) for details on authorizing your requests
 
 ## Endpoints 
 #### Authentication
-Endpoint                  | Functionality                                                | Required Scope
-------------------------- | ------------------------------------------------------------ | --------------
-`POST /auth/token`        | [Create Auth Token](endpoints/auth.md#create-token)          | `user`
-`POST /auth/verify`       | [Verify Credentials](endpoints/auth.md#verify-credentials)   | `user`
-`POST /auth/invalidate`   | [Invalidate Auth Token](endpoints/auth.md#invalidate-token)  | `user`
-`POST /auth/register`     | [Register User](endpoints/auth.md#register-user)             | `user`
+Endpoint                  | Functionality                                                      | Required Scope
+------------------------- | ------------------------------------------------------------------ | --------------
+`POST /auth/token`        | [Create Auth Token](endpoints/auth.md#create-token)                | `user`
+`POST /auth/verify`       | [Verify Credentials](endpoints/auth.md#verify-credentials)         | `user`
+`POST /auth/invalidate`   | [Invalidate Auth Token](endpoints/auth.md#invalidate-token)        | `user`
+`POST /auth/register`     | [Register User](endpoints/auth.md#register-user)                   | `user`
+`POST /auth/phoenix`      | [Create Phoenix Session](endpoints/auth.md#create-phoenix-session) | `user`
 
 > :construction: New [OAuth endpoints](endpoints/oauth.md) are under construction and will be the preferred way to authenticate clients
 > across all services once they're shipped. Stay tuned!

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -210,3 +210,32 @@ curl -X POST \
   }
 }
 ```
+
+## Create Phoenix Session
+
+This will create a "magic login" link to create a Phoenix session for the authenticated user.
+The user must already have a connected Phoenix account to use this endpoint.
+
+```
+POST /auth/phoenix
+```
+
+**Example Request:**
+```
+curl -X POST \
+  -H "X-DS-REST-API-Key: ${REST_API_KEY}" \
+  -H "Authorization: Bearer ${AUTHORIZATION_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  https://northstar.dosomething.org/v1/auth/phoenix
+```
+
+**Example Response:**
+```js
+// 200 OK
+
+{
+  "url": "https://www.dosomething.org/user/magic/12345/1465404849/jPA1_ohenxutorZQ6b8OoAi4VsbJapRs-M2FJwJrhPY",
+  "expires": "2016-06-08T16:54:09+00:00"
+}
+```


### PR DESCRIPTION
#### What's this PR do?
This PR adds a little Northstar wrapper around the Phoenix [magic login link](https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/users.md#create-magic-login-url) endpoint, which allows users to create Phoenix login links using their Northstar authentication token.

#### How should this be reviewed?
👀! 🚥!

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd
