### PR TITLE
Add index to the source field, so it can be filtered.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -180,7 +180,7 @@ class Registrar
         // For the first `where` query, we want to limit results... from then on,
         // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
         $firstWhere = true;
-        foreach (User::$indexes as $type) {
+        foreach (User::$uniqueIndexes as $type) {
             if (isset($credentials[$type])) {
                 $matches = $matches->where($type, '=', $credentials[$type], ($firstWhere ? 'and' : 'or'));
                 $firstWhere = false;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -92,7 +92,7 @@ class UserController extends Controller
 
         // Makes sure we can't "upsert" a record to have a changed index if already set.
         // @TODO: There must be a better way to do this...
-        foreach (User::$indexes as $index) {
+        foreach (User::$uniqueIndexes as $index) {
             if ($request->has($index) && ! empty($existingUser->{$index}) && $request->input($index) !== $existingUser->{$index}) {
                 app('stathat')->ezCount('upsert conflict');
                 logger('attempted to upsert an existing index', [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -102,7 +102,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $indexes = [
-        '_id', 'drupal_id', 'email', 'mobile',
+        '_id', 'drupal_id', 'email', 'mobile', 'source',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -101,6 +101,18 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @var array
      */
+    public static $uniqueIndexes = [
+        '_id', 'drupal_id', 'email', 'mobile',
+    ];
+
+    /**
+     * Attributes that can be queried when filtering.
+     *
+     * This array is manually maintained. It does not necessarily mean that
+     * any of these are actual indexes on the database... but they should be!
+     *
+     * @var array
+     */
     public static $indexes = [
         '_id', 'drupal_id', 'email', 'mobile', 'source',
     ];

--- a/database/migrations/2016_07_05_155130_AddIndexToSource.php
+++ b/database/migrations/2016_07_05_155130_AddIndexToSource.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToSource extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('source', ['sparse' => true]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('source');
+        });
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Closes #180. This adds an index to the `source` field on the user collection, so it can be filtered against via the API without everything grinding to a halt.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd
