### PR TITLE
Add a script to remove users with duplicated Drupal IDs.

### DIFF
--- a/app/Console/Commands/CleanDrupalIdsCommand.php
+++ b/app/Console/Commands/CleanDrupalIdsCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Illuminate\Console\Command;
+use Jenssegers\Mongodb\Collection;
+use Northstar\Models\User;
+
+class CleanDrupalIdsCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'northstar:clean_drupal_ids';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clean up users with empty Drupal ID fields.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        // Find all duplicate users by Drupal ID.
+        $blanks = User::raw(function (Collection $collection) {
+            return $collection->aggregate([
+                [
+                    '$sort' => [
+                        'created_at' => -1,
+                    ],
+                ],
+                [
+                    '$match' => [
+                        'drupal_id' => ['$exists' => true],
+                    ],
+                ],
+                [
+                    '$group' => [
+                        '_id' => ['drupal_id' => '$drupal_id'],
+                        'uniqueIds' => ['$addToSet' => '$_id'],
+                        'count' => ['$sum' => 1],
+                    ],
+                ],
+                [
+                    '$match' => [
+                        '_id' => ['$ne' => 'null'],
+                        'count' => ['$gt' => 1],
+                    ],
+                ],
+            ], [
+                'allowDiskUse' => true,
+            ]);
+        });
+
+        $blanks->each(function ($result) {
+            $this->info('Found '.$result->count.' duplicates for '.$result->_id['drupal_id'].'.');
+
+            foreach ($result->uniqueIds as $index => $duplicateId) {
+                $user = User::find($duplicateId);
+
+                if ($index !== 0) {
+                    $user->delete();
+                    $this->comment('Deleted duplicate with ID '.$user->id.'!');
+                }
+            }
+        });
+    }
+}

--- a/app/Console/Commands/CleanDrupalIdsCommand.php
+++ b/app/Console/Commands/CleanDrupalIdsCommand.php
@@ -9,11 +9,11 @@ use Northstar\Models\User;
 class CleanDrupalIdsCommand extends Command
 {
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'northstar:clean_drupal_ids';
+    protected $signature = 'northstar:clean_drupal_ids {--pretend : List the duplicates that would be deleted.}';
 
     /**
      * The console command description.
@@ -56,7 +56,7 @@ class CleanDrupalIdsCommand extends Command
         });
 
         foreach ($blanks['result'] as $result) {
-            $this->info('Found '.$result['count'].' duplicates for '.$result['_id']['drupal_id'].'.');
+            $this->info('Found '.$result['count'].' duplicates for '.$result['_id']['drupal_id'].':');
 
             // Load each duplicated user model, sort them by their created_at, and reset keys.
             $users = User::findMany($result['uniqueIds'])
@@ -76,8 +76,13 @@ class CleanDrupalIdsCommand extends Command
                     return;
                 }
 
-                $user->delete();
-                $this->comment('Deleted duplicate with ID '.$user->id.'!');
+                $shouldDelete = ! $this->option('pretend');
+                if ($shouldDelete) {
+                    $user->delete();
+                }
+
+                $verb = $shouldDelete ? 'Deleted' : 'Would have deleted';
+                $this->comment($verb.' duplicate with ID '.$user->id.'!');
             });
         }
     }

--- a/app/Console/Commands/CleanDrupalIdsCommand.php
+++ b/app/Console/Commands/CleanDrupalIdsCommand.php
@@ -62,8 +62,16 @@ class CleanDrupalIdsCommand extends Command
             $users = User::findMany($result['uniqueIds'])
                 ->sortBy('created_at')->values();
 
-            // Delete all but the oldest dupe.
             $users->each(function ($user, $index) {
+                // If the Drupal ID is explicitly set null, unset that field & don't delete.
+                if (is_null($user->drupal_id)) {
+                    $user->unset('drupal_id');
+                    $user->save();
+
+                    return;
+                }
+
+                // We want to delete all but the oldest (sorted first) dupe.
                 if ($index === 0) {
                     return;
                 }

--- a/app/Console/Commands/CleanDrupalIdsCommand.php
+++ b/app/Console/Commands/CleanDrupalIdsCommand.php
@@ -60,10 +60,10 @@ class CleanDrupalIdsCommand extends Command
             ]);
         });
 
-        $blanks->each(function ($result) {
-            $this->info('Found '.$result->count.' duplicates for '.$result->_id['drupal_id'].'.');
+        foreach ($blanks['result'] as $result) {
+            $this->info('Found '.$result['count'].' duplicates for '.$result['_id']['drupal_id'].'.');
 
-            foreach ($result->uniqueIds as $index => $duplicateId) {
+            foreach ($result['uniqueIds'] as $index => $duplicateId) {
                 $user = User::find($duplicateId);
 
                 if ($index !== 0) {
@@ -71,6 +71,6 @@ class CleanDrupalIdsCommand extends Command
                     $this->comment('Deleted duplicate with ID '.$user->id.'!');
                 }
             }
-        });
+        }
     }
 }

--- a/app/Console/Commands/RemoveDuplicateUsersCommand.php
+++ b/app/Console/Commands/RemoveDuplicateUsersCommand.php
@@ -12,7 +12,7 @@ class RemoveDuplicateUsersCommand extends Command
      *
      * @var string
      */
-    protected $name = 'users:dedupe';
+    protected $name = 'northstar:dedupe';
 
     /**
      * The console command description.
@@ -20,16 +20,6 @@ class RemoveDuplicateUsersCommand extends Command
      * @var string
      */
     protected $description = 'Script to remove duplicate users.';
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
 
     /**
      * Execute the console command.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         \Northstar\Console\Commands\RemoveDuplicateUsersCommand::class,
+        \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        'Northstar\Console\Commands\RemoveDuplicateUsersCommand',
+        \Northstar\Console\Commands\RemoveDuplicateUsersCommand::class,
     ];
 
     /**

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -9,6 +9,7 @@ use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
  *
  * @method static \Illuminate\Database\Eloquent\Builder where(string $field, string $comparison = '=', string $value)
  * @method static \Illuminate\Database\Eloquent\Builder find(string $id, array $columns=['*'])
+ * @method static \Illuminate\Database\Eloquent\Builder findMany(array $ids)
  * @method static \Illuminate\Database\Eloquent\Builder findOrFail(string $id, array $columns=['*'])
  */
 class Model extends BaseModel

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.18.30",
+            "version": "3.18.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "fbce85229b913a9e1aded54e464a9bbff0787bf1"
+                "reference": "48362bce008fa9c20a71dfa6a68aebac65a8ab1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/fbce85229b913a9e1aded54e464a9bbff0787bf1",
-                "reference": "fbce85229b913a9e1aded54e464a9bbff0787bf1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/48362bce008fa9c20a71dfa6a68aebac65a8ab1b",
+                "reference": "48362bce008fa9c20a71dfa6a68aebac65a8ab1b",
                 "shasum": ""
             },
             "require": {
@@ -85,7 +85,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-07-18 16:15:53"
+            "time": "2016-08-02 20:49:01"
         },
         {
             "name": "classpreloader/classpreloader",
@@ -657,16 +657,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.2.39",
+            "version": "5.2.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c2a77050269b4e03bd9a735a9f24e573a7598b8a"
+                "reference": "29ba2e310cfeb42ab6545bcd81ff4c2ec1f6b5c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c2a77050269b4e03bd9a735a9f24e573a7598b8a",
-                "reference": "c2a77050269b4e03bd9a735a9f24e573a7598b8a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/29ba2e310cfeb42ab6545bcd81ff4c2ec1f6b5c2",
+                "reference": "29ba2e310cfeb42ab6545bcd81ff4c2ec1f6b5c2",
                 "shasum": ""
             },
             "require": {
@@ -723,7 +723,8 @@
                 "illuminate/support": "self.version",
                 "illuminate/translation": "self.version",
                 "illuminate/validation": "self.version",
-                "illuminate/view": "self.version"
+                "illuminate/view": "self.version",
+                "tightenco/collect": "self.version"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "~3.0",
@@ -782,20 +783,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-06-17 19:25:12"
+            "time": "2016-07-20 13:13:06"
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "afea8e682e911a21574fd8519321b32522fa25b5"
+                "reference": "9a8db2cd42346f96993928ff6a6c22563f555ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/afea8e682e911a21574fd8519321b32522fa25b5",
-                "reference": "afea8e682e911a21574fd8519321b32522fa25b5",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/9a8db2cd42346f96993928ff6a6c22563f555ab1",
+                "reference": "9a8db2cd42346f96993928ff6a6c22563f555ab1",
                 "shasum": ""
             },
             "require": {
@@ -803,7 +804,7 @@
                 "php": ">=5.5"
             },
             "require-dev": {
-                "mdanter/ecc": "~0.3",
+                "mdanter/ecc": "~0.3.1",
                 "mikey179/vfsstream": "~1.5",
                 "phpmd/phpmd": "~2.2",
                 "phpunit/php-invoker": "~1.1",
@@ -840,7 +841,7 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2016-03-24 22:46:13"
+            "time": "2016-07-27 11:09:37"
         },
         {
             "name": "league/event",
@@ -894,16 +895,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.25",
+            "version": "1.0.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "a76afa4035931be0c78ca8efc6abf3902362f437"
+                "reference": "fb3b30dca320b36931ea878fea17ebe136fba1b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a76afa4035931be0c78ca8efc6abf3902362f437",
-                "reference": "a76afa4035931be0c78ca8efc6abf3902362f437",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/fb3b30dca320b36931ea878fea17ebe136fba1b0",
+                "reference": "fb3b30dca320b36931ea878fea17ebe136fba1b0",
                 "shasum": ""
             },
             "require": {
@@ -973,7 +974,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-07-18 12:22:57"
+            "time": "2016-08-03 09:49:11"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -1087,16 +1088,16 @@
         },
         {
             "name": "league/oauth2-server",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "68e4b1d39064ba69af2d2461cb657e8aa053447f"
+                "reference": "b8b92e59255ffe586ddd50a3975d7219ca9a8c38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/68e4b1d39064ba69af2d2461cb657e8aa053447f",
-                "reference": "68e4b1d39064ba69af2d2461cb657e8aa053447f",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/b8b92e59255ffe586ddd50a3975d7219ca9a8c38",
+                "reference": "b8b92e59255ffe586ddd50a3975d7219ca9a8c38",
                 "shasum": ""
             },
             "require": {
@@ -1159,20 +1160,20 @@
                 "secure",
                 "server"
             ],
-            "time": "2016-06-28 08:03:41"
+            "time": "2016-07-26 19:42:03"
         },
         {
             "name": "monolog/monolog",
-            "version": "1.20.0",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037"
+                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/55841909e2bcde01b5318c35f2b74f8ecc86e037",
-                "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
                 "shasum": ""
             },
             "require": {
@@ -1237,7 +1238,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-07-02 14:02:10"
+            "time": "2016-07-29 03:23:52"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -1751,16 +1752,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a7abb7153f6d1da47f87ec50274844e246b09d9f"
+                "reference": "926061e74229e935d3c5b4e9ba87237316c6693f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a7abb7153f6d1da47f87ec50274844e246b09d9f",
-                "reference": "a7abb7153f6d1da47f87ec50274844e246b09d9f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/926061e74229e935d3c5b4e9ba87237316c6693f",
+                "reference": "926061e74229e935d3c5b4e9ba87237316c6693f",
                 "shasum": ""
             },
             "require": {
@@ -1807,20 +1808,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:21"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "c54bc3539c3b87e86799533801e8ae0e971d78c2"
+                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/c54bc3539c3b87e86799533801e8ae0e971d78c2",
-                "reference": "c54bc3539c3b87e86799533801e8ae0e971d78c2",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/697c527acd9ea1b2d3efac34d9806bf255278b0a",
+                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a",
                 "shasum": ""
             },
             "require": {
@@ -1864,20 +1865,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
+                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
                 "shasum": ""
             },
             "require": {
@@ -1924,11 +1925,11 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-19 10:45:57"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -1977,16 +1978,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "1341139f906d295baa4f4abd55293d07e25a065a"
+                "reference": "49ba00f8ede742169cb6b70abe33243f4d673f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/1341139f906d295baa4f4abd55293d07e25a065a",
-                "reference": "1341139f906d295baa4f4abd55293d07e25a065a",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/49ba00f8ede742169cb6b70abe33243f4d673f82",
+                "reference": "49ba00f8ede742169cb6b70abe33243f4d673f82",
                 "shasum": ""
             },
             "require": {
@@ -2026,20 +2027,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:21"
+            "time": "2016-07-17 13:54:30"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "177b63b2d50b63fa6d82ea41359ed9928cc7a1fb"
+                "reference": "d97ba4425e36e79c794e7d14ff36f00f081b37b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/177b63b2d50b63fa6d82ea41359ed9928cc7a1fb",
-                "reference": "177b63b2d50b63fa6d82ea41359ed9928cc7a1fb",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/d97ba4425e36e79c794e7d14ff36f00f081b37b3",
+                "reference": "d97ba4425e36e79c794e7d14ff36f00f081b37b3",
                 "shasum": ""
             },
             "require": {
@@ -2108,7 +2109,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-30 16:30:17"
+            "time": "2016-07-30 09:10:37"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2279,16 +2280,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d7cde1f9d94d87060204f863779389b61c382eeb"
+                "reference": "768debc5996f599c4372b322d9061dba2a4bf505"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d7cde1f9d94d87060204f863779389b61c382eeb",
-                "reference": "d7cde1f9d94d87060204f863779389b61c382eeb",
+                "url": "https://api.github.com/repos/symfony/process/zipball/768debc5996f599c4372b322d9061dba2a4bf505",
+                "reference": "768debc5996f599c4372b322d9061dba2a4bf505",
                 "shasum": ""
             },
             "require": {
@@ -2324,7 +2325,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-07-28 11:13:34"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -2382,7 +2383,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -2457,16 +2458,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "6bf844e1ee3c820c012386c10427a5c67bbefec8"
+                "reference": "eee6c664853fd0576f21ae25725cfffeafe83f26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/6bf844e1ee3c820c012386c10427a5c67bbefec8",
-                "reference": "6bf844e1ee3c820c012386c10427a5c67bbefec8",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/eee6c664853fd0576f21ae25725cfffeafe83f26",
+                "reference": "eee6c664853fd0576f21ae25725cfffeafe83f26",
                 "shasum": ""
             },
             "require": {
@@ -2517,20 +2518,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-07-30 07:22:48"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.0.8",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "2f046e9a9d571f22cc8b26783564876713b06579"
+                "reference": "1f7e071aafc6676fcb6e3f0497f87c2397247377"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/2f046e9a9d571f22cc8b26783564876713b06579",
-                "reference": "2f046e9a9d571f22cc8b26783564876713b06579",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/1f7e071aafc6676fcb6e3f0497f87c2397247377",
+                "reference": "1f7e071aafc6676fcb6e3f0497f87c2397247377",
                 "shasum": ""
             },
             "require": {
@@ -2580,7 +2581,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-07-26 08:03:56"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -3461,16 +3462,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.26",
+            "version": "4.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74"
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fc1d8cd5b5de11625979125c5639347896ac2c74",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
                 "shasum": ""
             },
             "require": {
@@ -3529,7 +3530,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2016-07-21 06:48:14"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3961,7 +3962,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -4014,16 +4015,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0"
+                "reference": "c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0",
-                "reference": "99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9",
+                "reference": "c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9",
                 "shasum": ""
             },
             "require": {
@@ -4066,20 +4067,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-26 08:04:17"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1819adf2066880c7967df7180f4f662b6f0567ac",
+                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac",
                 "shasum": ""
             },
             "require": {
@@ -4115,7 +4116,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-17 14:02:08"
         },
         {
             "name": "webmozart/assert",

--- a/tests/Artisan/CleanDrupalIdsCommandTest.php
+++ b/tests/Artisan/CleanDrupalIdsCommandTest.php
@@ -37,12 +37,21 @@ class CleanDrupalIdsCommandTest extends TestCase
             }
         }
 
+        // Make 5 users with explicitly null Drupal ID. Trouble-makers!
+        for ($i = 0; $i < 5; $i++) {
+            User::create([
+                'first_name' => $this->faker->firstName,
+                'email' => $this->faker->email,
+                'drupal_id' => null,
+            ]);
+        }
+
         // There should be 20 users to start with...
-        $this->assertEquals(20, User::all()->count(), 'created all the expected duplicates');
+        $this->assertEquals(25, User::all()->count(), 'created all the expected duplicates');
 
         // And after running the command, we should have only the 10 unique Drupal IDs.
         $this->artisan('northstar:clean_drupal_ids');
-        $this->assertEquals(10, User::all()->count(), 'removed the expected number of duplicates');
+        $this->assertEquals(15, User::all()->count(), 'removed the expected number of duplicates');
 
         // Finally, make sure that we kept all the right records.
         $this->assertEquals('Khan', User::where('drupal_id', $kamala->drupal_id)->first()->last_name);

--- a/tests/Artisan/CleanDrupalIdsCommandTest.php
+++ b/tests/Artisan/CleanDrupalIdsCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Northstar\Models\User;
+
+class CleanDrupalIdsCommandTest extends TestCase
+{
+    /**
+     * Test that it does the thing its supposed to.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testThatItDeletesTheDupes()
+    {
+        User::create(['first_name' => 'Tony', 'last_name' => 'Stark', 'drupal_id' => '12345']);
+        User::create(['first_name' => 'Steve', 'last_name' => 'Rogers', 'drupal_id' => '12346']);
+
+        // Make 5 duplicates for each of these fake Drupal IDs.
+        foreach (['12345', '12346'] as $drupalId) {
+            for ($i = 0; $i < 5; $i++) {
+                User::create([
+                    'first_name' => $this->faker->firstName,
+                    'email' => $this->faker->email,
+                    'drupal_id' => $drupalId,
+                ]);
+            }
+        }
+
+        // Make some users with no Drupal ID.
+        factory(User::class, 7)->create();
+
+        // And finally, a single user with a non-duplicated Drupal ID.
+        User::create(['first_name' => $this->faker->firstName, 'drupal_id' => '55555']);
+
+        // There should be 18 users to start with...
+        $this->assertEquals(20, User::all()->count(), 'created all the expected duplicates');
+
+        // And after running the command, we should have only the 10 unique Drupal IDs.
+        $this->artisan('northstar:clean_drupal_ids');
+        $this->assertEquals(10, User::all()->count(), 'removed the expected number of duplicates');
+
+        // Finally, make sure those original two records for the duped Drupal IDs are the ones we kept.
+        $this->assertEquals('Stark', User::where('drupal_id', '12345')->first()->last_name);
+        $this->assertEquals('Rogers', User::where('drupal_id', '12346')->first()->last_name);
+    }
+}

--- a/tests/Artisan/CleanDrupalIdsCommandTest.php
+++ b/tests/Artisan/CleanDrupalIdsCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Northstar\Models\User;
 
 class CleanDrupalIdsCommandTest extends TestCase
@@ -12,8 +13,12 @@ class CleanDrupalIdsCommandTest extends TestCase
      */
     public function testThatItDeletesTheDupes()
     {
-        User::create(['first_name' => 'Tony', 'last_name' => 'Stark', 'drupal_id' => '12345']);
-        User::create(['first_name' => 'Steve', 'last_name' => 'Rogers', 'drupal_id' => '12346']);
+        $tony = User::create(['first_name' => 'Tony', 'last_name' => 'Stark', 'drupal_id' => '12345']);
+        $tony->setCreatedAt(new Carbon('March 10 1963'))->save();
+
+        $steve = User::create(['first_name' => 'Steve', 'last_name' => 'Rogers', 'drupal_id' => '12346']);
+        $steve->setCreatedAt(new Carbon('July 4 1920'))->save();
+
         User::create(['first_name' => $this->faker->firstName, 'drupal_id' => '55555']);
 
         // Make some users with no Drupal ID.
@@ -30,7 +35,7 @@ class CleanDrupalIdsCommandTest extends TestCase
             }
         }
 
-        // There should be 18 users to start with...
+        // There should be 20 users to start with...
         $this->assertEquals(20, User::all()->count(), 'created all the expected duplicates');
 
         // And after running the command, we should have only the 10 unique Drupal IDs.
@@ -38,7 +43,7 @@ class CleanDrupalIdsCommandTest extends TestCase
         $this->assertEquals(10, User::all()->count(), 'removed the expected number of duplicates');
 
         // Finally, make sure those original two records for the duped Drupal IDs are the ones we kept.
-        $this->assertEquals('Stark', User::where('drupal_id', '12345')->first()->last_name);
-        $this->assertEquals('Rogers', User::where('drupal_id', '12346')->first()->last_name);
+        $this->assertEquals('Stark', User::where('drupal_id', $tony->drupal_id)->first()->last_name);
+        $this->assertEquals('Rogers', User::where('drupal_id', $steve->drupal_id)->first()->last_name);
     }
 }

--- a/tests/Artisan/CleanDrupalIdsCommandTest.php
+++ b/tests/Artisan/CleanDrupalIdsCommandTest.php
@@ -14,8 +14,12 @@ class CleanDrupalIdsCommandTest extends TestCase
     {
         User::create(['first_name' => 'Tony', 'last_name' => 'Stark', 'drupal_id' => '12345']);
         User::create(['first_name' => 'Steve', 'last_name' => 'Rogers', 'drupal_id' => '12346']);
+        User::create(['first_name' => $this->faker->firstName, 'drupal_id' => '55555']);
 
-        // Make 5 duplicates for each of these fake Drupal IDs.
+        // Make some users with no Drupal ID.
+        factory(User::class, 7)->create();
+
+        // Make 5 duplicates for Tony Stark & Steve Rogers' Drupal IDs.
         foreach (['12345', '12346'] as $drupalId) {
             for ($i = 0; $i < 5; $i++) {
                 User::create([
@@ -25,12 +29,6 @@ class CleanDrupalIdsCommandTest extends TestCase
                 ]);
             }
         }
-
-        // Make some users with no Drupal ID.
-        factory(User::class, 7)->create();
-
-        // And finally, a single user with a non-duplicated Drupal ID.
-        User::create(['first_name' => $this->faker->firstName, 'drupal_id' => '55555']);
 
         // There should be 18 users to start with...
         $this->assertEquals(20, User::all()->count(), 'created all the expected duplicates');


### PR DESCRIPTION
#### What's this PR do?
This PR adds an Artisan `northstar:clean_drupal_ids` script which removes records with duplicated Drupal IDs (keeping the oldest, since that seems like a smart heuristic from spot-checking some production data).

References #334.

#### How should this be reviewed?
There's [a test](https://github.com/DFurnes/northstar/blob/0831c8380ca61960406780a15d844cf215b0d3c7/tests/Artisan/CleanDrupalIdsCommandTest.php)! Did I check all the right edge cases?

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 