### PR TITLE
Add a Role class for handling role authorization.

### DIFF
--- a/app/Auth/Role.php
+++ b/app/Auth/Role.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Northstar\Auth;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class Role
+{
+    /**
+     * Available roles.
+     * @var array
+     */
+    protected static $roles = [
+        'admin' => [
+            'description' => 'This user is an administrator.',
+        ],
+        'staff' => [
+            'description' => 'This user is a staff member.',
+        ],
+        'user' => [
+            'description' => 'Default user permissions. This is a normal member.',
+        ],
+    ];
+
+    /**
+     * Return a list of all roles & their descriptions.
+     *
+     * @return array
+     */
+    public static function all()
+    {
+        return static::$roles;
+    }
+
+    /**
+     * Validate if the given role is valid.
+     *
+     * @param $role
+     * @return bool
+     */
+    public static function validateRole($role)
+    {
+        return in_array($role, array_keys(static::$roles));
+    }
+
+    /**
+     * Return whether the user for the current request has the right role.
+     *
+     * @param array $allowedRoles
+     * @return bool
+     */
+    public static function allows(array $allowedRoles)
+    {
+        // The 'admin' scope should grant the active user the admin role.
+        if (in_array('admin', $allowedRoles) && Scope::allows('admin')) {
+            return true;
+        }
+
+        /** @var \Northstar\Models\User $user */
+        $user = auth()->user();
+
+        // If there isn't a logged-in user, they can't have a role!
+        if (! $user) {
+            return false;
+        }
+
+        $role = $user->role;
+
+        // Check that the client is allowed to act as this role.
+        Scope::gate('role:'.$role);
+
+        return in_array($role, $allowedRoles);
+    }
+
+    /**
+     * Throw an exception if a properly scoped API key is not
+     * provided with the current request.
+     *
+     * @param array $allowedRoles
+     * @throws OAuthServerException
+     */
+    public static function gate(array $allowedRoles)
+    {
+        if (! static::allows($allowedRoles)) {
+            app('stathat')->ezCount('invalid role error');
+
+            // If scopes have been parsed from a provided JWT access token, use OAuth access
+            // denied exception to return a 401 error.
+            if (request()->attributes->has('oauth_scopes')) {
+                throw OAuthServerException::accessDenied('Requires one of the following roles: `'.implode(', ', $allowedRoles).'.');
+            }
+
+            // ...if we're using a legacy API key, return the expected 403 error.
+            throw new AccessDeniedHttpException('Requires one of the following roles: `'.implode(', ', $allowedRoles).'.');
+        }
+    }
+}

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -61,6 +61,12 @@ class Scope
      */
     public static function allows($scope)
     {
+        // If trying to check `role:user`, check `user` scope instead.
+        // @TODO: Change this scope so it's consistent.
+        if ($scope === 'role:user') {
+            $scope = 'user';
+        }
+
         $oauthScopes = request()->attributes->get('oauth_scopes');
 
         // If scopes have been parsed from a provided JWT access token, check against

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -42,7 +42,7 @@ class UserController extends Controller
 
         $this->transformer = new UserTransformer();
 
-        $this->middleware('role:admin', ['except' => ['show']]);
+        $this->middleware('role:admin,staff', ['except' => ['show']]);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -4,7 +4,7 @@ namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
-use Northstar\Auth\Scope;
+use Northstar\Auth\Role;
 use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Http\Transformers\UserTransformer;
 use Northstar\Services\Phoenix;
@@ -137,9 +137,9 @@ class UserController extends Controller
      */
     public function show($term, $id)
     {
-        // Restrict email/mobile profile lookup to admin keys.
-        if (in_array($term, ['email', 'mobile'])) {
-            Scope::gate('admin');
+        // Restrict username/email/mobile profile lookup to admin or staff.
+        if (in_array($term, ['username', 'email', 'mobile'])) {
+            Role::gate(['admin', 'staff']);
         }
 
         $user = $this->registrar->resolveOrFail([$term => $id]);

--- a/app/Http/Middleware/RequireRole.php
+++ b/app/Http/Middleware/RequireRole.php
@@ -3,7 +3,7 @@
 namespace Northstar\Http\Middleware;
 
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Northstar\Auth\Scope;
+use Northstar\Auth\Role;
 use Closure;
 
 class RequireRole
@@ -13,24 +13,14 @@ class RequireRole
      *
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure $next
-     * @param $role
+     * @param array $roles
      * @return mixed
      * @throws OAuthServerException
+     * @internal param $role
      */
-    public function handle($request, Closure $next, $role)
+    public function handle($request, Closure $next, ...$roles)
     {
-        // The 'admin' scope should grant admin privileges, even if the
-        // authorized user doesn't have that role.
-        if ($role === 'admin' && Scope::allows('admin')) {
-            return $next($request);
-        }
-
-        // First, does this client allow us to do things with this role?
-        Scope::gate('role:'.$role);
-
-        if (auth()->user()->role !== $role) {
-            throw OAuthServerException::accessDenied('The authenticated user must have the `'.$role.'` role.');
-        }
+        Role::gate($roles);
 
         return $next($request);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Northstar\Auth\Role;
 
 /**
  * The User model. (Fight for the user!)
@@ -233,7 +234,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setRoleAttribute($value)
     {
-        if (! in_array($value, ['user', 'staff', 'admin'])) {
+        if (! Role::validateRole($value)) {
             return;
         }
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -24,3 +24,33 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'source' => 'factory',
     ];
 });
+
+$factory->defineAs(Northstar\Models\User::class, 'staff', function (Faker\Generator $faker) {
+    return [
+        'first_name' => $faker->firstName,
+        'last_name' => $faker->lastName,
+        'email' => $faker->unique()->safeEmail,
+        'mobile' => $faker->unique()->phoneNumber,
+        'password' => $faker->password,
+        'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),
+        'country' => $faker->countryCode,
+        'language' => $faker->languageCode,
+        'source' => 'factory',
+        'role' => 'staff',
+    ];
+});
+
+$factory->defineAs(Northstar\Models\User::class, 'admin', function (Faker\Generator $faker) {
+    return [
+        'first_name' => $faker->firstName,
+        'last_name' => $faker->lastName,
+        'email' => $faker->unique()->safeEmail,
+        'mobile' => $faker->unique()->phoneNumber,
+        'password' => $faker->password,
+        'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),
+        'country' => $faker->countryCode,
+        'language' => $faker->languageCode,
+        'source' => 'factory',
+        'role' => 'admin',
+    ];
+});

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -1,6 +1,7 @@
 # User Endpoints
 ## Retrieve All Users
-Get data for all users in a paginated format. This requires `admin` scope.
+Get data for all users in a paginated format. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
+
 
 ```
 GET /v1/users
@@ -90,8 +91,7 @@ Index fields (such as `email`, `mobile`, `drupal_id`) can _only_ be "upserted" i
 account. To change an existing value for one of these fields, you must explicitly update that user via the
 [update](#update-a-user) endpoint.
 
-This endpoint requires an API key with `admin` scope. For registering a user, consider using the
-[`auth/register`](#register-user) endpoint, which will also create and return a new authentication token.
+This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope. 
 
 ```
 POST /v1/users
@@ -189,7 +189,7 @@ curl -X POST \
 Get profile data for a specific user. This can be retrieved with either the user's Northstar ID (which is automatically
 generated when a new database record is created), a mobile phone number, an email address, or the user's Drupal ID.
 
-Fetching a user via email or mobile requires `admin` scope.
+Fetching a user via username, email, or mobile requires either the `admin` scope, or an "admin" or "staff" role with the appropriate scope.
 
 ```
 GET /v1/users/id/<user_id>
@@ -234,7 +234,7 @@ curl -X GET \
 ```
 
 ## Update a User
-Update a user resource. This can be retrieved with the user's Northstar ID or the source ID (`drupal_id`). This endpoint requires an API key with `admin` scope.
+Update a user resource. This can be retrieved with the user's Northstar ID or the source ID (`drupal_id`). This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```
 PUT /v1/users/_id/<user_id>
@@ -306,7 +306,7 @@ curl -X PUT \
 ```
 
 ## Delete a User
-Destroy a user resource. The  `user_id` property of the user to delete must be provided in the URL path, and refers to the user's Northstar ID. This endpoint requires an API key with `admin` scope.
+Destroy a user resource. The `user_id` property of the user to delete must be provided in the URL path, and refers to the user's Northstar ID. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```
 DELETE /v1/users/:user_id

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -104,9 +104,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
      */
     public function asAdminUser()
     {
-        $admin = factory(User::class)->create();
-        $admin->role = 'admin';
-        $admin->save();
+        $admin = factory(User::class, 'admin')->create();
 
         return $this->asUser($admin, ['user', 'role:admin']);
     }


### PR DESCRIPTION
#### What's this PR do?
There's a couple changes in this PR, so I'd recommend checking things out commit-by-commit:

🚥 Splits up methods in `ClientTest` to make things less messy. This makes it easier to see what is causing an issue when something breaks, since it prevents side-effects from previous assertions from leaking into the following embedded "tests" when they're all in one method. (4e9e1b8)

🏭 Defines factories for users with the "staff" or "admin" roles. (4031d13)

🔏 Adds a `Role` class to handle authorization by user roles. This closely mirrors the [`Scope`](https://github.com/DoSomething/northstar/blob/dev/app/Auth/Scope.php) class that we already have, so they can be used more-or-less the same. (8b3ed5c)

💁 Allow users with the "staff" role to view and edit user records. This allows staff members to access the new OAuth-powered Aurora using their Northstar role. (770e1e5)

👓 Restrict looking up a user by username, email, or mobile to "admin" or "staff" user roles (in addition to allowing the `admin` scope to override this check, which was all we checked before). This is because we don't want non-trusted users to be able to look up profile details (even something as innocuous as first name) by a user's email or phone number. (ce66885)

#### How should this be reviewed?
I'd recommend reviewing commit-by-commit. Tests should continue to pass!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 