### PR TITLE
Remove admin scope requirement for searching.

### DIFF
--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -2,8 +2,6 @@
 
 namespace Northstar\Http\Controllers\Traits;
 
-use Northstar\Auth\Scope;
-
 trait FiltersRequests
 {
     /**
@@ -65,9 +63,6 @@ trait FiltersRequests
         if (! $searches) {
             return $query;
         }
-
-        // Only "admin" keys should be able to search
-        Scope::gate('admin');
 
         // Searches may only be performed on indexed fields.
         $searches = array_intersect_key($searches, array_flip($indexes));

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -12,7 +12,7 @@ GET /v1/users
 - `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v1/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.
-- `search`: Search the collection for users with fields whose value match the query. For example, `/v1/users?search[id]=test@example.com&search[email]=test@example.org` would return all users with either an ID or email address matching `test@example.org`. You can search by one or more indexed fields. This is limited to admin-scoped API keys!
+- `search`: Search the collection for users with fields whose value match the query. For example, `/v1/users?search[id]=test@example.com&search[email]=test@example.org` would return all users with either an ID or email address matching `test@example.org`. You can search by one or more indexed fields.
 
 **Example Request:**
 


### PR DESCRIPTION
#### What's this PR do?
The `?search[<field>]=<value>` was previously gated to the `admin` key. We can remove this since the _entire_ index route is now gated to admins (especially because this check prevents search from working on Aurora because it no longer has the `admin` scope, only `role:admin` and the user's role).

#### How should this be reviewed?
We can verify that this is still working since [this test](https://github.com/DoSomething/northstar/blob/97070f4a567c7049fff3838f9b08817c80b8432f/tests/Legacy/UserTest.php#L295-L317) still passes. 🚥

#### Checklist
- [x] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither 