### PR TITLE
Don't report validation exceptions as app errors.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -30,6 +30,7 @@ class Handler extends ExceptionHandler
         OAuthServerException::class,
         ModelNotFoundException::class,
         ValidationException::class,
+        NorthstarValidationException::class,
         LegacyValidationException::class,
     ];
 


### PR DESCRIPTION
#### What's this PR do?
We didn't exclude `NorthstarValidationException`s from being reported to New Relic, so it'd cause alerting to go off. Now Northstar should be much more _chill_. ❄️

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @weerd 
/cc @mshmsh5000 

