### PR TITLE
Add role scopes & middleware.

### DIFF
--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -13,8 +13,15 @@ class Scope
      * @var array
      */
     protected static $scopes = [
+        'role:admin' => [
+            'description' => 'Allows this client to act as an administrator if the user has that role.',
+        ],
+        'role:staff' => [
+            'description' => 'Allows this client to act as a staff member if the user has that role.',
+        ],
         'admin' => [
-            'description' => 'Allows "administrative" actions that should not be user-accessible, like deleting user records.',
+            'description' => 'Grant administrative privileges to this token, whether or not the user has the admin role.',
+            'warning' => true,
         ],
         'user' => [
             'description' => 'Allows actions to be made on a user\'s behalf.',

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -19,7 +19,7 @@ class ClientController extends Controller
     {
         $this->transformer = $transformer;
 
-        $this->middleware('scope:admin');
+        $this->middleware('role:admin');
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -42,7 +42,7 @@ class UserController extends Controller
 
         $this->transformer = new UserTransformer();
 
-        $this->middleware('scope:admin', ['except' => ['show']]);
+        $this->middleware('role:admin', ['except' => ['show']]);
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -40,5 +40,6 @@ class Kernel extends HttpKernel
         'auth' => \Northstar\Http\Middleware\Authenticate::class,
         'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
         'scope' => \Northstar\Http\Middleware\RequireScope::class,
+        'role' => \Northstar\Http\Middleware\RequireRole::class,
     ];
 }

--- a/app/Http/Middleware/RequireRole.php
+++ b/app/Http/Middleware/RequireRole.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Northstar\Auth\Scope;
+use Closure;
+
+class RequireRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @param $role
+     * @return mixed
+     * @throws OAuthServerException
+     */
+    public function handle($request, Closure $next, $role)
+    {
+        // The 'admin' scope should grant admin privileges, even if the
+        // authorized user doesn't have that role.
+        if ($role === 'admin' && Scope::allows('admin')) {
+            return $next($request);
+        }
+
+        // First, does this client allow us to do things with this role?
+        Scope::gate('role:'.$role);
+
+        if (auth()->user()->role !== $role) {
+            throw OAuthServerException::accessDenied('The authenticated user must have the `'.$role.'` role.');
+        }
+
+        return $next($request);
+    }
+}

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Seeder;
 use Northstar\Models\Client;
+use Northstar\Auth\Scope;
 
 class ApiKeyTableSeeder extends Seeder
 {
@@ -14,15 +15,17 @@ class ApiKeyTableSeeder extends Seeder
     {
         DB::table('clients')->delete();
 
+        // For easy testing, we'll seed one client with all scopes...
         Client::create([
-            'client_id' => '456',
-            'client_secret' => 'abc4324',
-            'scope' => ['admin', 'user'],
+            'client_id' => 'trusted-test-client',
+            'client_secret' => 'secret1',
+            'scope' => collect(Scope::all())->keys()->toArray(),
         ]);
 
+        // ..and one with limited scopes.
         Client::create([
-            'client_id' => '123',
-            'client_secret' => '5464utyrs',
+            'client_id' => 'untrusted-test-client',
+            'client_secret' => 'secret2',
             'scope' => ['user'],
         ]);
     }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Northstar\Models\User;
+
+class UserTest extends TestCase
+{
+    /**
+     * Test retrieving multiple users.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testIndexNotVisibleToUserRole()
+    {
+        // Make a normal user to test acting as.
+        $user = factory(User::class)->create();
+
+        // Make some test users to see in the index.
+        factory(User::class, 5)->create();
+
+        $this->asUser($user, ['role:admin'])->get('v1/users');
+        $this->assertResponseStatus(401);
+    }
+
+    /**
+     * Test retrieving multiple users.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testIndexVisibleToAdminRole()
+    {
+        // Make a admin to test acting as.
+        $admin = factory(User::class)->create();
+        $admin->role = 'admin';
+        $admin->save();
+
+        // Make some test users to see in the index.
+        factory(User::class, 5)->create();
+
+        $this->asUser($admin, ['role:admin'])->get('v1/users');
+        $this->assertResponseStatus(200);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This PR adds new `role:staff` and `role:admin` middleware that grants a client the ability to act on those roles _only_ if the authorized user has that role assigned.

So for example, a normal user who logged in to Aurora would be granted the `role:staff` and `role:admin` scopes because the client requested them, but would still only have `role: "user"` on their token so they couldn't act on them.

(The existing `admin` scope will still grant admin privileges to _any_ user to maintain backwards compatibility, but we should consider phasing that out since it seems like we could easily shoot ourselves in the foot with it.)

#### How should this be reviewed?
Tests should continue to pass.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd
