### PR TITLE
Validate mobiles

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -149,7 +149,7 @@ class Registrar
         $existingId = isset($user->id) ? $user->id : 'null';
         $rules = [
             'email' => 'email|unique:users,email,'.$existingId.',_id|required_without:mobile',
-            'mobile' => 'unique:users,mobile,'.$existingId.',_id|required_without:email',
+            'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id|required_without:email',
             'drupal_id' => 'unique:users,drupal_id,'.$existingId.',_id',
         ];
 

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -14,5 +14,22 @@ use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
  */
 class Model extends BaseModel
 {
-    // ...
+    /**
+     * Set a given attribute on the model.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return mixed
+     */
+    public function setAttribute($key, $value)
+    {
+        // Drop field if attribute is empty string or null.
+        if (empty($value)) {
+            $this->drop($key);
+
+            return null;
+        }
+
+        return parent::setAttribute($key, $value);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -161,13 +161,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setEmailAttribute($value)
     {
-        // Drop field if attribute is empty string or null.
-        if (empty($value)) {
-            $this->drop('email');
-
-            return;
-        }
-
         $this->attributes['email'] = strtolower($value);
     }
 
@@ -191,15 +184,15 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setMobileAttribute($value)
     {
-        // Drop field if attribute is empty string or null.
-        if (empty($value)) {
-            $this->drop('mobile');
+        // Remove all non-numeric characters.
+        $sanitized_value = preg_replace('/[^0-9]/', '', $value);
 
-            return;
+        if (strlen($sanitized_value) === 10) {
+            $this->attributes['mobile'] = $sanitized_value;
+        } else if (strlen($sanitized_value) === 11 && $sanitized_value[0] == 1) {
+            // If it's 11-digits and the leading digit is a 1, then remove it.
+            $this->attributes['mobile'] = substr($sanitized_value, 1);
         }
-
-        // Otherwise, remove all non-numeric characters.
-        $this->attributes['mobile'] = preg_replace('/[^0-9]/', '', $value);
     }
 
     /**
@@ -212,9 +205,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setSourceAttribute($value)
     {
-        if (empty($this->attributes['source'])) {
-            $this->attributes['source'] = $value;
+        if (! empty($this->attributes['source'])) {
+            return;
         }
+
+        $this->attributes['source'] = $value;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -185,14 +185,16 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setMobileAttribute($value)
     {
         // Remove all non-numeric characters.
-        $sanitized_value = preg_replace('/[^0-9]/', '', $value);
+        $sanitizedValue = preg_replace('/[^0-9]/', '', $value);
 
-        if (strlen($sanitized_value) === 10) {
-            $this->attributes['mobile'] = $sanitized_value;
-        } else if (strlen($sanitized_value) === 11 && $sanitized_value[0] == 1) {
-            // If it's 11-digits and the leading digit is a 1, then remove it.
-            $this->attributes['mobile'] = substr($sanitized_value, 1);
+        // If it's 11-digits and the leading digit is a 1, then remove country code.
+        if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === 1) {
+            $this->attributes['mobile'] = substr($sanitizedValue, 1);
+
+            return;
         }
+
+        $this->attributes['mobile'] = $sanitizedValue;
     }
 
     /**

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -23,6 +23,15 @@ class ValidationServiceProvider extends ServiceProvider
     {
         $this->validator = $this->app->make('validator');
 
+        // Add custom validator for US mobile numbers.
+        // @see: Phoenix's dosomething_user_valid_mobile() function.
+        $this->validator->extend('mobile', function ($attribute, $value, $parameters) {
+            preg_match('#^(?:\+?([0-9]{1,3})([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})#', preg_replace('#[\-\s\.]#', '', $value), $valid);
+            preg_match('#([0-9]{1})\1{9,}#', preg_replace('#[^0-9]+#', '', $value), $repeat);
+
+            return ! empty($valid) && empty($repeat);
+        }, 'The :attribute must be a valid US phone number.');
+
         // Add custom validator for localized date (e.g. `MM/DD/YYYY` or `DD/MM/YYYY`).
         $this->validator->extend('scope', function ($attribute, $value, $parameters) {
             return Scope::validateScopes($value);

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -32,7 +32,7 @@ class ValidationServiceProvider extends ServiceProvider
             return ! empty($valid) && empty($repeat);
         }, 'The :attribute must be a valid US phone number.');
 
-        // Add custom validator for localized date (e.g. `MM/DD/YYYY` or `DD/MM/YYYY`).
+        // Add custom validator for OAuth scopes.
         $this->validator->extend('scope', function ($attribute, $value, $parameters) {
             return Scope::validateScopes($value);
         }, 'Invalid scope(s) provided.');

--- a/tests/Legacy/AuthTest.php
+++ b/tests/Legacy/AuthTest.php
@@ -228,6 +228,22 @@ class AuthTest extends TestCase
     }
 
     /**
+     * Test that we can't register a user with an invalid mobile.
+     * POST /auth/register
+     *
+     * @return void
+     */
+    public function testRegisterValidatesMobile()
+    {
+        $this->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/auth/register', [
+            'mobile' => '123',
+            'password' => 'secret',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /**
      * Test that a user can't set "internal" fields when registering.
      * POST /auth/register
      *


### PR DESCRIPTION
#### What's this PR do?
Fixes #357. This PR adds validation and better normalization for the `mobile` attribute, based on the rules that we apply for this field in Phoenix. This will prevent users from being created with silly mobile numbers.

This PR also applies the "unset if empty string" rule for all attributes, so we're not duplicating this for each of our unique indexed fields. I don't think there should be any downside to doing this.

#### How should this be reviewed?
Tests! 🚥 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 