### PR TITLE
Add 'role' field to user document.

### DIFF
--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -6,6 +6,7 @@ use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use Northstar\Auth\Entities\AccessTokenEntity;
+use Northstar\Models\User;
 
 class AccessTokenRepository implements AccessTokenRepositoryInterface
 {
@@ -22,8 +23,8 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         $accessToken = new AccessTokenEntity();
 
         if ($userIdentifier) {
-            // @TODO: Set this from the user model once field is added.
-            $accessToken->setRole('user');
+            $user = User::find($userIdentifier);
+            $accessToken->setRole($user->role);
         }
 
         return $accessToken;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -56,6 +56,7 @@ class UserTransformer extends TransformerAbstract
 
         // Drupal ID for this user. Used in the mobile app.
         $response['drupal_id'] = $user->drupal_id;
+        $response['role'] = $user->role;
 
         $response['updated_at'] = $user->updated_at->toIso8601String();
         $response['created_at'] = $user->created_at->toIso8601String();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -217,7 +217,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         if (! in_array($value, ['user', 'staff', 'admin'])) {
             return;
         }
-        
+
         $this->attributes['role'] = $value;
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
  * @property string $photo
  * @property array  $interests
  * @property string $source
+ * @property string $role - The user's role, e.g. 'user', 'staff', or 'admin'
  *
  * @property string $addr_street1
  * @property string $addr_street2
@@ -66,7 +67,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     protected $fillable = [
-        'email', 'mobile', 'password', 'drupal_password',
+        'email', 'mobile', 'password', 'drupal_password', 'role',
 
         'first_name', 'last_name', 'birthdate', 'photo', 'interests',
         'race', 'religion',
@@ -89,7 +90,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $internal = [
-        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'drupal_password',
+        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'drupal_password', 'role',
     ];
 
     /**
@@ -198,6 +199,26 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         if (empty($this->attributes['source'])) {
             $this->attributes['source'] = $value;
         }
+    }
+
+    /**
+     * Mutator for the `role` field.
+     */
+    public function getRoleAttribute()
+    {
+        return ! empty($this->attributes['role']) ? $this->attributes['role'] : 'user';
+    }
+
+    /**
+     * Mutator for the `role` field.
+     */
+    public function setRoleAttribute($value)
+    {
+        if (! in_array($value, ['user', 'staff', 'admin'])) {
+            return;
+        }
+        
+        $this->attributes['role'] = $value;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -131,6 +131,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     /**
      * Computed last initial field, for public profiles.
+     *
      * @return string
      */
     public function getLastInitialAttribute()
@@ -193,6 +194,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * a source, that value cannot be changed). This allows applications to always
      * pass their own identifier in the user's source, without overwriting that value
      * for existing users.
+     *
+     * @param string $value
      */
     public function setSourceAttribute($value)
     {
@@ -202,7 +205,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Mutator for the `role` field.
+     * Accessor for the `role` field.
+     *
+     * @return string
      */
     public function getRoleAttribute()
     {
@@ -211,6 +216,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     /**
      * Mutator for the `role` field.
+     *
+     * @param string $value
      */
     public function setRoleAttribute($value)
     {
@@ -224,6 +231,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     /**
      * Mutator to add new Parse IDs to the user's installation IDs array,
      * either by passing an array or a comma-separated list of values.
+     *
+     * @param array|string $value
      */
     public function setParseInstallationIdsAttribute($value)
     {
@@ -236,6 +245,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * Mutator to remove any existing password if we migrate a hashed password.
      * This is a one-time thing for syncing users from Phoenix and ensuring that
      * we *only* keep their latest hashed Drupal password.
+     *
+     * @param string $value
      */
     public function setDrupalPasswordAttribute($value)
     {
@@ -250,6 +261,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     /**
      * Mutator to automatically hash any value saved to the password field,
      * and remove the hashed Drupal password if one exists.
+     *
+     * @param string $value
      */
     public function setPasswordAttribute($value)
     {

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -56,7 +56,7 @@ Here's an annotated payload from an example access token:
   // Subject: the Northstar ID of the user that is authorized by this JWT.
   "sub": "5430e850dt8hbc541c37tt3d",
   
-  // Role: the user's role
+  // Role: the user's role (e.g. 'user', 'staff', 'admin')
   "role": "user",
   
   // Scopes: the privileges this key authorizes the client to act with.

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -130,6 +130,7 @@ Either a mobile number or email is required.
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)
+  role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   
   // Hidden fields (optional):
   race: String
@@ -177,6 +178,7 @@ curl -X POST \
             "hockeys",
             "kickballs"
         ],
+        "role": "user",
         "updated_at": "2016-02-25T19:33:24+0000",
         "created_at": "2016-02-25T18:33:24+0000"
     }
@@ -224,6 +226,7 @@ curl -X GET \
         "birthdate": "12/17/91",
         "first_name": "First",
         "last_name": "Last",
+        "role": "user",
         "updated_at": "2016-02-25T19:33:24+0000",
         "created_at": "2016-02-25T19:33:24+0000"
     }
@@ -263,6 +266,7 @@ PUT /v1/users/drupal_id/<drupal_id>
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)
+  role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   
   // Hidden fields (optional):
   race: String

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -210,10 +210,10 @@ class AuthTest extends TestCase
         ]);
 
         $this->assertResponseStatus(200);
-        
+
         // Newly registered users should have the 'user' role.
         $this->assertEquals('user', $this->decodeResponseJson()['data']['user']['data']['role']);
-        
+
         // Assert expected response format.
         $this->seeJsonStructure([
             'data' => [

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -210,6 +210,11 @@ class AuthTest extends TestCase
         ]);
 
         $this->assertResponseStatus(200);
+        
+        // Newly registered users should have the 'user' role.
+        $this->assertEquals('user', $this->decodeResponseJson()['data']['user']['data']['role']);
+        
+        // Assert expected response format.
         $this->seeJsonStructure([
             'data' => [
                 'key',
@@ -234,12 +239,14 @@ class AuthTest extends TestCase
             'email' => 'test-registration@dosomething.org',
             'drupal_id' => '123456', // <-- we should ignore this!
             'password' => 'secret',
+            'role' => 'admin',
         ]);
 
         $this->assertResponseStatus(200);
 
-        // The provided `drupal_id` should have been ignored.
+        // The provided `drupal_id` and `role` should have been ignored.
         $this->assertEquals(null, $this->decodeResponseJson()['data']['user']['data']['drupal_id']);
+        $this->assertEquals('user', $this->decodeResponseJson()['data']['user']['data']['role']);
     }
 
     /**

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -44,12 +44,14 @@ class ProfileTest extends TestCase
             'first_name' => $this->faker->firstName,
             'last_name' => $this->faker->lastName,
             'drupal_id' => 123456,
+            'role' => 'user',
         ]);
 
         $this->asUser($user)->withScopes(['user'])->json('POST', 'v1/profile', [
             'mobile' => '(555) 123-4567',
             'language' => 'en',
             'drupal_id' => 666666,
+            'role' => 'admin',
         ]);
 
         $this->assertResponseStatus(200);
@@ -60,6 +62,7 @@ class ProfileTest extends TestCase
                 'first_name' => $user->first_name,
                 'last_name' => $user->last_name,
                 'drupal_id' => 123456, // shouldn't have changed, field is read-only for users!
+                'role' => 'user', // shouldn't have changed, field is read-only for users!
                 'mobile' => '5551234567', // should be normalized!
                 'language' => 'en',
             ],


### PR DESCRIPTION
#### What's this PR do?
Users should have a `role` field that can be used to store their role (for now either `user`, `staff`, or `admin`) and assign permissions across services. This allows us to have a single source for where authorization is defined, rather than multiple individual stores.

Users are prohibited from changing this field when registering or updating their profile (via the `User::$internal` property).

#### How should this be reviewed?
Take a look and let me know if anything looks amiss. Is there any way a user could sneakily set this property for themselves and become an admin without permission?

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 