### PR TITLE
Guzzle 6 requires cookies to be in a CookieJar. :cookie:

### DIFF
--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -4,6 +4,7 @@ namespace Northstar\Services;
 
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -73,11 +74,11 @@ class Phoenix
     /**
      * Get the cookie for the authenticated API session.
      *
-     * @return array - cookie key/value
+     * @return CookieJar
      */
     private function getAuthenticationCookie()
     {
-        return $this->authenticate()['cookie'];
+        return CookieJar::fromArray($this->authenticate()['cookie'], config('services.drupal.url'));
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
Another Guzzle 6 tweak... The `cookies` option for requests is now required to be a `\GuzzleHttp\Cookies\CookieJar` so we'll make one of those...

#### How should this be reviewed?
![cookie monster](http://media.gizmodo.co.uk/wp-content/uploads/2016/04/1kwVorF-620x349.jpg)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 

