### PR TITLE
Allow specifying a redirect to go to after logout.

### DIFF
--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -40,7 +40,7 @@ class WebController extends BaseController
         $this->auth = $auth;
         $this->registrar = $registrar;
 
-        $this->middleware('auth:web', ['only' => ['home', 'getLogout']]);
+        $this->middleware('auth:web', ['only' => ['home']]);
         $this->middleware('guest:web', ['except' => ['home', 'getLogout']]);
     }
 
@@ -91,13 +91,17 @@ class WebController extends BaseController
      * Log a user out from Northstar, preventing one-click
      * sign-ons to other DoSomething.org websites.
      *
+     * @param Request $request
      * @return \Illuminate\Http\Response
      */
-    public function getLogout()
+    public function getLogout(Request $request)
     {
+        // A custom post-logout redirect can be specified with `/logout?redirect=`
+        $redirect = $request->query('redirect', 'login');
+
         $this->auth->guard('web')->logout();
 
-        return redirect('login');
+        return redirect($redirect);
     }
 
     /**

--- a/tests/WebTest.php
+++ b/tests/WebTest.php
@@ -78,7 +78,22 @@ class WebTest extends TestCase
         $this->get('logout')->followRedirects();
         $this->see('Log in to get started!');
 
-        $this->assertEquals(false, auth()->check());
+        $this->dontSeeIsAuthenticated('web');
+    }
+
+    /**
+     * Test that we can specify a custom post-logout redirect.
+     */
+    public function testLogoutRedirect()
+    {
+        $user = factory(User::class)->create();
+        $this->be($user, 'web');
+
+        $this->get('logout?redirect=http://dev.dosomething.org:8888');
+
+        $this->dontSeeIsAuthenticated('web');
+        $this->assertResponseStatus(302);
+        $this->seeHeader('Location', 'http://dev.dosomething.org:8888');
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This PR allows an optional "redirect" override. This allows us to log out of a Northstar single sign-on session from Phoenix, but still be redirected back to the Phoenix homepage as expected.

#### How should this be reviewed?
🚪

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @angaither @weerd
