### PR TITLE
Re-throw external service errors to be more friendly.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
+    const PRODUCTION_ERROR_MESSAGE = 'Looks like something went wrong. We\'ve noted the problem and will try to get it fixed!';
+
     /**
      * A list of the exception types that should not be reported.
      *
@@ -75,10 +77,11 @@ class Handler extends ExceptionHandler
             }
 
             $code = $e instanceof HttpException ? $e->getStatusCode() : 500;
+            $shouldHideErrorDetails = $code == 500 && ! config('app.debug');
             $response = [
                 'error' => [
                     'code' => $code,
-                    'message' => $e->getMessage(),
+                    'message' => $shouldHideErrorDetails ? self::PRODUCTION_ERROR_MESSAGE : $e->getMessage(),
                 ],
             ];
 


### PR DESCRIPTION
#### What's this PR do?
This PR makes error messages returned from production environments more friendly, since chances are we have everything we need in the logs.

#### How should this be reviewed?
Check out that conditional. 👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither 
