### PR TITLE
Some additional admin functionality.

### DIFF
--- a/app/Auth/Role.php
+++ b/app/Auth/Role.php
@@ -85,9 +85,9 @@ class Role
         if (! static::allows($allowedRoles)) {
             app('stathat')->ezCount('invalid role error');
 
-            // If scopes have been parsed from a provided JWT access token, use OAuth access
-            // denied exception to return a 401 error.
-            if (request()->attributes->has('oauth_scopes')) {
+            // If request is authenticated by a JWT access token or we are looking at a v2 endpoint,
+            // use OAuth access denied exception to return a 401 error.
+            if (request()->attributes->has('oauth_user_id') || request()->route()->getPrefix() === '/v2') {
                 throw OAuthServerException::accessDenied('Requires one of the following roles: `'.implode(', ', $allowedRoles).'.');
             }
 

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -95,9 +95,9 @@ class Scope
         if (! static::allows($scope)) {
             app('stathat')->ezCount('invalid client scope error');
 
-            // If scopes have been parsed from a provided JWT access token, use OAuth access
-            // denied exception to return a 401 error.
-            if (request()->attributes->has('oauth_scopes')) {
+            // If scopes have been parsed from a provided JWT access token or we are looking at a v2 endpoint,
+            // use OAuth access denied exception to return a 401 error.
+            if (request()->attributes->has('oauth_scopes') || request()->route()->getPrefix() === '/v2') {
                 throw OAuthServerException::accessDenied('Requires the `'.$scope.'` scope.');
             }
 

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -101,6 +101,6 @@ class ClientController extends Controller
         $client = Client::findOrFail($client_id);
         $client->delete();
 
-        return $this->respond('Deleted key.', 200);
+        return $this->respond('Deleted client.', 200);
     }
 }

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+class KeyController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('role:admin');
+    }
+
+    /**
+     * Return the public key, which can be used by other services
+     * to verify JWT access tokens.
+     * GET /key
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function show()
+    {
+        $path = base_path('storage/keys/public.key');
+        $publicKey = file_get_contents($path);
+
+        return [
+            'algorithm' => 'RS256',
+            'issuer' => url('/'),
+            'public_key' => $publicKey,
+        ];
+    }
+}

--- a/app/Http/Transformers/ClientTransformer.php
+++ b/app/Http/Transformers/ClientTransformer.php
@@ -18,6 +18,8 @@ class ClientTransformer extends TransformerAbstract
             'client_secret' => $client->client_secret,
             'scope' => $client->scope,
 
+            'refresh_tokens' => $client->getRefreshTokenCount(),
+
             'updated_at' => $client->updated_at->toISO8601String(),
             'created_at' => $client->created_at->toISO8601String(),
         ];

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -34,6 +34,9 @@ $router->group(['prefix' => 'v2'], function () use ($router) {
     // OAuth Clients
     $router->resource('clients', 'ClientController');
 
+    // Public Key
+    $router->get('key', 'KeyController@show');
+
     // Scopes
     $router->get('scopes', function () {
         return \Northstar\Auth\Scope::all();

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -98,4 +98,13 @@ class Client extends Model
 
         return $this->attributes['scope'];
     }
+
+    /**
+     * Get the number of refresh tokens assigned to this client.
+     * @return array
+     */
+    public function getRefreshTokenCount()
+    {
+        return RefreshToken::where('client_id', $this->client_id)->count();
+    }
 }

--- a/database/migrations/2016_07_12_195635_AddMoreIndexesToRefreshTokens.php
+++ b/database/migrations/2016_07_12_195635_AddMoreIndexesToRefreshTokens.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMoreIndexesToRefreshTokens extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('refresh_tokens', function (Blueprint $collection) {
+            $collection->index('user_id');
+            $collection->index('client_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('refresh_tokens', function (Blueprint $collection) {
+            $collection->dropIndex('user_id');
+            $collection->dropIndex('client_id');
+        });
+    }
+}

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -58,14 +58,15 @@ Endpoint                                     | Functionality                    
 > __Note:__ These endpoints are lightweight proxies to their Phoenix equivalents.
 
 #### Clients
-Endpoint                                     | Functionality                                                    | Required Scope
--------------------------------------------- | ---------------------------------------------------------------- | --------------
-`GET v2/clients`                             | [Retrieve All Clients](endpoints/keys.md#retrieve-all-api-keys)  | `role:admin` or `admin`
-`POST v2/clients`                            | [Create a Client](endpoints/keys.md#create-an-api-key)           | `role:admin` or `admin`
-`GET v2/clients/:client_id`                  | [Retrieve a Client](endpoints/keys.md#retrieve-an-api-key)       | `role:admin` or `admin`
-`PUT v2/clients/:client_id`                  | [Update a Client](endpoints/keys.md#update-an-api-key)           | `role:admin` or `admin`
-`DELETE v2/clients/:client_id`               | [Delete a Client](endpoints/keys.md#delete-an-api-key)           | `role:admin` or `admin`
-`GET v2/scopes`                              | [Retrieve All Client Scopes](endpoints/keys.md#retrieve-all-api-key-scopes) |
+Endpoint                                     | Functionality                                                       | Required Scope
+-------------------------------------------- | ------------------------------------------------------------------- | --------------
+`GET v2/clients`                             | [Retrieve All Clients](endpoints/clients.md#retrieve-all-clients)   | `role:admin` or `admin`
+`POST v2/clients`                            | [Create a Client](endpoints/clients.md#create-a-client)             | `role:admin` or `admin`
+`GET v2/clients/:client_id`                  | [Retrieve a Client](endpoints/clients.md#retrieve-a-client)         | `role:admin` or `admin`
+`PUT v2/clients/:client_id`                  | [Update a Client](endpoints/clients.md#update-a-client)             | `role:admin` or `admin`
+`DELETE v2/clients/:client_id`               | [Delete a Client](endpoints/clients.md#delete-a-client)             | `role:admin` or `admin`
+`GET v2/scopes`                              | [Retrieve All Client Scopes](endpoints/clients.md#retrieve-all-client-scopes) |
+`GET v2/key`                                 | [Retrieve Public Key](endpoints/clients.md#retrieve-public-key)     | `role:admin` or `admin`
 
 <br>
 > :bulb: __Did you know?__ We also have a shared [Paw Collection](endpoints.paw) for testing these endpoints against your local environment.  

--- a/documentation/endpoints/clients.md
+++ b/documentation/endpoints/clients.md
@@ -28,6 +28,7 @@ curl -X GET \
         "user",
         "role:admin"
       ],
+      "refresh_tokens": 28,
       "updated_at": "2016-07-07T15:46:21+0000",
       "created_at": "2016-07-06T18:26:04+0000"
     },
@@ -37,6 +38,7 @@ curl -X GET \
       "scope": [
         "user"
       ],
+      "refresh_tokens": 16,
       "updated_at": "2016-07-06T18:26:04+0000",
       "created_at": "2016-07-06T18:26:04+0000"
     }
@@ -95,6 +97,7 @@ curl -X POST \
     "scope": [
       "user"
     ],
+    "refresh_tokens": 0,
     "updated_at": "2015-05-19 17:10:37",
     "created_at": "2015-05-19 17:10:37",
   }
@@ -130,6 +133,7 @@ curl -X GET\
       "admin",
       "user"
     ],
+    "refresh_tokens": 32,
     "updated_at": "2015-05-19 17:10:37",
     "created_at": "2015-05-19 17:10:37",
   }
@@ -175,6 +179,7 @@ curl -X PUT \
       "admin",
       "user"
     ],
+    "refresh_tokens": 32,
     "updated_at": "2015-05-19 17:10:37",
     "created_at": "2015-05-19 17:10:37",
   }

--- a/documentation/endpoints/clients.md
+++ b/documentation/endpoints/clients.md
@@ -187,8 +187,9 @@ curl -X PUT \
 ```
 
 
-## Delete an API Key
-Delete an OAuth client. This requires either the `admin` scope, or `role:admin` with an admin user.
+## Delete a Client 
+Delete an OAuth client. This will invalidate all refresh tokens that have been created by that client. This requires
+either the `admin` scope, or `role:admin` with an admin user.
 
 ```
 DELETE /v2/clients/:client_id
@@ -212,7 +213,7 @@ curl -X DELETE \
 {
   "success": {
     "code": 200,
-    "message": "Deleted key."
+    "message": "Deleted client."
   }
 }
 ```
@@ -250,4 +251,30 @@ curl -X GET https://northstar.dosomething.org/v2/scopes
 }
 ```
 
+
+## Retrieve Public Key
+Retrieves the public key which can be used to verify issued JWT access tokens. This endpoint requires either the `admin` scope,
+or `role:admin` with an admin user.
+
+```
+GET /v2/key
+```
+
+**Example Request:**
+```sh
+curl -X GET https://northstar.dosomething.org/v2/key \
+  -H "Authorization: ${ACCESS_TOKEN}" \
+  -H "Accept: application/json"
+```
+
+**Example Response:**
+```js
+// 200 OK
+
+{
+  "algorithm": "RS256",
+  "issuer": "http://northstar.dosomething.org",
+  "public_key": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n"
+}
+```
 

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Northstar\Models\User;
+
+class KeyTest extends TestCase
+{
+    /**
+     * Test retrieving multiple users.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testKeyNotVisibleToUserRole()
+    {
+        $this->get('v2/key');
+        $this->assertResponseStatus(401);
+
+        $this->asNormalUser()->get('v2/key');
+        $this->assertResponseStatus(401);
+    }
+
+    /**
+     * Test retrieving multiple users.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testKeyNotVisibleToStaffRole()
+    {
+        // Make a staff user & some test users.
+        $staff = factory(User::class, 'staff')->create();
+
+        $this->asUser($staff, ['role:staff'])->get('v2/key');
+        $this->assertResponseStatus(401);
+    }
+
+    /**
+     * Test retrieving multiple users.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testKeyVisibleToAdminRole()
+    {
+        $this->asAdminUser()->get('v2/key');
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure([
+            'algorithm',
+            'issuer',
+            'public_key',
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -98,6 +98,18 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     }
 
     /**
+     * Make the following request as a staff user with the `user` and `role:staff` scopes.
+     *
+     * @return $this
+     */
+    public function asStaffUser()
+    {
+        $staff = factory(User::class, 'staff')->create();
+
+        return $this->asUser($staff, ['user', 'role:staff']);
+    }
+
+    /**
      * Make the following request as an admin user with the `user` and `role:admin` scopes.
      *
      * @return $this


### PR DESCRIPTION
#### What's this PR do?
🍡 Adds an index on the `user_id` and `client_id` fields for refresh tokens so we can easily look up all of a user or client's refresh tokens.

🔢 Adds a `refresh_tokens` field to the client responses that shows a count of how many refresh tokens that client has. We can display this in Aurora for an easy way to track how much active usage an client has. (This isn't done super efficiently right now, but I'm not too worried since we won't likely ever have all that many clients.)

🔑 Adds an endpoint to allow admins to request Northstar's public key. This is used by clients to verify JWT tokens (but _cannot_ be used to create tokens). This will be displayed in Aurora for easy access.

🍸 Updates scope & role "gate" methods to always use the OAuth-style error formatting when on a `v2/...` route (so for example, a request missing the `Authorization` header will still return a 401 rather than defaulting to the legacy 403).

#### How should this be reviewed?
Tests should continue to pass. It's probably easiest to review this PR commit-by-commit.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 