### PR TITLE
Fixes errors in Drupal cleanup command.

### DIFF
--- a/app/Console/Commands/CleanDrupalIdsCommand.php
+++ b/app/Console/Commands/CleanDrupalIdsCommand.php
@@ -58,12 +58,11 @@ class CleanDrupalIdsCommand extends Command
             ]);
         });
 
-        $app = $this;
-        $blanks->each(function ($this) use (&$app) {
-            $app->info('Found '.$this['count'].' duplicates for '.$this['_id']['drupal_id'].' ('.config('services.drupal.url').'/user/'.$this['_id']['drupal_id'].'):');
+        foreach ($blanks as $result) {
+            $this->info('Found '.$result['count'].' duplicates for '.$result['_id']['drupal_id'].' ('.config('services.drupal.url').'/user/'.$result['_id']['drupal_id'].'):');
 
             // Load each duplicated user model, sort them by their created_at, and reset keys.
-            $users = User::findMany($this['uniqueIds']->bsonSerialize())
+            $users = User::findMany($result['uniqueIds']->bsonSerialize())
               ->sortBy('created_at')->values();
 
             $users->each(function ($user, $index) {
@@ -101,7 +100,7 @@ class CleanDrupalIdsCommand extends Command
                 $this->comment($verb.' duplicate: '.$aurora.'/users/'.$user->id.' ('.$user->email.' / '.$user->first_name.')');
             });
 
-            $app->line('');
-        });
+            $this->line('');
+        }
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Fixes #461. This prevents an exception from being thrown in our test suite (caused by trying to pass `$this` as a renamed variable pointer). These were failing on my local PHP 7 vagrant box, but weren't caught on Wercker builds since we're still running PHP 5.6 there.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd 