### PR TITLE
Add throttling to anonymous & authenticated requests.

### DIFF
--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -26,6 +26,10 @@ class Scope
         'user' => [
             'description' => 'Allows actions to be made on a user\'s behalf.',
         ],
+        'unlimited' => [
+            'description' => 'Disables rate limiting for this client.',
+            'warning' => true,
+        ],
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -30,6 +30,7 @@ class Kernel extends HttpKernel
         ],
         'api' => [
             \Northstar\Http\Middleware\ParseOAuthHeader::class,
+            \Northstar\Http\Middleware\ThrottleRequests::class,
         ],
     ];
 

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Middleware\ThrottleRequests as LaravelThrottleMiddleware;
+use Northstar\Auth\Scope;
+
+class ThrottleRequests extends LaravelThrottleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $maxAttempts = null, $decayMinutes = 60)
+    {
+        // If the current request has the 'unlimited' scope, do not rate limit.
+        if (Scope::allows('unlimited')) {
+            return $next($request);
+        }
+
+        // Allow 5000 requests/hour per authorized user, or 50 per IP for anonymous requests.
+        if (is_null($maxAttempts)) {
+            $isAuthenticatedRequest = ! is_null($request->get('oauth_access_token_id'));
+            $maxAttempts = $isAuthenticatedRequest ? 5000 : 50;
+        }
+
+        return parent::handle($request, $next, $maxAttempts, $decayMinutes);
+    }
+
+    /**
+     * Resolve request signature.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function resolveRequestSignature($request)
+    {
+        return $request->get('oauth_user_id', sha1($request->ip()));
+    }
+
+    /**
+     * Create a 'too many attempts' response.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @return \Illuminate\Http\Response
+     */
+    protected function buildResponse($key, $maxAttempts)
+    {
+        $response = new JsonResponse(['error' => [
+            'code' => 429,
+            'message' => 'Too many attempts.',
+        ]], 429);
+
+        $retryAfter = $this->limiter->availableIn($key);
+        $remainingAttempts = $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter);
+
+        return $this->addHeaders($response, $maxAttempts, $remainingAttempts, $retryAfter);
+    }
+}

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -118,6 +118,7 @@ Code | Meaning
 404  | __Not Found__ – The specified resource could not be found.
 418  | __I'm a teapot__ – The user [needs more caffeine](https://www.ietf.org/rfc/rfc2324.txt).
 422  | __Unprocessable Entity__ – The request couldn't be completed due to validation errors. See the `error.fields` property on the response.
+429  | __Too Many Requests__ – The user/client has sent too many requests in the past hour. See [Rate Limiting](#rate-limiting).
 500  | __Internal Server Error__ – Northstar has encountered an internal error. Please [make a bug report](https://github.com/DoSomething/northstar/issues/new) with as much detail as possible about what led to the error!
 503  | __Service Unavailable__ – Northstar is temporarily unavailable.
 
@@ -158,6 +159,19 @@ OAuth authentication errors are formatted slightly differently (to conform to [t
   "hint": "..."
 }
 ```
+
+## Rate Limiting
+Unauthenticated clients may make up to 50 requests per hour from a single IP address. Authenticated users may make up
+up to 5000 requests per hour. In special cases, a client with the `unlimited` scope may opt out of rate limiting.
+
+The currently applied rate limit and remaining requests are returned as headers on each response:
+
+Header                  | Description
+----------------------- | -------------------------------------------------------------------------
+`X-RateLimit-Limit`     |	The maximum number of requests that this client may make per hour.
+`X-RateLimit-Remaining` |	The number of requests remaining of your provided limit.
+`Retry-After`           | If rate limit is exceeded, this is the amount of time until you may make another request.
+
 
 ## Libraries
 We have a [PHP API client](https://github.com/DoSomething/northstar-php) for simplified usage of the API in PHP clients.

--- a/tests/ThrottleRequestsTest.php
+++ b/tests/ThrottleRequestsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Northstar\Models\User;
+
+class ThrottleRequestsTest extends TestCase
+{
+    /**
+     * Test that anonymous requests are heavily rate limited.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testThrottlesAnonymousRequests()
+    {
+        // Let's just get 48 requests out of the way.
+        for ($i = 1; $i <= 49; $i++) {
+            $this->get('v1/scopes');
+        }
+
+        // Since these requests are made anonymously, they should be limited to 50/hr.
+        $this->seeHeader('X-RateLimit-Limit', 50);
+
+        // The 50th request should be a-okay, but...
+        $this->get('v1/scopes');
+        $this->assertResponseStatus(200);
+
+        // The 51st request should be refused.
+        $this->get('v1/scopes');
+        $this->assertResponseStatus(429);
+    }
+
+    /**
+     * Test that authenticated requests are rate limited.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testThrottlesAuthenticatedRequests()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user'])->get('v1/profile');
+
+        // See that we have the "authenticated" limit of 5000/hr per token.
+        $this->seeHeader('X-RateLimit-Limit', 5000);
+        $this->seeHeader('X-RateLimit-Remaining', 4999);
+
+        // Using a different access token for the same user should share the same rate limit.
+        $this->asUser($user, ['user'])->get('v1/profile');
+        $this->seeHeader('X-RateLimit-Remaining', 4998);
+    }
+
+    /**
+     * Test that requests with 'unlimited' scope are not rate limited.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testDoesNotThrottleUnlimitedScope()
+    {
+        $user = factory(User::class)->create();
+        $this->asUser($user, ['unlimited'])->get('v1/scopes');
+
+        // See that we are not rate limited.
+        $this->assertFalse($this->response->headers->has('X-RateLimit-Limit'));
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This PR adds rate limiting for anonymous requests (50 requests/hour per IP address), and more generous rate limiting for OAuth authenticated requests (5000 requests/hour per user ID). Individual clients can be opted out of rate limiting (e.g. Phoenix, for example) using the new `unlimited` scope.

#### How should this be reviewed?
Sanity check, and tests should all pass. 🚥 

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 
