### PR TITLE
Fix issue with mobile number normalization.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -101,6 +101,7 @@ class Registrar
      * Sanitize an email address before verifying or saving to the database.
      * This method will likely be called multiple times per user, so it *must*
      * provide the same result if so.
+     * @TODO: This should be moved into a Normalizer class to DRY up.
      *
      * @param string $email
      * @return string
@@ -114,6 +115,7 @@ class Registrar
      * Sanitize a mobile number before verifying or saving to the database.
      * This method will likely be called multiple times per user, so it *must*
      * provide the same result if so.
+     * @TODO: This should be moved into a Normalizer class to DRY up.
      *
      * @param string $mobile
      * @return string

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -125,10 +125,11 @@ class Registrar
         // Remove all non-numeric characters.
         $sanitizedValue = preg_replace('/[^0-9]/', '', $mobile);
 
+        // @TODO: Look-ups should be normalized too, but waiting until data is fixed in prod.
         // If it's 11-digits and the leading digit is a 1, then remove country code.
-        if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === '1') {
-            $sanitizedValue = substr($sanitizedValue, 1);
-        }
+        // if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === '1') {
+        //     $sanitizedValue = substr($sanitizedValue, 1);
+        // }
 
         return $sanitizedValue;
     }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -120,7 +120,15 @@ class Registrar
      */
     public function normalizeMobile($mobile)
     {
-        return preg_replace('/[^0-9]/', '', $mobile);
+        // Remove all non-numeric characters.
+        $sanitizedValue = preg_replace('/[^0-9]/', '', $mobile);
+
+        // If it's 11-digits and the leading digit is a 1, then remove country code.
+        if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === '1') {
+            $sanitizedValue = substr($sanitizedValue, 1);
+        }
+
+        return $sanitizedValue;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Northstar\Auth\Registrar;
 use Northstar\Auth\Role;
 
 /**
@@ -161,7 +162,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setEmailAttribute($value)
     {
-        $this->attributes['email'] = strtolower($value);
+        $this->attributes['email'] = app(Registrar::class)->normalizeEmail($value);
     }
 
     /**
@@ -184,17 +185,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setMobileAttribute($value)
     {
-        // Remove all non-numeric characters.
-        $sanitizedValue = preg_replace('/[^0-9]/', '', $value);
-
-        // If it's 11-digits and the leading digit is a 1, then remove country code.
-        if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === 1) {
-            $this->attributes['mobile'] = substr($sanitizedValue, 1);
-
-            return;
-        }
-
-        $this->attributes['mobile'] = $sanitizedValue;
+        $this->attributes['mobile'] = app(Registrar::class)->normalizeMobile($value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -156,6 +156,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     /**
      * Mutator to normalize email addresses to lowercase.
+     * @TODO: This should be moved into a Normalizer class to DRY up.
      *
      * @param string $value
      */
@@ -179,6 +180,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     /**
      * Mutator to strip non-numeric characters from mobile numbers.
+     * @TODO: This should be moved into a Normalizer class to DRY up.
      *
      * @param string $value
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
-use Northstar\Auth\Registrar;
 use Northstar\Auth\Role;
 
 /**
@@ -162,7 +161,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setEmailAttribute($value)
     {
-        $this->attributes['email'] = app(Registrar::class)->normalizeEmail($value);
+        $this->attributes['email'] = trim(strtolower($value));
     }
 
     /**
@@ -185,7 +184,15 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setMobileAttribute($value)
     {
-        $this->attributes['mobile'] = app(Registrar::class)->normalizeMobile($value);
+        // Remove all non-numeric characters.
+        $sanitizedValue = preg_replace('/[^0-9]/', '', $value);
+
+        // If it's 11-digits and the leading digit is a 1, then remove country code.
+        if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === '1') {
+            $sanitizedValue = substr($sanitizedValue, 1);
+        }
+
+        $this->attributes['mobile'] = $sanitizedValue;
     }
 
     /**

--- a/tests/RegistrarTest.php
+++ b/tests/RegistrarTest.php
@@ -59,7 +59,7 @@ class RegistrarTest extends TestCase
             'mobile' => '1 (555) 123-4567',
         ]);
 
-        $this->assertSame('15551234567', $normalized['mobile']);
+        $this->assertSame('5551234567', $normalized['mobile']);
     }
 
     /**
@@ -93,7 +93,7 @@ class RegistrarTest extends TestCase
         $this->assertArrayNotHasKey('username', $normalized);
         $this->assertArrayNotHasKey('email', $normalized);
 
-        $this->assertSame('15551234567', $normalized['mobile']);
+        $this->assertSame('5551234567', $normalized['mobile']);
     }
 
     /**

--- a/tests/RegistrarTest.php
+++ b/tests/RegistrarTest.php
@@ -59,7 +59,7 @@ class RegistrarTest extends TestCase
             'mobile' => '1 (555) 123-4567',
         ]);
 
-        $this->assertSame('5551234567', $normalized['mobile']);
+        $this->assertSame('15551234567', $normalized['mobile']);
     }
 
     /**
@@ -93,7 +93,7 @@ class RegistrarTest extends TestCase
         $this->assertArrayNotHasKey('username', $normalized);
         $this->assertArrayNotHasKey('email', $normalized);
 
-        $this->assertSame('5551234567', $normalized['mobile']);
+        $this->assertSame('15551234567', $normalized['mobile']);
     }
 
     /**

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -189,4 +189,26 @@ class UserTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * Test that creating a user results in saving normalized data.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testFieldsAreNormalized()
+    {
+        $this->asAdminUser()->json('POST', 'v1/users', [
+            'first_name' => 'Batman',
+            'email' => 'BatMan@example.com',
+            'mobile' => '1 (222) 333-5555',
+        ]);
+
+        $this->assertResponseStatus(201);
+        $this->seeInDatabase('users', [
+            'first_name' => 'Batman',
+            'email' => 'batman@example.com',
+            'mobile' => '2223335555',
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
This fixes a bug with normalizing mobile numbers (accidentally trying to strictly compare a `'1'` with `1`, and so always skipping the conditional). This means some accounts will still have been saved with leading 1s in the production database.

~~It also uses the Registrar's normalize methods for the User model's mutators to DRY things up.~~ Well, there seems to be some sort of strange error when trying to resolve the Registrar from the User model... keeping things WET for the moment, and will extract to a "Normalizer" in a future PR. 💦 

Fixes #409. References #357.

#### How should this be reviewed?
The failing test added in 382df67 should :sos:, ~~and then it should be ✓ in 8853a65~~... okay but then it should _really_ be ✅ in 10e7ec7. Great work.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 
/cc @sergii-tkachenko 