### PR TITLE
Enable auth code flow.

### DIFF
--- a/app/Auth/Entities/AuthCodeEntity.php
+++ b/app/Auth/Entities/AuthCodeEntity.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Northstar\Auth\Entities;
+
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
+
+class AuthCodeEntity implements AuthCodeEntityInterface
+{
+    use EntityTrait, TokenEntityTrait, AuthCodeTrait;
+}

--- a/app/Auth/Entities/ClientEntity.php
+++ b/app/Auth/Entities/ClientEntity.php
@@ -22,14 +22,12 @@ class ClientEntity implements ClientEntityInterface
      * @param $client_id
      * @param $scopes
      */
-    public function __construct($client_id, $scopes)
+    public function __construct($client_id, $scopes, $redirect_uri = '')
     {
         $this->name = $client_id; // @TODO: If we store a human-readable client name, use here.
         $this->allowedScopes = $scopes;
         $this->identifier = $client_id;
-
-        // @TODO: Will need this for authentication code flow. Save this per client!
-        $this->redirectUri = '';
+        $this->redirectUri = $redirect_uri;
     }
 
     /**

--- a/app/Auth/Repositories/AuthCodeRepository.php
+++ b/app/Auth/Repositories/AuthCodeRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Northstar\Auth\Repositories;
+
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
+use Northstar\Auth\Entities\AuthCodeEntity;
+use Northstar\Models\AuthCode;
+
+class AuthCodeRepository implements AuthCodeRepositoryInterface
+{
+    /**
+     * Creates a new AuthCode
+     *
+     * @return AuthCodeEntityInterface
+     */
+    public function getNewAuthCode()
+    {
+        return new AuthCodeEntity();
+    }
+
+    /**
+     * Persists a new auth code to permanent storage.
+     *
+     * @param AuthCodeEntityInterface $authCodeEntity
+     */
+    public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
+    {
+        AuthCode::create([
+            'code' => $authCodeEntity->getIdentifier(),
+            'scopes' => $authCodeEntity->getScopes(),
+            'expiration' => $authCodeEntity->getExpiryDateTime(),
+            'user_id' => $authCodeEntity->getUserIdentifier(),
+            'client_id' => $authCodeEntity->getClient()->getIdentifier(),
+            'redirect_uri' => $authCodeEntity->getRedirectUri(),
+        ]);
+    }
+
+    /**
+     * Revoke an auth code.
+     *
+     * @param string $codeId
+     */
+    public function revokeAuthCode($codeId)
+    {
+        AuthCode::where('code', $codeId)->delete();
+    }
+
+    /**
+     * Check if the auth code has been revoked.
+     *
+     * @param string $codeId
+     * @return bool Return true if this code has been revoked
+     */
+    public function isAuthCodeRevoked($codeId)
+    {
+        return ! AuthCode::where('code', $codeId)->exists();
+    }
+}

--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -37,7 +37,7 @@ class ClientRepository implements ClientRepositoryInterface
             return null;
         }
 
-        return new ClientEntity($model->client_id, $model->scope);
+        return new ClientEntity($model->client_id, $model->scope, $model->redirect_uri);
     }
 
     /**

--- a/app/Models/AuthCode.php
+++ b/app/Models/AuthCode.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Northstar\Models;
+
+use Carbon\Carbon;
+
+/**
+ * The OAuth refresh token model.
+ *
+ * @property string $id
+ * @property string $code
+ * @property string $token
+ * @property array $scopes
+ * @property Carbon $expiration
+ * @property string $user_id
+ * @property string $client_id
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder where(string $field, string $comparison = '=', string $value)
+ */
+class AuthCode extends Model
+{
+    /**
+     * The database collection used by the model.
+     *
+     * @var string
+     */
+    protected $collection = 'auth_codes';
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'expiration' => 'date',
+        'scopes' => 'array',
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['code', 'scopes', 'user_id', 'client_id', 'expiration', 'redirect_uri'];
+}

--- a/database/migrations/2016_09_12_155104_AddIndexToAuthCodes.php
+++ b/database/migrations/2016_09_12_155104_AddIndexToAuthCodes.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToAuthCodes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('auth_codes', function (Blueprint $collection) {
+            $collection->unique('code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('auth_codes', function (Blueprint $collection) {
+            $collection->dropUnique('code');
+        });
+    }
+}

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -21,7 +21,8 @@ class ClientTableSeeder extends Seeder
             'description' => 'This is an example OAuth client seeded with your local Northstar installation. It was automatically given all scopes that were defined when it was created.',
             'client_id' => 'trusted-test-client',
             'client_secret' => 'secret1',
-            'allowed_grants' => ['password', 'client_credentials'],
+            'redirect_uri' => 'http://northstar.dev:8000',
+            'allowed_grants' => ['authorization_code', 'password', 'client_credentials'],
             'scope' => collect(Scope::all())->keys()->toArray(),
         ]);
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,6 +12,7 @@ See [Authentication](authentication.md) for details on authorizing your requests
 #### Authentication
 Endpoint                  | Functionality                                                      | Required Scope
 ------------------------- | ------------------------------------------------------------------ | --------------
+`POST v2/auth/token`      | [Create Auth Token (Authorization Code Grant)](endpoints/auth.md#create-token-authorization-code-grant) | 
 `POST v2/auth/token`      | [Create Auth Token (Password Grant)](endpoints/auth.md#create-token-password-grant) | 
 `POST v2/auth/token`      | [Create Auth Token (Client Credentials Grant)](endpoints/auth.md#create-token-client-credentials-grant) | 
 `POST v2/auth/token`      | [Create Auth Token (Refresh Token Grant)](endpoints/auth.md#create-token-refresh-token-grant) | 

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -21,11 +21,11 @@ Each client has a list of whitelisted scopes, and scopes that are not allowed fo
 For example, a malicious user with the mobile app client credentials could never request the ability to delete users.
 
 The allowed scopes for each client are listed on Aurora. A machine-friendly list of scopes and their descriptions can be
-retrieved from the public [`scopes`](endpoints/keys.md#retrieving-all-api-key-scopes) endpoint.
+retrieved from the public [`scopes`](endpoints/clients.md#retrieve-all-client-scopes) endpoint.
 
 ### Access Tokens
-The [Password Grant](endpoints/oauth.md#create-token-password-grant) may be used to request an **access token** so that requests can be
-made on behalf of a particular user.
+The [Authorization Code Grant](endpoints/auth.md#create-token-authorization-code-grant) or [Password Grant](endpoints/auth.md#create-token-password-grant)
+may be used to request an **access token** which can "authorize" requests on behalf of a particular user.
 
 We authenticate requests to our APIs using [JSON Web Tokens](https://jwt.io), another [open standard](https://tools.ietf.org/html/rfc7519)
 that allows us to issue cryptographically signed tokens. Because the tokens are signed, this data can't be tampered with without invalidating
@@ -73,12 +73,12 @@ Access tokens are short-lived and expire after an hour. Since that's not a very 
 **refresh tokens** which can be used (once!) to create another access token. Refresh tokens _never_ expire, but can be revoked
 manually - for example, if a user "removes" an application or logs out from their account.
 
-Once a refresh token is used to create a new access token through the [Refresh Token Grant](endpoints/oauth.md#create-token-refresh-token-grant),
+Once a refresh token is used to create a new access token through the [Refresh Token Grant](endpoints/auth.md#create-token-refresh-token-grant),
 a _new_ access token and refresh token are returned & the old refresh token cannot be used again.
 
 ### "Computer" Authentication
 Some services don't authenticate on behalf of a user (for example, an internal batch-processing service). These clients can use the
-[Client Credentials Grant](endpoints/oauth.md#create-token-client-credentials-grant) to request a signed authentication token
+[Client Credentials Grant](endpoints/auth.md#create-token-client-credentials-grant) to request a signed authentication token
 that securely identifies that particular application. Since user credentials are not involved, this does _not_ create a refresh
 token.
 

--- a/tests/Legacy/AuthTest.php
+++ b/tests/Legacy/AuthTest.php
@@ -388,7 +388,7 @@ class AuthTest extends TestCase
      */
     public function testMissingToken()
     {
-        $this->withLegacyApiKeyScopes(['user'])->get('v1/profile');
+        $this->withLegacyApiKeyScopes(['user'])->json('GET', 'v1/profile');
         $this->assertResponseStatus(401);
     }
 
@@ -398,7 +398,7 @@ class AuthTest extends TestCase
      */
     public function testFakeToken()
     {
-        $this->withLegacyApiKeyScopes(['user'])->get('v1/profile', [
+        $this->withLegacyApiKeyScopes(['user'])->json('GET', 'v1/profile', [
             'Authorization' => 'Bearer any_token_anytime_anywhere',
         ]);
 
@@ -420,7 +420,7 @@ class AuthTest extends TestCase
                 'expires' => '2016-06-08T16:54:09+00:00',
             ]);
 
-        $this->asUserUsingLegacyAuth($user)->withLegacyApiKeyScopes(['user'])->post('v1/auth/phoenix');
+        $this->asUserUsingLegacyAuth($user)->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/auth/phoenix');
 
         $this->assertResponseStatus(200);
         $this->seeJsonStructure([
@@ -435,7 +435,7 @@ class AuthTest extends TestCase
     {
         $user = User::create(['email' => $this->faker->email]);
 
-        $this->asUserUsingLegacyAuth($user)->withLegacyApiKeyScopes(['user'])->post('v1/auth/phoenix');
+        $this->asUserUsingLegacyAuth($user)->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/auth/phoenix');
         $this->assertResponseStatus(403);
     }
 
@@ -444,7 +444,7 @@ class AuthTest extends TestCase
      */
     public function testMagicLoginAnonymous()
     {
-        $this->withLegacyApiKeyScopes(['user'])->post('v1/auth/phoenix');
+        $this->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/auth/phoenix');
         $this->assertResponseStatus(401);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,16 +19,6 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     protected $baseUrl = 'http://localhost';
 
     /**
-     * Additional server variables for the request.
-     *
-     * @var array
-     */
-    protected $serverVariables = [
-        'CONTENT_TYPE' => 'application/json',
-        'HTTP_Accept' => 'application/json',
-    ];
-
-    /**
      * The Faker generator, for creating test data.
      *
      * @var \Faker\Generator


### PR DESCRIPTION
#### What's this PR do?
This PR enables the [authorization code grant](https://oauth2.thephpleague.com/authorization-server/auth-code-grant/) (where the user is authenticated through Northstar's web interface). This is a nice improvement over the password grant (where each service needs to hand off the plain-text password... eww), and is a pre-requisite for testing out [OpenID Connect](https://openidconnect.net).

Closes #419.

![screen recording 2016-09-12 at 01 46 pm](https://cloud.githubusercontent.com/assets/583202/18446213/5b465496-78ef-11e6-9a95-571d22b74192.gif)

#### How should this be reviewed?
Still need to add documentation & tests, but feel free to take a sneak peek! 🚧

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @angaither @weerd 
