### PR TITLE
OpenID Connect testing.

### DIFF
--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -29,6 +29,9 @@ class Scope
         'profile' => [
             'description' => 'Allows viewing an authenticated user\'s full profile.',
         ],
+        'email' => [
+            'description' => 'Allows viewing the authenticated user\'s email address.',
+        ],
         'openid' => [
             'description' => 'Allows users to be authorized by OpenID Connect.',
         ],

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -26,6 +26,12 @@ class Scope
         'user' => [
             'description' => 'Allows actions to be made on a user\'s behalf.',
         ],
+        'profile' => [
+            'description' => 'Allows viewing an authenticated user\'s full profile.',
+        ],
+        'openid' => [
+            'description' => 'Allows users to be authorized by OpenID Connect.',
+        ],
     ];
 
     /**

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Auth\Factory as Auth;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Northstar\Auth\Encrypter;
 use Northstar\Auth\Entities\UserEntity;
+use Northstar\Http\Transformers\UserInfoTransformer;
 use Northstar\Models\RefreshToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -49,7 +50,7 @@ class OAuthController extends Controller
         $this->encrypter = $encrypter;
 
         $this->middleware('auth:web', ['only' => 'authorize']);
-        $this->middleware('auth:api', ['only' => 'invalidateToken']);
+        $this->middleware('auth:api', ['only' => ['info', 'invalidateToken']]);
     }
 
     /**
@@ -76,6 +77,18 @@ class OAuthController extends Controller
 
         // Return the HTTP redirect response.
         return $this->oauth->completeAuthorizationRequest($authRequest, $response);
+    }
+
+    /**
+     * Show the user info for the authorized user.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function info()
+    {
+        $user = $this->auth->guard('api')->user();
+
+        return $this->item($user, 200, [], new UserInfoTransformer);
     }
 
     /**

--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -13,6 +13,8 @@ class UserInfoTransformer extends TransformerAbstract
      */
     public function transform(User $user)
     {
+        // User data, formatted according to OpenID Connect spec, section 5.3.
+        // @see http://openid.net/specs/openid-connect-core-1_0.html#UserInfo
         $response = [
             'id' => $user->_id,
             'given_name' => $user->first_name,

--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Northstar\Http\Transformers;
+
+use Northstar\Models\User;
+use League\Fractal\TransformerAbstract;
+
+class UserInfoTransformer extends TransformerAbstract
+{
+    /**
+     * @param User $user
+     * @return array
+     */
+    public function transform(User $user)
+    {
+        $response = [
+            'id' => $user->_id,
+            'given_name' => $user->first_name,
+            'family_name' => $user->last_name,
+            'email' => $user->email,
+            'phone_number' => $user->mobile,
+
+            'address' => [
+                'street_address' => implode(PHP_EOL, [$user->addr_street1, $user->addr_street2]),
+                'locality' => $user->addr_city,
+                'region' => $user->addr_state,
+                'postal_code' => $user->addr_zip,
+                'country' => $user->country,
+            ],
+
+            'updated_at' => $user->updated_at->timestamp,
+            'created_at' => $user->created_at->timestamp,
+        ];
+
+        return $response;
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -25,6 +25,7 @@ $router->group(['guard' => 'web', 'middleware' => ['web']], function () use ($ro
 $router->group(['prefix' => 'v2', 'middleware' => ['api']], function () use ($router) {
     // Authentication
     $router->post('auth/token', 'OAuthController@createToken');
+    $router->get('auth/info', 'OAuthController@info');
     $router->delete('auth/token', 'OAuthController@invalidateToken');
 
     // Users

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -23,7 +23,7 @@ class ClientTableSeeder extends Seeder
             'client_secret' => 'secret1',
             'redirect_uri' => [
                 'http://northstar.dev:8000',
-                'http://dev.dosomething.org:8888/openid-connect/generic',
+                'http://dev.dosomething.org:8888/openid-connect/northstar',
             ],
             'allowed_grants' => ['authorization_code', 'password', 'client_credentials'],
             'scope' => collect(Scope::all())->keys()->toArray(),

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -21,7 +21,10 @@ class ClientTableSeeder extends Seeder
             'description' => 'This is an example OAuth client seeded with your local Northstar installation. It was automatically given all scopes that were defined when it was created.',
             'client_id' => 'trusted-test-client',
             'client_secret' => 'secret1',
-            'redirect_uri' => 'http://northstar.dev:8000',
+            'redirect_uri' => [
+                'http://northstar.dev:8000',
+                'http://dev.dosomething.org:8888/openid-connect/generic',
+            ],
             'allowed_grants' => ['authorization_code', 'password', 'client_credentials'],
             'scope' => collect(Scope::all())->keys()->toArray(),
         ]);

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -17,6 +17,7 @@ Endpoint                  | Functionality                                       
 `POST v2/auth/token`      | [Create Auth Token (Client Credentials Grant)](endpoints/auth.md#create-token-client-credentials-grant) | 
 `POST v2/auth/token`      | [Create Auth Token (Refresh Token Grant)](endpoints/auth.md#create-token-refresh-token-grant) | 
 `DELETE v2/auth/token`    | [Invalidate Auth Token](endpoints/auth.md#revoke-token) | 
+`GET v2/auth/info`        | [Get User Info](endpoints/auth.md#get-user-info) | 
 
 > :memo: There's also the [legacy authentication endpoints](endpoints/legacy/auth.md), but those are deprecated so don't get too attached!
 

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -293,3 +293,44 @@ curl -X DELETE \
   }
 }
 ```
+
+## Get User Info
+
+This will display the user's profile according to the format [defined in the OpenID Connect specification](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo).
+
+```
+GET /v2/auth/info
+```
+
+**Example Request:**
+```sh
+curl -X GET \
+  -H "Authorization: ${ACCESS_TOKEN}" \
+  -H "Accept: application/json"
+  https://northstar.dosomething.org/v2/auth/info
+```
+
+**Example Response:**
+
+```js
+// 200 OK
+
+{
+  "data": {
+    "id": "57dac28fbffebcb7708b4567",
+    "given_name": "Ezra",
+    "family_name": null,
+    "email": "test@dosomething.org",
+    "phone_number": "3294927429",
+    "address": {
+      "street_address": "518 Lorenza Creek Suite 862\n",
+      "locality": null,
+      "region": "AL",
+      "postal_code": "04296",
+      "country": "SY"
+    },
+    "updated_at": 1473954542,
+    "created_at": 1473954447
+  }
+}
+```

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -337,6 +337,45 @@ class OAuthTest extends TestCase
     }
 
     /**
+     * Test that the user info route requires an access token.
+     */
+    public function testUserInfoAnonymous()
+    {
+        $this->json('GET', 'v2/auth/info');
+        $this->assertResponseStatus(401);
+    }
+
+    /**
+     * Test that an authenticated user can see their profile data, formatted
+     * according to the OpenID Connect spec.
+     */
+    public function testUserInfo()
+    {
+        $this->asNormalUser()->json('GET', 'v2/auth/info');
+        $this->assertResponseStatus(200);
+
+        $this->seeJsonStructure([
+            'data' => [
+                'given_name',
+                'family_name',
+                'email',
+                'phone_number',
+
+                'address' => [
+                    'street_address',
+                    'locality',
+                    'region',
+                    'postal_code',
+                    'country',
+                ],
+
+                'updated_at',
+                'created_at',
+            ],
+        ]);
+    }
+
+    /**
      * Test that a refresh token can be revoked.
      */
     public function testRevokeRefreshToken()


### PR DESCRIPTION
#### What's this PR do?
This PR adds some things for testing OpenID Connect in Phoenix:

🔍 Adds some new scopes (just as placeholders for now).

♻️ Whitelists the local Phoenix redirect URI in the default test client.

📖 Adds a ["user info" endpoint](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo) so that Phoenix can fetch a user's profile info according to the spec.

References DoSomething/phoenix#7046.

#### How should this be reviewed?
🚥 👀 ✏️ 

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.

---
For review: @weerd