### PR TITLE
Cleanup and fixes

### DIFF
--- a/resources/assets/patterns/_container.scss
+++ b/resources/assets/patterns/_container.scss
@@ -14,11 +14,11 @@
       box-shadow: $soft-box-shadow;
       max-width: $container-max-width;
       margin: $section-spacing auto;
-    }
 
-    > .wrapper {
-      margin-left: 0;
-      width: 100%;
+      > .wrapper {
+        margin-left: 0;
+        width: 100%;
+      }
     }
 
     .navigation + & {

--- a/resources/assets/patterns/_container.scss
+++ b/resources/assets/patterns/_container.scss
@@ -1,7 +1,7 @@
 // @TODO: incorporate into the Container pattern in Forge!
 
 .container {
-  // @TODO: patternize in Forge?
+  // @TODO: patternize in Forge
   &.-framed {
     background-color: $white;
     margin-top: $base-spacing;
@@ -14,6 +14,11 @@
       box-shadow: $soft-box-shadow;
       max-width: $container-max-width;
       margin: $section-spacing auto;
+    }
+
+    > .wrapper {
+      margin-left: 0;
+      width: 100%;
     }
 
     .navigation + & {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -24,7 +24,7 @@
 
             <div class="form-item">
                 <label for="username" class="field-label">Email address or cell number</label>
-                <input name="username" type="text" class="text-field" placeholder="puppet-sloth@example.org" value="{{ old('username') }}">
+                <input name="username" type="text" class="text-field" placeholder="puppet-sloth@example.org" value="{{ old('username') }}" autofocus>
             </div>
 
             <div class="form-item">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -23,7 +23,7 @@
 
             <div class="form-item">
                 <label for="first_name" class="field-label">First Name</label>
-                <input name="first_name" type="text" class="text-field" placeholder="What do we call you?"value="{{ old('first_name') }}">
+                <input name="first_name" type="text" class="text-field" placeholder="What do we call you?"value="{{ old('first_name') }}" autofocus>
             </div>
 
             <div class="form-item">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -3,48 +3,38 @@
 @section('title', 'Profile | DoSomething.org')
 
 @section('content')
-    <main role="main">
-        <article class="profile">
-        <section class="container">
-                <div class="wrapper">
+    <div class="container__block -centered">
+        <figure class="figure -medium">
+            <div class="figure__media">
+                <img class="avatar" alt="avatar" src="{{ $user->avatar or asset('avatar-placeholder.png') }}" />
+            </div>
+            <div class="figure__body">
+                You are logged in as <strong>{{ $user->displayName() }}</strong>.
+            </div>
+        </figure>
+    </div>
 
-                    <div class="container__block -centered">
-                        <figure class="figure -medium">
-                            <div class="figure__media">
-                                <img class="avatar" alt="avatar" src="{{ $user->avatar or asset('avatar-placeholder.png') }}" />
-                            </div>
-                            <div class="figure__body">
-                                You are logged in as <strong>{{ $user->displayName() }}</strong>.
-                            </div>
-                        </figure>
-                    </div>
-
-                    <div class="container__block -narrow">
-                        <div class="key-value">
-                            {{-- @TODO: Might want to handle null values a little better so empty <dd>'s and <p>'s don't output  --}}
-                            <dt>First Name:</dt>
-                            <dd>{{ $user->first_name }}</dd>
-                            <dt>Last Name:</dt>
-                            <dd>{{ $user->last_name }}</dd>
-                            <dt>Email:</dt>
-                            <dd>{{ $user->email }}</dd>
-                            <dt>Mobile:</dt>
-                            <dd>{{ $user->mobile }}</dd>
-                            <dt>Address:</dt>
-                            <dd>
-                                <p>{{ $user->addr_street1 }}</p>
-                                <p>{{ $user->addr_street2 }}</p>
-                                <p>{{ $user->addr_city }}</p>
-                                <p>{{ $user->addr_state }}</p>
-                                <p>{{ $user->addr_zip }}</p>
-                            </dd>
-                            <dt>Country:</dt>
-                            <dd>{{ $user->country }}</dd>
-                        </div>
-                    </div>
-
-                </div>
-            </section>
-        </article>
-    </main>
+    <div class="container__block">
+        <div class="key-value">
+            {{-- @TODO: Might want to handle null values a little better so empty <dd>'s and <p>'s don't output  --}}
+            <dt>First Name:</dt>
+            <dd>{{ $user->first_name }}</dd>
+            <dt>Last Name:</dt>
+            <dd>{{ $user->last_name }}</dd>
+            <dt>Email:</dt>
+            <dd>{{ $user->email }}</dd>
+            <dt>Mobile:</dt>
+            <dd>{{ $user->mobile }}</dd>
+            <dt>Address:</dt>
+            <dd>
+                <p>{{ $user->addr_street1 }}</p>
+                <p>{{ $user->addr_street2 }}</p>
+                <p>{{ $user->addr_city }}</p>
+                <p>{{ $user->addr_state }}</p>
+                <p>{{ $user->addr_zip }}</p>
+            </dd>
+            <dt>Country:</dt>
+            <dd>{{ $user->country }}</dd>
+        </div>
+    </div>
 @stop


### PR DESCRIPTION
#### What's this PR do?
This PR does a quick fix to the `.container > .wrapper` to override the default styles which force it to a 75% width and large left margin. However, for the context of the `.-framed` modifier, this is not needed and needs to be overridden to help expand the content to fit the framed container properly. This override was intended for #463 but ended up getting accidentally removed.

It also, does a bit of tweaking and cleanup for the show profile view.

#### How should this be reviewed?
👁 

---
@DFurnes 
