### PR TITLE
Add JWT custom claims.

### DIFF
--- a/app/Auth/Entities/AccessTokenEntity.php
+++ b/app/Auth/Entities/AccessTokenEntity.php
@@ -17,7 +17,7 @@ class AccessTokenEntity implements AccessTokenEntityInterface
 
     /**
      * The user's role.
-     * 
+     *
      * @var string
      */
     protected $role = '';

--- a/app/Auth/Entities/AccessTokenEntity.php
+++ b/app/Auth/Entities/AccessTokenEntity.php
@@ -2,6 +2,10 @@
 
 namespace Northstar\Auth\Entities;
 
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
@@ -10,4 +14,27 @@ use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 class AccessTokenEntity implements AccessTokenEntityInterface
 {
     use EntityTrait, AccessTokenTrait, TokenEntityTrait;
+
+    /**
+     * Generate a JWT from the access token. We override this method from
+     * AccessTokenTrait so that we can add the `iss` and `role` claims.
+     *
+     * @param \League\OAuth2\Server\CryptKey $privateKey
+     * @return string
+     */
+    public function convertToJWT(CryptKey $privateKey)
+    {
+        return (new Builder())
+            ->setIssuer(url('/'))
+            ->setAudience($this->getClient()->getIdentifier())
+            ->setId($this->getIdentifier(), true)
+            ->setIssuedAt(time())
+            ->setNotBefore(time())
+            ->setExpiration($this->getExpiryDateTime()->getTimestamp())
+            ->setSubject($this->getUserIdentifier())
+            ->set('role', 'user') // @TODO: Get from user.
+            ->set('scopes', $this->getScopes())
+            ->sign(new Sha256(), new Key($privateKey->getKeyPath(), $privateKey->getPassPhrase()))
+            ->getToken();
+    }
 }

--- a/app/Auth/Entities/AccessTokenEntity.php
+++ b/app/Auth/Entities/AccessTokenEntity.php
@@ -16,6 +16,33 @@ class AccessTokenEntity implements AccessTokenEntityInterface
     use EntityTrait, AccessTokenTrait, TokenEntityTrait;
 
     /**
+     * The user's role.
+     * 
+     * @var string
+     */
+    protected $role = '';
+
+    /**
+     * Get the role for the user that the token was issued to.
+     *
+     * @return string
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+
+    /**
+     * Set the role for the user that the token was issued to.
+     *
+     * @param string $role
+     */
+    public function setRole($role)
+    {
+        $this->role = $role;
+    }
+
+    /**
      * Generate a JWT from the access token. We override this method from
      * AccessTokenTrait so that we can add the `iss` and `role` claims.
      *
@@ -32,7 +59,7 @@ class AccessTokenEntity implements AccessTokenEntityInterface
             ->setNotBefore(time())
             ->setExpiration($this->getExpiryDateTime()->getTimestamp())
             ->setSubject($this->getUserIdentifier())
-            ->set('role', 'user') // @TODO: Get from user.
+            ->set('role', $this->getRole())
             ->set('scopes', $this->getScopes())
             ->sign(new Sha256(), new Key($privateKey->getKeyPath(), $privateKey->getPassPhrase()))
             ->getToken();

--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -20,8 +20,8 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
     {
         $accessToken = new AccessTokenEntity();
-        
-        if($userIdentifier) {
+
+        if ($userIdentifier) {
             // @TODO: Set this from the user model once field is added.
             $accessToken->setRole('user');
         }

--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -19,16 +19,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
     {
-        $accessToken = new AccessTokenEntity();
-        $accessToken->setClient($clientEntity);
-
-        foreach ($scopes as $scope) {
-            $accessToken->addScope($scope);
-        }
-
-        $accessToken->setUserIdentifier($userIdentifier);
-
-        return $accessToken;
+        return new AccessTokenEntity();
     }
 
     /**

--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -19,7 +19,14 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
     {
-        return new AccessTokenEntity();
+        $accessToken = new AccessTokenEntity();
+        
+        if($userIdentifier) {
+            // @TODO: Set this from the user model once field is added.
+            $accessToken->setRole('user');
+        }
+
+        return $accessToken;
     }
 
     /**

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -35,6 +35,9 @@ Here's an annotated payload from an example access token:
 
 ```js
 {
+  // Issuer: the authorization server URL.
+  "iss": "https://northstar.dosomething.org",
+
   // Audience: the client which requested this token. 
   "aud": "phoenix",
   
@@ -52,6 +55,9 @@ Here's an annotated payload from an example access token:
   
   // Subject: the Northstar ID of the user that is authorized by this JWT.
   "sub": "5430e850dt8hbc541c37tt3d",
+  
+  // Role: the user's role
+  "role": "user",
   
   // Scopes: the privileges this key authorizes the client to act with.
   "scopes": [

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -39,6 +39,9 @@ POST /v2/auth/token
 
   /* Required */
   password: String,
+  
+  /* Scopes to request, space-delimited. */
+  scope: String,
 }
 ```
 
@@ -89,6 +92,9 @@ POST /v2/auth/token
   
   // The client application's Client Secret (required for "trusted" applications)
   client_secret: String,
+  
+  /* Scopes to request, space-delimited. */
+  scope: String,
 }
 ```
 
@@ -139,6 +145,9 @@ POST /v2/auth/token
 
   /* An unused refresh token, returned from the Password Grant */
   refresh_token: String,
+  
+  /* Optional: Adjust the scopes for the new access token. */
+  scope: String,
 }
 ```
 

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -78,7 +78,6 @@ POST /v2/auth/token
 
 **Parameters:**
 
-In addition to the password, either mobile number or email is required.
 ```js
 // Content-Type: application/json
  

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -36,6 +36,7 @@ class OAuthTest extends TestCase
 
         // Check that the token has the expected user ID and scopes.
         $this->assertSame($user->id, $jwt->getClaim('sub'));
+        $this->assertSame('user', $jwt->getClaim('role'));
         $this->assertSame(['admin', 'user'], $jwt->getClaim('scopes'));
 
         // Check that a refresh token was saved to the database.


### PR DESCRIPTION
#### What's this PR do?
This PR adds two additional claims to the JWT access tokens:

🍁 The issuer claim (`iss`) indicates what authorization server issued the token. This may be useful for debugging, i.e. why a token generated from QA doesn't work on prod servers or vice versa.

🔏 Adds a custom `role` claim which can contain the user's role once we start storing that on the user model. For now, just returning `user` for all users. References #376.

#### How should this be reviewed?
Tests should all continue to pass!

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 