### PR TITLE
Login tweaks

### DIFF
--- a/app/Auth/Entities/ClientEntity.php
+++ b/app/Auth/Entities/ClientEntity.php
@@ -21,7 +21,9 @@ class ClientEntity implements ClientEntityInterface
      * Make a new OAuth Client entity.
      *
      * @param $client_id
+     * @param $client_name
      * @param $scopes
+     * @param $redirect_uri
      */
     public function __construct($client_id, $client_name, $scopes, $redirect_uri = '')
     {

--- a/app/Auth/Entities/ClientEntity.php
+++ b/app/Auth/Entities/ClientEntity.php
@@ -5,6 +5,7 @@ namespace Northstar\Auth\Entities;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Traits\ClientTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use Northstar\Models\Client;
 
 class ClientEntity implements ClientEntityInterface
 {
@@ -22,12 +23,23 @@ class ClientEntity implements ClientEntityInterface
      * @param $client_id
      * @param $scopes
      */
-    public function __construct($client_id, $scopes, $redirect_uri = '')
+    public function __construct($client_id, $client_name, $scopes, $redirect_uri = '')
     {
-        $this->name = $client_id; // @TODO: If we store a human-readable client name, use here.
-        $this->allowedScopes = $scopes;
         $this->identifier = $client_id;
+        $this->name = $client_name;
+        $this->allowedScopes = $scopes;
         $this->redirectUri = $redirect_uri;
+    }
+
+    /**
+     * Make a new ClientEntity from an Eloquent model.
+     *
+     * @param Client $client
+     * @return ClientEntity
+     */
+    public static function fromModel(Client $client)
+    {
+        return new self($client->client_id, $client->title, $client->scope, $client->redirect_uri);
     }
 
     /**

--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -21,8 +21,9 @@ class ClientRepository implements ClientRepositoryInterface
      */
     public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $mustValidateSecret = true)
     {
-        // Fetch client from the database.
+        /** @var \Northstar\Models\Client $model */
         $model = Client::where('client_id', $clientIdentifier)->first();
+
         if (! $model) {
             return null;
         }
@@ -37,7 +38,7 @@ class ClientRepository implements ClientRepositoryInterface
             return null;
         }
 
-        return new ClientEntity($model->client_id, $model->scope, $model->redirect_uri);
+        return ClientEntity::fromModel($model);
     }
 
     /**

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -64,8 +64,12 @@ class OAuthController extends Controller
     {
         // Validate the HTTP request and return an AuthorizationRequest.
         $authRequest = $this->oauth->validateAuthorizationRequest($request);
+        $client = $authRequest->getClient();
 
         if (! $this->auth->guard('web')->check()) {
+            $destination = request()->query('destination', $client->getName());
+            session(['destination' => $destination]);
+
             return redirect()->guest('login');
         }
 

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -49,7 +49,6 @@ class OAuthController extends Controller
         $this->auth = $auth;
         $this->encrypter = $encrypter;
 
-        $this->middleware('auth:web', ['only' => 'authorize']);
         $this->middleware('auth:api', ['only' => ['info', 'invalidateToken']]);
     }
 
@@ -65,6 +64,10 @@ class OAuthController extends Controller
     {
         // Validate the HTTP request and return an AuthorizationRequest.
         $authRequest = $this->oauth->validateAuthorizationRequest($request);
+
+        if (! $this->auth->guard('web')->check()) {
+            return redirect()->guest('login');
+        }
 
         $entity = new UserEntity();
         $userId = $this->auth->guard('web')->user()->getAuthIdentifier();

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -84,6 +84,9 @@ class WebController extends BaseController
                 ->withErrors(['username' => 'These credentials do not match our records.']);
         }
 
+        // If we had stored a destination name, reset it.
+        session()->pull('destination');
+
         return redirect()->intended('/');
     }
 

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -6,8 +6,11 @@ namespace Northstar\Models;
  * The Client model. These identify the "client application" making
  * a request, and their maximum allowed scopes.
  *
- * @property string client_id
- * @property string client_secret
+ * @property string $title
+ * @property string $description
+ * @property string $client_id
+ * @property string $client_secret
+ * @property string $redirect_uri
  * @property array $scope
  */
 class Client extends Model

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -24,6 +24,7 @@ Redirect the user to Northstar's "authorize" page with the following query strin
 
 * `response_type` with the value `code`
 * `client_id` with your Client ID
+* `destination` with a destination to display on the login page (optional)
 * `scope` with a space-delimited list of scopes to request
 * `state` with a CSRF token that can be validated below
 

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -30,9 +30,9 @@ body, html {
 .container .container__block {
   &.-centered {
     @include media($tablet) {
-      @include span(9 of 12);
-      @include push(2);
-
+      float: none;
+      max-width: 600px;
+      margin: $base-spacing auto;
       text-align: center;
 
       // @TODO: Hacky!

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -6,7 +6,8 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -centered">
-                <h1>Log in to get started!</h1>
+                <h1>Let's do this!</h1>
+                <h3>Log in to continue to {{ session('destination', 'DoSomething.org') }}.</h3>
             </div>
             <div class="container__block -centered">
                 @if (count($errors) > 0)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -122,7 +122,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function asUser($user, $scopes = [])
     {
         $accessToken = new AccessTokenEntity();
-        $accessToken->setClient(new ClientEntity('phpunit', $scopes));
+        $accessToken->setClient(new ClientEntity('phpunit', 'PHPUnit', $scopes));
         $accessToken->setIdentifier(bin2hex(random_bytes(40)));
         $accessToken->setExpiryDateTime((new \DateTime())->add(new DateInterval('PT1H')));
 

--- a/tests/WebTest.php
+++ b/tests/WebTest.php
@@ -75,8 +75,8 @@ class WebTest extends TestCase
         $this->be($user, 'web');
 
         $this->get('logout')->followRedirects();
-        $this->see('Log in to get started!');
 
+        $this->seePageIs('login');
         $this->dontSeeIsAuthenticated('web');
     }
 


### PR DESCRIPTION
#### What's this PR do?
This PR includes some improvements to the login flow & general tidiness:

📄 Adds missing `Client` fields to the class's docblock for syntax highlighting goodness.

🔒 Checks authentication for the `/authorize` endpoint via the guard. This allows us to redirect to the login page after we have already figured out the client information for the request.

💻 Adds the human-readable client name to the `ClientEntity`, and adds a `ClientEntity::fromModel` static method that creates a new entity from the corresponding Eloquent model.

🎨 Makes the `.-centered` container fixed-width (just like our modals are), since otherwise the container seemed either a bit too big or a bit too small at either extreme.

🎨 Adds the destination (by default, client name but can be customized with `?destination=...`) to the heading "Log in to continue to ___" when making authorization requests:

![screen shot 2016-09-29 at 4 23 40 pm](https://cloud.githubusercontent.com/assets/583202/18970893/1a39ecea-8661-11e6-9cd6-507217bd205e.png)

#### How should this be reviewed?
👀

#### Checklist
- [x] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.

---
For review: @weerd @angaither 