### PR TITLE
Add web sessions, functional login and logout routes.

### DIFF
--- a/app/Auth/NorthstarTokenGuard.php
+++ b/app/Auth/NorthstarTokenGuard.php
@@ -125,11 +125,9 @@ class NorthstarTokenGuard extends TokenGuard implements Guard
      */
     public function validate(array $credentials = [])
     {
-        if ($this->getUserForToken($credentials[$this->inputKey])) {
-            return true;
-        }
+        $user = $this->provider->retrieveByCredentials($credentials);
 
-        return false;
+        return $this->provider->validateCredentials($user, $credentials);
     }
 
     /**

--- a/app/Auth/NorthstarUserProvider.php
+++ b/app/Auth/NorthstarUserProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Northstar\Auth;
+
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
+use Illuminate\Contracts\Auth\Authenticatable as UserContract;
+
+class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
+{
+    /**
+     * The registrar handles retrieving users from the database.
+     * @var Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Create a new database user provider.
+     *
+     * @param \Northstar\Auth\Registrar $registrar
+     * @param \Illuminate\Contracts\Hashing\Hasher $hasher
+     * @param string $model
+     */
+    public function __construct(Registrar $registrar, HasherContract $hasher, $model)
+    {
+        $this->registrar = $registrar;
+
+        parent::__construct($hasher, $model);
+    }
+
+    /**
+     * Retrieve a user by the given credentials.
+     *
+     * @param  array  $credentials
+     * @return \Northstar\Models\User|null
+     */
+    public function retrieveByCredentials(array $credentials)
+    {
+        return $this->registrar->resolve($credentials);
+    }
+
+    /**
+     * Validate a user against the given credentials. If the user has a Drupal
+     * password & it matches, re-hash and save to the user document.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  array  $credentials
+     * @return bool
+     */
+    public function validateCredentials(UserContract $user, array $credentials)
+    {
+        return $this->registrar->validateCredentials($user, $credentials);
+    }
+}

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Models\User;
 use Northstar\Services\Phoenix;
+use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 
 class Registrar
 {
@@ -138,14 +139,14 @@ class Registrar
     }
 
     /**
-     * Verify the given user and credentials. If the user has a Drupal
+     * Validate a user against the given credentials. If the user has a Drupal
      * password & it matches, re-hash and save to the user document.
      *
-     * @param User $user
+     * @param UserContract|User $user
      * @param array $credentials
      * @return bool
      */
-    public function verify($user, $credentials)
+    public function validateCredentials(UserContract $user, array $credentials)
     {
         if (! $user) {
             return false;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -88,7 +88,9 @@ class Registrar
      */
     public function resolve($credentials)
     {
+        // Normalize credentials and remove password if provided.
         $credentials = normalize('credentials', $credentials);
+        $credentials = array_except($credentials, 'password');
 
         $matches = (new User)->query();
 

--- a/app/Auth/Repositories/UserRepository.php
+++ b/app/Auth/Repositories/UserRepository.php
@@ -11,6 +11,7 @@ class UserRepository implements UserRepositoryInterface
 {
     /**
      * Northstar's user registrar.
+     *
      * @var Registrar
      */
     protected $registrar;
@@ -39,7 +40,7 @@ class UserRepository implements UserRepositoryInterface
         $credentials = ['username' => $username, 'password' => $password];
         $user = $this->registrar->resolve($credentials);
 
-        if (! $user || ! $this->registrar->verify($user, $credentials)) {
+        if (! $this->registrar->validateCredentials($user, $credentials)) {
             return null;
         }
 

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -85,7 +85,7 @@ class AuthController extends Controller
         $credentials = $request->only('email', 'mobile', 'password');
         $user = $this->registrar->resolve($credentials);
 
-        if (! $this->registrar->verify($user, $credentials)) {
+        if (! $this->registrar->validateCredentials($user, $credentials)) {
             throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 
@@ -111,7 +111,7 @@ class AuthController extends Controller
         $credentials = $request->only('email', 'mobile', 'password');
         $user = $this->registrar->resolve($credentials);
 
-        if (! $this->registrar->verify($user, $credentials)) {
+        if (! $this->registrar->validateCredentials($user, $credentials)) {
             throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -12,14 +12,14 @@ use Northstar\Services\Phoenix;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Illuminate\Contracts\Auth\Guard as Auth;
+use Illuminate\Contracts\Auth\Factory as Auth;
 use Northstar\Auth\Registrar;
 
 class AuthController extends Controller
 {
     /**
-     * The authentication guard.
-     * @var \Northstar\Auth\NorthstarTokenGuard
+     * The authentication factory.
+     * @var \Illuminate\Contracts\Auth\Factory
      */
     protected $auth;
 
@@ -91,7 +91,7 @@ class AuthController extends Controller
 
         // Create a legacy token & set the user for this request.
         $token = Token::create(['user_id' => $user->id]);
-        $this->auth->setUser($user);
+        $this->auth->guard('api')->setUser($user);
 
         return $this->item($token, 201);
     }
@@ -128,7 +128,7 @@ class AuthController extends Controller
      */
     public function invalidateToken(Request $request)
     {
-        $token = $this->auth->token();
+        $token = $this->auth->guard('api')->token();
 
         // Attempt to delete token.
         $deleted = $token->delete();

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -3,7 +3,7 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Contracts\Auth\Guard as Auth;
+use Illuminate\Contracts\Auth\Factory as Auth;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Northstar\Auth\Encrypter;
 use Northstar\Models\RefreshToken;
@@ -15,13 +15,15 @@ class OAuthController extends Controller
 {
     /**
      * The OAuth authorization server.
+     *
      * @var AuthorizationServer
      */
     protected $oauth;
 
     /**
-     * The authentication guard.
-     * @var \Northstar\Auth\NorthstarTokenGuard
+     * The authentication factory.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
      */
     protected $auth;
 
@@ -103,7 +105,7 @@ class OAuthController extends Controller
         }
 
         // Make sure that the authenticated user is allowed to do this.
-        if ($this->auth->user()->getAuthIdentifier() !== $refreshToken['user_id']) {
+        if ($this->auth->guard('api')->user()->getAuthIdentifier() !== $refreshToken['user_id']) {
             throw OAuthServerException::accessDenied('That refresh token does not belong to the currently authorized user.');
         }
 

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -3,6 +3,7 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Contracts\Auth\Factory as Auth;
 
 class WebController extends Controller
 {

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -3,17 +3,32 @@
 namespace Northstar\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Contracts\Auth\Factory as Auth;
 
-class WebController extends Controller
+class WebController extends BaseController
 {
+    use ValidatesRequests;
+
     /**
-     * Make a new HomeController, inject dependencies,
-     * and set middleware for this controller's methods.
+     * The authentication factory.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
      */
-    public function __construct()
+    protected $auth;
+
+    /**
+     * Make a new WebController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param \Illuminate\Contracts\Auth\Factory $auth
+     */
+    public function __construct(Auth $auth)
     {
-        // ...
+        $this->auth = $auth;
+
+        $this->middleware('auth:web', ['except' => ['getLogin', 'postLogin']]);
     }
 
     /**
@@ -23,7 +38,7 @@ class WebController extends Controller
      */
     public function home()
     {
-        return redirect()->to('https://www.dosomething.org');
+        return view('home');
     }
 
     /**
@@ -37,10 +52,10 @@ class WebController extends Controller
     }
 
     /**
-     * the login form.
+     * Handle submissions of the login form.
      *
      * @param Request $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function postLogin(Request $request)
     {
@@ -49,16 +64,26 @@ class WebController extends Controller
             'password' => 'required',
         ]);
 
-        return $this->respond('Not yet implemented.', 501);
+        $credentials = $request->only('username', 'password');
+        if (! $this->auth->guard('web')->attempt($credentials, true)) {
+            return redirect()->back()
+                ->withInput($request->only('username'))
+                ->withErrors(['username' => 'These credentials do not match our records.']);
+        }
+
+        return redirect()->intended('/');
     }
 
     /**
-     * Placeholder logout route.
+     * Log a user out from Northstar, preventing one-click
+     * sign-ons to other DoSomething.org websites.
      *
      * @return \Illuminate\Http\Response
      */
     public function getLogout()
     {
-        return $this->respond('Not yet implemented.', 501);
+        $this->auth->guard('web')->logout();
+
+        return redirect('login');
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,8 @@ use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\ResourceServer;
 use Northstar\Auth\NorthstarTokenGuard;
+use Northstar\Auth\NorthstarUserProvider;
+use Northstar\Auth\Registrar;
 use Northstar\Auth\Repositories\AccessTokenRepository;
 use Northstar\Auth\Repositories\ClientRepository;
 use Northstar\Auth\Repositories\RefreshTokenRepository;
@@ -48,6 +50,11 @@ class AuthServiceProvider extends ServiceProvider
          * @var \Illuminate\Auth\AuthManager $auth
          */
         $auth = $this->app['auth'];
+
+        // Register our custom user provider
+        $auth->provider('northstar', function ($app, array $config) {
+            return new NorthstarUserProvider($app[Registrar::class], $app['hash'], $config['model']);
+        });
 
         // Register our custom token Guard implementation
         $auth->extend('northstar-token', function ($app, $name, array $config) use ($auth) {

--- a/config/auth.php
+++ b/config/auth.php
@@ -66,7 +66,7 @@ return [
 
     'providers' => [
         'users' => [
-            'driver' => 'eloquent',
+            'driver' => 'northstar', // @see: \Northstar\Auth\NorthstarUserProvider
             'model' => Northstar\Models\User::class,
         ],
     ],

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -2,3 +2,52 @@ $forge-path: "~@dosomething/forge/assets/";
 
 // Import Forge.
 @import "~@dosomething/forge/scss/forge";
+
+// Remove the gray background from the page.
+body, html {
+  background: #fff;
+}
+
+// Remove the shadow from the chrome so it's border-less.
+.chrome > .wrapper {
+  box-shadow: none;
+}
+
+// The navigation shouldn't float on mobile here.
+@include media($mobile) {
+  .navigation .navigation__logo {
+    position: static;
+  }
+}
+
+// Fix a strange issue with the Container on mobile.
+// @TODO: Why is this happening here?
+.container > .wrapper {
+  width: 100%;
+}
+
+// Add a new `.-centered` variation to the Container Block.
+.container .container__block {
+  &.-centered {
+    @include media($tablet) {
+      @include span(9 of 12);
+      @include push(2);
+
+      text-align: center;
+
+      // @TODO: Hacky!
+      .field-label { text-align: left; }
+    }
+  }
+}
+
+// Validation Errors
+.validation-error {
+  color: #ff4747;
+  text-align: left;
+  margin: 12px 0;
+
+  & h4 {
+    color: #ff4747
+  }
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -12,7 +12,7 @@
 <body class="modernizr-no-js">
 <div class="chrome">
     <div class="wrapper">
-        <nav class="navigation -floating">
+        <nav class="navigation">
             <a class="navigation__logo" href="http://www.dosomething.org"><span>DoSomething.org</span></a>
         </nav>
         @yield('content')

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,17 @@
+@extends('app')
+
+@section('title', 'Log In | DoSomething.org')
+
+@section('content')
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -centered">
+                <h1>You're logged in.</h1>
+            </div>
+            <div class="container__block -centered">
+                <p><a href="{{ url('logout') }}" class="button -secondary">Log out</a></p>
+                <p class="footnote">(That's all for now.)</p>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -3,21 +3,45 @@
 @section('title', 'Log In | DoSomething.org')
 
 @section('content')
-    <header role="banner" class="header">
+    <div class="container -padded">
         <div class="wrapper">
-            <h1 class="header__title">Log In</h1>
-            <p class="header__subtitle">Please log in to continue!</p>
-        </div>
-    </header>
+            <div class="container__block -centered">
+                <h1>Log in to get started!</h1>
+            </div>
+            <div class="container__block -centered">
+                @if (count($errors) > 0)
+                    <div class="validation-error fade-in-up">
+                        <h4>Hmm, there were some issues with that submission:</h4>
+                        <ul class="list -compacted">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+                <form method="POST" action="{{ url('login') }}">
+                    <input name="_token" type="hidden" value="{{ csrf_token() }}">
 
-    <div class="container">
-        <div class="wrapper">
-            <div class="container__block -narrow">
-                <p>Hey, <strong>Application Name</strong> wants you to log in.</p>
+                    <div class="form-item">
+                        <label for="username" class="field-label">Email address or cell number</label>
+                        <input name="username" type="text" class="text-field" placeholder="puppet-sloth@example.org">
+                    </div>
 
-                <form action="#">
-                    <input type="hidden" value="{{ csrf_token() }}">
+                    <div class="form-item">
+                        <label for="password" class="field-label">Password</label>
+                        <input name="password" type="password" class="text-field" placeholder="••••••••">
+                    </div>
+
+                    <div class="form-actions -padded">
+                        <input type="submit" class="button" value="Log In">
+                    </div>
                 </form>
+            </div>
+            <div class="container__block -centered">
+                <ul>
+                    <li><a href="{{ url(config('services.drupal.url').'/user/register') }}">Create a DoSomething.org account</a></li>
+                    <li><a href="{{ url(config('services.drupal.url').'/user/password') }}">Forgot your password?</a></li>
+                </ul>
             </div>
         </div>
     </div>

--- a/tests/WebTest.php
+++ b/tests/WebTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Northstar\Models\User;
+
+class WebTest extends TestCase
+{
+    /**
+     * Reset the server variables for the request.
+     *
+     * @var array
+     */
+    protected $serverVariables = [
+        'Accept' => 'text/html',
+    ];
+
+    /**
+     * Test that the homepage redirects to login page.
+     */
+    public function testHomepageAnonymousRedirect()
+    {
+        $this->get('/')->followRedirects();
+
+        $this->seePageIs('login');
+    }
+
+    /**
+     * Test that the homepage renders for logged-in users.
+     */
+    public function testHomepage()
+    {
+        $user = factory(User::class)->create();
+        $this->be($user, 'web');
+
+        $this->visit('/');
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test that users can log in via the web.
+     */
+    public function testLogin()
+    {
+        $user = factory(User::class)->create(['email' => 'login-test@dosomething.org', 'password' => 'secret']);
+
+        $this->visit('login')
+            ->type('Login-Test@dosomething.org', 'username')
+            ->type('secret', 'password')
+            ->press('Log In');
+
+        $this->assertEquals($user->id, auth()->id());
+        $this->see('You\'re logged in.');
+    }
+
+    /**
+     * Test that users cannot login with bad credentials via the web.
+     */
+    public function testLoginWithInvalidCredentials()
+    {
+        factory(User::class)->create(['email' => 'login-test@dosomething.org', 'password' => 'secret']);
+
+        $this->visit('login')
+            ->type('Login-Test@dosomething.org', 'username')
+            ->type('open-sesame', 'password') // <-- wrong password!
+            ->press('Log In');
+
+        $this->see('These credentials do not match our records.');
+    }
+
+    /**
+     * Test that an authenticated user can log out.
+     */
+    public function testLogout()
+    {
+        $user = factory(User::class)->create();
+        $this->be($user, 'web');
+
+        $this->get('logout')->followRedirects();
+        $this->see('Log in to get started!');
+
+        $this->assertEquals(false, auth()->check());
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Woo! This implements the fabled web login flow for Northstar:

![screen recording 2016-09-09 at 02 39 pm](https://cloud.githubusercontent.com/assets/583202/18398551/51e226ba-769b-11e6-8473-3c9a2d07af60.gif)

Step by step:

🎫 Some little tweaks to the Registrar: should ignore any provided passwords when _resolving_ (since that's not an authentication action), and renames `verify` to `validateCredentials` for clarity and because it matches the interface name for the Laravel user provider! (7a17e8a, 5512b65)

🔑 The token guard's `validate` method should check actual credentials, rather than just looking for token deets. This way the `$this->auth->guard(...)->once()` method works as expected. (a756e2b)

👪 Adds a custom user provider so Laravel's built-in SessionGuard works out of the box with our Registrar, and start using the auth factory to allow selecting specific guard rather than always injecting the API-specific one. (7cfc041, 178e5e5)

💻 Fully implements login & logout routes, styled to look like the Phoenix modals. This is how the Auth Code flow will log a user in before redirecting back to the client app. (1b096bd, 1b096bd)

References #419.

#### How should this be reviewed?
Commits for each part of this PR are linked above, and tests are added for the new flows. 🚥

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 