### PR TITLE
Only allow admins to set user roles.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -106,7 +106,7 @@ class UserController extends Controller
         }
 
         $upserting = ! is_null($existingUser);
-        $user = $this->registrar->register($request->all(), $existingUser);
+        $user = $this->registrar->register($request->except('role'), $existingUser);
 
         // Optionally, allow setting a custom "created_at" (useful for back-filling from other services).
         if ($request->has('created_at')) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -101,7 +101,7 @@ class UserController extends Controller
                     'existing' => $existingUser->{$index},
                 ]);
 
-                throw new NorthstarValidationException([$index => ['Cannot upsert an existing index.']]);
+                throw new NorthstarValidationException([$index => ['Cannot upsert an existing index.']], $existingUser);
             }
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -165,13 +165,19 @@ class UserController extends Controller
         $request = $this->registrar->normalize($request);
         $this->registrar->validate($request, $user);
 
-        $user = $this->registrar->register($request->all(), $user);
+        // Only admins can change the role field.
+        if ($request->has('role') && $request->input('role') !== 'user') {
+            Role::gate(['admin']);
+        }
+
+        $user->fill($request->all());
 
         // Should we try to make a Drupal account for this user?
         if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {
             $user = $this->registrar->createDrupalUser($user, $request->input('password'));
-            $user->save();
         }
+
+        $user->save();
 
         return $this->item($user);
     }

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -130,7 +130,6 @@ Either a mobile number or email is required.
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)
-  role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   
   // Hidden fields (optional):
   race: String

--- a/tests/Legacy/UserTest.php
+++ b/tests/Legacy/UserTest.php
@@ -569,6 +569,7 @@ class LegacyUserTest extends TestCase
             'password' => 'secret',
             'first_name' => 'Puppet',
             'source' => 'phpunit',
+            'role' => 'admin',
         ]);
 
         // The response should return JSON with a 200 Okay status code
@@ -576,11 +577,16 @@ class LegacyUserTest extends TestCase
         $this->seeJsonSubset([
             'data' => [
                 'email' => 'upsert-me@dosomething.org',
+
                 // Check for the new fields we "upserted":
                 'first_name' => 'Puppet',
                 'mobile' => '5556667777',
+
                 // Ensure the `source` field is immutable (since we tried to update to 'phpunit'):
                 'source' => 'database',
+
+                // The role should *not* be changed by upsert (since that'd make it easily to accidentally grant!)
+                'role' => 'user',
             ],
         ]);
     }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -120,4 +120,73 @@ class UserTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * Test that a staffer can update a user's profile.
+     * GET /users/:term/:id
+     *
+     * @return void
+     */
+    public function testUpdateProfileAsStaff()
+    {
+        $user = factory(User::class)->create();
+        $staff = factory(User::class, 'staff')->create();
+
+        $this->asUser($staff, ['user', 'role:staff'])->json('PUT', 'v1/users/id/'.$user->id, [
+            'first_name' => 'Alexander',
+            'last_name' => 'Hamilton',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The user should remain unchanged.
+        $user->fresh();
+        $this->assertNotEquals('Alexander', $user->first_name);
+        $this->assertNotEquals('Hamilton', $user->last_name);
+    }
+
+    /**
+     * Test that a staffer cannot change a user's role.
+     * GET /users/:term/:id
+     *
+     * @return void
+     */
+    public function testGrantRoleAsStaff()
+    {
+        $user = factory(User::class)->create();
+        $staff = factory(User::class, 'staff')->create();
+
+        $this->asUser($staff, ['user', 'role:staff'])->json('PUT', 'v1/users/id/'.$user->id, [
+            'role' => 'admin',
+        ]);
+
+        $this->assertResponseStatus(401);
+    }
+
+    /**
+     * Test that an admin can update a user's profile, including their role.
+     * GET /users/:term/:id
+     *
+     * @return void
+     */
+    public function testUpdateProfileAsAdmin()
+    {
+        $user = factory(User::class)->create();
+        $admin = factory(User::class, 'admin')->create();
+
+        $this->asUser($admin, ['user', 'role:admin'])->json('PUT', 'v1/users/id/'.$user->id, [
+            'first_name' => 'Hercules',
+            'last_name' => 'Mulligan',
+            'role' => 'admin',
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'first_name' => 'Hercules',
+                'last_name' => 'Mulligan',
+                'role' => 'admin',
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR makes it so only admins (or clients with `admin` scope) can edit other user's roles. This prevents staff members from setting the admin role for themselves (which would render the two different roles moot!)

It also prevents setting the `role` field when creating or upserting a user, to limit the potential of doing this by accident. 🔒

#### How should this be reviewed?
Tests should pass. Are there loopholes I missed?

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 