### PR TITLE
Remove the redirect_uri specified in the client seeder.

### DIFF
--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -21,10 +21,6 @@ class ClientTableSeeder extends Seeder
             'description' => 'This is an example OAuth client seeded with your local Northstar installation. It was automatically given all scopes that were defined when it was created.',
             'client_id' => 'trusted-test-client',
             'client_secret' => 'secret1',
-            'redirect_uri' => [
-                'http://northstar.dev:8000',
-                'http://dev.dosomething.org:8888/openid-connect/northstar',
-            ],
             'allowed_grants' => ['authorization_code', 'password', 'client_credentials'],
             'scope' => collect(Scope::all())->keys()->toArray(),
         ]);


### PR DESCRIPTION
#### What's this PR do?
This PR removes the `redirect_uri` from the seeded client.

#### How should this be reviewed?
👀   @DFurnes Can't remember if this was something only I needed to do, or if it's something we decided was needed to be changed.

---
For review: @DFurnes 

