### PR TITLE
Don't explode when handling non-HTTP exceptions.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -73,10 +73,10 @@ class Handler extends ExceptionHandler
             $e = new NotFoundHttpException('That resource could not be found.');
         }
 
-        // If route has 'Accepts: application/json' header or is in the `api`
-        // middleware group, render the exception as JSON object.
-        $middleware = app('router')->getCurrentRoute()->middleware();
-        $isApiRoute = in_array('api', $middleware);
+        // If request has 'Accepts: application/json' header or we're on a route that
+        // is in the `api` middleware group, render the exception as JSON object.
+        $currentRoute = app('router')->getCurrentRoute();
+        $isApiRoute = $currentRoute && in_array('api', $currentRoute->middleware());
         if ($request->ajax() || $request->wantsJson() || $isApiRoute) {
             return $this->buildJsonResponse($e);
         }


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes a wee little error (#454). The problem was that the Router's `getCurrentRoute()` method returns null if not on a route, so you can't always just chain `->middleware()` on the result. This just adds a check that `$currentRoute` is not null first.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd 
