### PR TITLE
Fix resolving fields on user "update" endpoint.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -4,6 +4,7 @@ namespace Northstar\Auth;
 
 use Hash;
 use Illuminate\Contracts\Auth\Guard as Auth;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\Factory as Validation;
 use Illuminate\Http\Request;
 use Northstar\Exceptions\NorthstarValidationException;
@@ -200,6 +201,24 @@ class Registrar
 
         // If we can't conclusively resolve one user so return null.
         return null;
+    }
+
+    /**
+     * Resolve a user account from the given credentials, or throw
+     * an exception to trigger a 404 if not able to.
+     *
+     * @param $credentials
+     * @return User|null
+     */
+    public function resolveOrFail($credentials)
+    {
+        $user = $this->resolve($credentials);
+
+        if (! $user) {
+            throw new ModelNotFoundException;
+        }
+
+        return $user;
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -142,12 +142,7 @@ class UserController extends Controller
             Scope::gate('admin');
         }
 
-        // Find the user.
-        $user = $this->registrar->resolve([$term => $id]);
-
-        if (! $user) {
-            throw new NotFoundHttpException('The resource does not exist.');
-        }
+        $user = $this->registrar->resolveOrFail([$term => $id]);
 
         return $this->item($user);
     }
@@ -194,12 +189,7 @@ class UserController extends Controller
      */
     public function destroy($id)
     {
-        $user = User::where('_id', $id)->first();
-
-        if (! $user) {
-            throw new NotFoundHttpException('The resource does not exist.');
-        }
-
+        $user = User::findOrFail($id);
         $user->delete();
 
         return $this->respond('No Content.');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -159,10 +159,7 @@ class UserController extends Controller
      */
     public function update($term, $id, Request $request)
     {
-        $user = User::where($term, $id)->first();
-        if (! $user) {
-            throw new NotFoundHttpException('The resource does not exist.');
-        }
+        $user = $this->registrar->resolveOrFail([$term => $id]);
 
         // Normalize input and validate the request
         $request = $this->registrar->normalize($request);


### PR DESCRIPTION
#### What's this PR do?
Fixes #386. Also adds a `resolveOrFail` method (like Eloquent's `findOrFail`) to the registrar that throws a `ModelNotFoundException` if the given index doesn't resolve to a user to DRY things up a little bit.

#### How should this be reviewed?
Tests should continue to pass! 🚥 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 