### PR TITLE
More cleanup for setting up the web authentication flow.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -65,18 +65,6 @@ class Registrar
     }
 
     /**
-     * Normalize the given credentials in the array or request (for example, before
-     * validating, or before saving to the database).
-     *
-     * @param \ArrayAccess|array $credentials
-     * @return mixed
-     */
-    public function normalize($credentials)
-    {
-        return normalize('credentials', $credentials);
-    }
-
-    /**
      * Validate the given user and request.
      *
      * @param Request $request
@@ -117,7 +105,7 @@ class Registrar
      */
     public function resolve($credentials)
     {
-        $credentials = $this->normalize($credentials);
+        $credentials = normalize('credentials', $credentials);
 
         $matches = (new User)->query();
 

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -2,8 +2,8 @@
 
 namespace Northstar\Auth;
 
-use Hash;
 use Illuminate\Contracts\Auth\Guard as Auth;
+use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\Factory as Validation;
 use Illuminate\Http\Request;
@@ -23,27 +23,39 @@ class Registrar
 
     /**
      * Phoenix Drupal API wrapper.
+     *
      * @var Phoenix
      */
     protected $phoenix;
 
     /**
      * Laravel's validation factory.
+     *
      * @var Validation
      */
     protected $validation;
 
     /**
+     * The hasher implementation.
+     *
+     * @var \Illuminate\Contracts\Hashing\Hasher
+     */
+    protected $hasher;
+
+    /**
      * Registrar constructor.
+     *
      * @param Auth $auth
      * @param Phoenix $phoenix
      * @param Validation $validation
+     * @param Hasher $hasher
      */
-    public function __construct(Auth $auth, Phoenix $phoenix, Validation $validation)
+    public function __construct(Auth $auth, Phoenix $phoenix, Validation $validation, Hasher $hasher)
     {
         $this->auth = $auth;
         $this->phoenix = $phoenix;
         $this->validation = $validation;
+        $this->hasher = $hasher;
     }
 
     /**
@@ -166,7 +178,7 @@ class Registrar
             return false;
         }
 
-        if (Hash::check($credentials['password'], $user->password)) {
+        if ($this->hasher->check($credentials['password'], $user->password)) {
             return true;
         }
 

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -2,25 +2,16 @@
 
 namespace Northstar\Auth;
 
-use Illuminate\Contracts\Auth\Guard as Auth;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\Factory as Validation;
 use Illuminate\Http\Request;
 use Northstar\Exceptions\NorthstarValidationException;
-use Northstar\Models\Token;
 use Northstar\Models\User;
 use Northstar\Services\Phoenix;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Registrar
 {
-    /**
-     * The authentication guard.
-     * @var Auth
-     */
-    protected $auth;
-
     /**
      * Phoenix Drupal API wrapper.
      *
@@ -45,35 +36,15 @@ class Registrar
     /**
      * Registrar constructor.
      *
-     * @param Auth $auth
      * @param Phoenix $phoenix
      * @param Validation $validation
      * @param Hasher $hasher
      */
-    public function __construct(Auth $auth, Phoenix $phoenix, Validation $validation, Hasher $hasher)
+    public function __construct(Phoenix $phoenix, Validation $validation, Hasher $hasher)
     {
-        $this->auth = $auth;
         $this->phoenix = $phoenix;
         $this->validation = $validation;
         $this->hasher = $hasher;
-    }
-
-    /**
-     * Authenticate a user based on the given credentials,
-     * and create a new session token.
-     *
-     * @param array $credentials
-     * @return mixed
-     */
-    public function login($credentials)
-    {
-        $user = $this->resolve($credentials);
-
-        if (! $this->verify($user, $credentials)) {
-            throw new UnauthorizedHttpException(null, 'Invalid credentials.');
-        }
-
-        return $this->createToken($user);
     }
 
     /**
@@ -193,21 +164,6 @@ class Registrar
 
         // Well, looks like we couldn't authenticate...
         return false;
-    }
-
-    /**
-     * Create a new authentication token & set the active user.
-     *
-     * @param User $user
-     * @return Token
-     */
-    public function createToken($user)
-    {
-        $token = $user->login();
-
-        $this->auth->setUser($user);
-
-        return $token;
     }
 
     /**

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -78,7 +78,7 @@ class AuthController extends Controller
      */
     public function createToken(Request $request)
     {
-        $request = $this->registrar->normalize($request);
+        $request = normalize('credentials', $request);
         $this->validate($request, $this->loginRules);
 
         $credentials = $request->only('email', 'mobile', 'password');
@@ -96,7 +96,7 @@ class AuthController extends Controller
      */
     public function verify(Request $request)
     {
-        $request = $this->registrar->normalize($request);
+        $request = normalize('credentials', $request);
         $this->validate($request, $this->loginRules);
 
         $credentials = $request->only('email', 'mobile', 'password');
@@ -148,7 +148,7 @@ class AuthController extends Controller
      */
     public function register(Request $request)
     {
-        $request = $this->registrar->normalize($request);
+        $request = normalize('credentials', $request);
 
         // If a user exists but has not set a password yet, allow them to
         // "register" to set a new password on their account.

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -65,7 +65,7 @@ class ProfileController extends Controller
         $user = $this->auth->user();
 
         // Normalize & validate the given request.
-        $request = $this->registrar->normalize($request);
+        $request = normalize('credentials', $request);
         $this->registrar->validate($request, $user);
 
         $user->fill($request->except(User::$internal));

--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -21,7 +21,7 @@ trait TransformsResponses
      * Transform the given item or collection.
      *
      * @param $resource
-     * @return \Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response
      */
     public function transform($resource, $code)
     {
@@ -38,7 +38,7 @@ trait TransformsResponses
      * @param int $code
      * @param array $meta
      * @param null $transformer
-     * @return \Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response
      */
     public function item($item, $code = 200, $meta = [], $transformer = null)
     {
@@ -77,7 +77,7 @@ trait TransformsResponses
      * Format & return a paginated collection response.
      *
      * @param $query - Eloquent query
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\Response
      */
     public function paginatedCollection($query, $request, $code = 200, $meta = [], $transformer = null)
     {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -59,10 +59,10 @@ class UserController extends Controller
         $query = $this->newQuery(User::class);
 
         $filters = $request->query('filter');
-        $query = $this->filter($query, $this->registrar->normalize($filters), User::$indexes);
+        $query = $this->filter($query, normalize('credentials', $filters), User::$indexes);
 
         $searches = $request->query('search');
-        $query = $this->search($query, $this->registrar->normalize($searches), User::$indexes);
+        $query = $this->search($query, normalize('credentials', $searches), User::$indexes);
 
         return $this->paginatedCollection($query, $request);
     }
@@ -87,7 +87,7 @@ class UserController extends Controller
         }
 
         // Normalize input and validate the request
-        $request = $this->registrar->normalize($request);
+        $request = normalize('credentials', $request);
         $this->registrar->validate($request, $existingUser);
 
         // Makes sure we can't "upsert" a record to have a changed index if already set.
@@ -162,7 +162,7 @@ class UserController extends Controller
         $user = $this->registrar->resolveOrFail([$term => $id]);
 
         // Normalize input and validate the request
-        $request = $this->registrar->normalize($request);
+        $request = normalize('credentials', $request);
         $this->registrar->validate($request, $user);
 
         // Only admins can change the role field.

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -27,7 +27,7 @@ class Token extends Model
      *
      * @var array
      */
-    protected $fillable = [];
+    protected $fillable = ['user_id'];
 
     /**
      * Create a new Token.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Northstar\Auth\Entities\ClientEntity;
 use Northstar\Auth\Entities\ScopeEntity;
 use Northstar\Auth\Scope;
 use Northstar\Models\Client;
+use Northstar\Models\Token;
 use Northstar\Models\User;
 
 class TestCase extends Illuminate\Foundation\Testing\TestCase
@@ -166,7 +167,9 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
      */
     public function asUserUsingLegacyAuth(User $user)
     {
-        $token = $user->login();
+        // Create a legacy token.
+        $token = Token::create(['user_id' => $user->id]);
+
         $this->serverVariables = array_replace($this->serverVariables, [
             'HTTP_Authorization' => 'Bearer '.$token->key,
         ]);


### PR DESCRIPTION
#### What's this PR do?

🍃 Removes the remaining calls to the Registrar's `normalize` method, so we can use the new `normalize()` helper function everywhere instead! (2962a18)

💉 Inject the hasher into the Registrar, rather than using the facade. My crusade continues! (d6f72cd)

👋 Remove the Registrar's `login` and `createToken` methods – these were only relevant for legacy authentication so keeping them around could be confusing at first glance, and authentication probably isn't the Registrar's concern anyways! (e22b907)

#### Why are you doing all this?!
I made these changes when adding web sessions & login for the authentication code grant, I promise! The problem I ran into was that I couldn't inject the Registrar into the user provider because it caused a circular dependency (it needs the authentication Guard for that `login` method). 

#### How should this be reviewed?
Like the last PR, it's probably easiest to go commit-by-commit (linked above). 🔢

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd