### PR TITLE
Always report API errors as JSON.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -73,8 +73,9 @@ class Handler extends ExceptionHandler
             $e = new NotFoundHttpException('That resource could not be found.');
         }
 
-        // If client requests it, render exception as JSON object
-        if ($request->ajax() || $request->wantsJson()) {
+        // If route is in the `api` group, render exception as JSON object.
+        $middleware = app('router')->getCurrentRoute()->middleware();
+        if (in_array('api', $middleware)) {
             return $this->buildJsonResponse($e);
         }
 


### PR DESCRIPTION
#### What's this PR do?
This updates Northstar's exception handler to always report errors on API routes as JSON. This fixes a UX issue where "expected" errors would show up as a "Whoops!" message in the browser and it would look like things were 💥 broken 💥.

#### How should this be reviewed?
Tests should all still pass.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd