### PR TITLE
Aurora related updates

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -47,10 +47,11 @@ class ClientController extends Controller
     {
         $this->validate($request, [
             'client_id' => 'required|unique:clients,client_id',
+            'title' => 'required',
             'scope' => 'array|scope', // @see Scope::validateScopes
         ]);
 
-        $key = Client::create($request->only('client_id', 'scope'));
+        $key = Client::create($request->only('client_id', 'title', 'description', 'scope'));
 
         return $this->item($key, 201);
     }
@@ -84,7 +85,7 @@ class ClientController extends Controller
         ]);
 
         $client = Client::findOrFail($client_id);
-        $client->update($request->only('scope'));
+        $client->update($request->only('title', 'description', 'scope'));
 
         return $this->item($client);
     }

--- a/app/Http/Transformers/ClientTransformer.php
+++ b/app/Http/Transformers/ClientTransformer.php
@@ -14,6 +14,9 @@ class ClientTransformer extends TransformerAbstract
     public function transform(Client $client)
     {
         return [
+            'title' => ! empty($client->title) ? $client->title : title_case($client->client_id),
+            'description' => $client->description,
+
             'client_id' => $client->client_id,
             'client_secret' => $client->client_secret,
             'scope' => $client->scope,

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -42,6 +42,8 @@ class Client extends Model
      */
     protected $fillable = [
         'client_id',
+        'title',
+        'description',
         'scope',
 
         // For backwards compatibility...

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -115,7 +115,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $indexes = [
-        '_id', 'drupal_id', 'email', 'mobile', 'source',
+        '_id', 'drupal_id', 'email', 'mobile', 'source', 'role',
     ];
 
     /**

--- a/database/migrations/2016_07_14_182348_AddIndexToRole.php
+++ b/database/migrations/2016_07_14_182348_AddIndexToRole.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToRole extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('role', ['sparse' => true]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('role');
+        });
+    }
+}

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -17,6 +17,8 @@ class ClientTableSeeder extends Seeder
 
         // For easy testing, we'll seed one client with all scopes...
         Client::create([
+            'title' => 'Trusted Test Client',
+            'description' => 'This is an example OAuth client seeded with your local Northstar installation. It was automatically given all scopes that were defined when it was created.',
             'client_id' => 'trusted-test-client',
             'client_secret' => 'secret1',
             'scope' => collect(Scope::all())->keys()->toArray(),
@@ -24,6 +26,8 @@ class ClientTableSeeder extends Seeder
 
         // ..and one with limited scopes.
         Client::create([
+            'title' => 'Untrusted Test Client',
+            'description' => 'This is an example OAuth client seeded with your local Northstar installation. It is only given the user scope, and can be used to simulate untrusted clients (for example, the mobile app).',
             'client_id' => 'untrusted-test-client',
             'client_secret' => 'secret2',
             'scope' => ['user'],

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -15,26 +15,20 @@ class UserTableSeeder extends Seeder
         // Clear the database.
         DB::table('users')->delete();
 
-        // Create a user with a predetermined ID to use when manually testing endpoints.
-        User::create([
-            '_id' => '5430e850dt8hbc541c37tt3d',
+        // Create an example normal & admin user for local development.
+        factory(User::class)->create([
             'email' => 'test@dosomething.org',
-            'mobile' => '5555550100',
             'password' => 'secret',
-            'drupal_id' => '100001',
-            'addr_street1' => '123',
-            'addr_street2' => '456',
-            'addr_city' => 'Paris',
-            'addr_state' => 'Florida',
-            'addr_zip' => '555555',
-            'country' => 'US',
-            'birthdate' => '12/17/91',
-            'first_name' => 'First',
-            'last_name' => 'Last',
-            'parse_installation_ids' => 'parse-abc123',
         ]);
 
-        // Then create a bunch of randomly-generated test data!
+        factory(User::class, 'admin')->create([
+            'email' => 'admin@dosomething.org',
+            'password' => 'secret',
+        ]);
+
+        // Then create some randomly-generated test data!
+        factory(User::class, 'admin', 4)->create();
+        factory(User::class, 'staff', 50)->create();
         factory(User::class, 250)->create();
     }
 }

--- a/documentation/endpoints/clients.md
+++ b/documentation/endpoints/clients.md
@@ -21,6 +21,8 @@ curl -X GET \
 {
   "data": [
     {
+      "title": "Trusted Test Client",
+      "description": "A trusted example client.",
       "client_id": "trusted-test-client",
       "client_secret": "Mq3kXQZldCXmDKs2XxJvC2qsuzfUusdQ",
       "scope": [
@@ -33,6 +35,8 @@ curl -X GET \
       "created_at": "2016-07-06T18:26:04+0000"
     },
     {
+      "title": "Untrusted Test Client",
+      "description": "A untrusted example client.",
       "client_id": "untrusted-test-client",
       "client_secret": "qZRBJiOXsE657sUuvYcRzHAMNjHUdjkH",
       "scope": [
@@ -67,7 +71,13 @@ POST /v2/clients
 
 ```js
 {
-  /* Application name registering for the new key */
+  /* The application's title. */
+  title: String
+
+  /* (optional) The description for this application. */
+  description: String
+  
+  /* Application ID for the new key */
   client_id: String
 
   /* Whitelisted client scope(s) */
@@ -81,7 +91,7 @@ curl -X POST \
   -H "Authorization: ${ACCESS_TOKEN}" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
-  -d '{"client_id": "test application", "scope": ["user"]}' \
+  -d '{"title": "Test Application", "description: "An example app.", "client_id": "test-application", "scope": ["user"]}' \
   https://northstar.dosomething.org/v2/clients
 ```
 
@@ -92,6 +102,8 @@ curl -X POST \
 
 {
   "data": {
+    "title": "Test Application",
+    "description": "An example app.",
     "client_id": "test-application",
     "client_secret": "1laEQhhKtQEaPK0qpESdXHm2EbdLu5sRIRLcRtF8",
     "scope": [
@@ -127,6 +139,8 @@ curl -X GET\
 
 {
   "data": {
+    "title": "Test Application",
+    "description": "An example app.",
     "client_id": "testapplication",
     "client_secret": "1laEQhhKtQEaPK0qpESdXHm2EbdLu5sRIRLcRtF8",
     "scope": [
@@ -151,6 +165,12 @@ PUT /v2/clients/:client_id
 
 ```js
 {
+  /* (optional) Change this application's title. */
+  title: String
+
+  /* (optional) Change the description for this application. */
+  description: String
+
   /* (optional) Change the whitelisted scope(s) for this application. */
   scope: Array
 }
@@ -173,6 +193,8 @@ curl -X PUT \
 
 {
   "data": {
+    "title": "Test Application",
+    "description": "An example app.",
     "client_id": "testapplication",
     "client_secret": "1laEQhhKtQEaPK0qpESdXHm2EbdLu5sRIRLcRtF8",
     "scope": [

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -38,7 +38,9 @@ class ClientTest extends TestCase
     public function testStoreAsNormalUser()
     {
         $this->asNormalUser()->json('POST', 'v2/clients', [
-            'client_id' => 'dog', // hello this is doge
+            'title' => 'Dog',
+            'description' => 'hello this is doge',
+            'client_id' => 'dog',
             'scope' => ['admin'],
         ]);
 
@@ -51,6 +53,8 @@ class ClientTest extends TestCase
     public function testStoreAsAdminUser()
     {
         $this->asAdminUser()->json('POST', 'v2/clients', [
+            'title' => 'Dog',
+            'description' => 'hello this is doge',
             'client_id' => 'dog',
             'scope' => ['admin'],
         ]);
@@ -119,6 +123,7 @@ class ClientTest extends TestCase
         $client = Client::create(['client_id' => 'update_key']);
 
         $this->asAdminUser()->json('PUT', 'v2/clients/'.$client->client_id, [
+            'title' => 'New Title',
             'scope' => [
                 'admin',
                 'user',
@@ -127,6 +132,7 @@ class ClientTest extends TestCase
 
         $this->assertResponseStatus(200);
         $this->seeInDatabase('clients', [
+            'title' => 'New Title',
             'client_id' => 'update_key',
             'scope' => ['admin', 'user'],
         ]);


### PR DESCRIPTION
#### What's this PR do?
This adds some updates for DoSomething/aurora#138:

🔏 Adds a `title` and `description` field to OAuth Clients so we can save details about them.

👓 Allows filtering users by `role` for the new "superusers" Aurora view.

#### How should this be reviewed?
Tests should continue to pass.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 