### PR TITLE
Misc cleanup and fixes

### DIFF
--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -2,8 +2,6 @@
 
 namespace Northstar\Models;
 
-use Illuminate\Support\Str;
-
 /**
  * The Client model. These identify the "client application" making
  * a request, and their maximum allowed scopes.
@@ -20,13 +18,6 @@ class Client extends Model
      * @var string
      */
     protected $primaryKey = 'client_id';
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * The database collection used by the model.
@@ -68,11 +59,11 @@ class Client extends Model
     {
         parent::__construct($attributes);
 
-        // Automatically set random API key. This field *may* be manually
+        // Automatically set random client secret. This field *may* be manually
         // set when seeding the database, so we first check if empty.
         static::creating(function (Client $client) {
             if (empty($client->client_secret)) {
-                $client->client_secret = Str::random(32);
+                $client->client_secret = str_random(32);
             }
         });
     }
@@ -83,7 +74,7 @@ class Client extends Model
      */
     public function setAppIdAttribute($value)
     {
-        $this->attributes['client_id'] = snake_case(str_replace(' ', '', $value));
+        $this->setClientIdAttribute($value);
     }
 
     /**
@@ -92,7 +83,7 @@ class Client extends Model
      */
     public function setClientIdAttribute($value)
     {
-        $this->attributes['client_id'] = snake_case(str_replace(' ', '', $value));
+        $this->attributes['client_id'] = snake_case($value);
     }
 
     /**
@@ -106,28 +97,5 @@ class Client extends Model
         }
 
         return $this->attributes['scope'];
-    }
-
-    /**
-     * Check if this API key has the given scope.
-     *
-     * @param $scope - Scope to test for
-     * @return bool
-     */
-    public function hasScope($scope)
-    {
-        return in_array($scope, $this->scope);
-    }
-
-    /**
-     * Get the API key specified for the current request.
-     *
-     * @return \Northstar\Models\Client
-     */
-    public static function current()
-    {
-        $client_secret = request()->header('X-DS-REST-API-Key');
-
-        return static::where('client_secret', $client_secret)->first();
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -19,6 +19,10 @@ class UserPolicy
      */
     public function viewFullProfile(User $user, User $profile)
     {
+        if (in_array($user->role, ['admin', 'staff'])) {
+            return true;
+        }
+
         return $user->id === $profile->id;
     }
 
@@ -32,6 +36,10 @@ class UserPolicy
      */
     public function editProfile(User $user, User $profile)
     {
+        if (in_array($user->role, ['admin', 'staff'])) {
+            return true;
+        }
+
         return $user->id === $profile->id;
     }
 }

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Seeder;
 use Northstar\Models\Client;
 use Northstar\Auth\Scope;
 
-class ApiKeyTableSeeder extends Seeder
+class ClientTableSeeder extends Seeder
 {
     /**
      * Run the database seeds.

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,8 +14,8 @@ class DatabaseSeeder extends Seeder
     {
         Model::unguard();
 
-        $this->call('UserTableSeeder');
-        $this->call('ApiKeyTableSeeder');
-        $this->call('TokenTableSeeder');
+        $this->call(UserTableSeeder::class);
+        $this->call(ClientTableSeeder::class);
+        $this->call(TokenTableSeeder::class);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR includes a couple of miscellaneous fixes:

🌱 Renames the `ApiKeyTableSeeder` to `ClientTableSeeder` because that's the name now.

🍃 Tidies up the `Client` and `Scope` classes, and removes some methods from the Client model that were only used for the old `X-DS-REST-API-Key` authentication method, since it's confusing to keep them around if they aren't applicable for everything.

🔑 When checking if a user is allowed to view/edit a profile, we should also be checking their role since admins and staff should be allowed to view and edit profiles on Aurora. This is necessary for the OAuth reworking being done in DoSomething/aurora#135.

#### How should this be reviewed?
Tests should continue to pass!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 