### PR TITLE
Redirect to Phoenix after resetting password.

### DIFF
--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -18,13 +18,6 @@ class PasswordController extends BaseController
     protected $guard = 'web';
 
     /**
-     * The path to redirect to after a successful reset.
-     *
-     * @var string
-     */
-    protected $redirectTo = '/';
-
-    /**
      * Reset the given user's password.
      *
      * @param  \Northstar\Models\User  $user
@@ -42,5 +35,15 @@ class PasswordController extends BaseController
 
         // And create a Northstar session for the user.
         auth()->guard($this->getGuard())->login($user);
+    }
+
+    /**
+     * Get the path to redirect to after resetting a password.
+     *
+     * @return string
+     */
+    public function redirectPath()
+    {
+        return config('services.drupal.url').'/user/authorize';
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -41,7 +41,7 @@
     <div class="container__block -centered">
         <ul>
             <li><a href="{{ url('register') }}">Create a DoSomething.org account</a></li>
-            <li><a href="{{ url(config('services.drupal.url').'/user/password') }}">Forgot your password?</a></li>
+            <li><a href="{{ url('password/reset') }}">Forgot your password?</a></li>
         </ul>
     </div>
 @stop

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -39,14 +39,14 @@ class PasswordResetTest extends TestCase
 
         // The user should visit the link that was sent via email & set a new password.
         $this->visit('/password/reset/'.$token.'?email='.$user->email);
-        $this->submitForm('Reset Password', [
+        $this->postForm('Reset Password', [
             'password' => 'top_secret',
             'password_confirmation' => 'top_secret',
         ]);
 
-        // The user should be logged-in and see the confirmation message.
-        $this->see('Your password has been reset!');
+        // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
         $this->seeIsAuthenticatedAs($user, 'web');
+        $this->assertRedirectedTo('http://dev.dosomething.org:8888/user/authorize');
 
         // And their account should be updated with their new password.
         $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -213,4 +213,21 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 
         return $mock;
     }
+
+    /**
+     * Submit a form on the page without crawling the returned page. Useful for
+     * when a form results in an external redirect that'd break test crawler.
+     *
+     * @param  string  $buttonText
+     * @param  array  $inputs
+     * @return $this
+     */
+    public function postForm($buttonText, array $inputs = [])
+    {
+        $form = $this->fillForm($buttonText, $inputs);
+
+        $this->call($form->getMethod(), $form->getUri(), $this->extractParametersFromForm($form));
+
+        return $this;
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
To match the current user flow, we want to redirect users to Phoenix's homepage after successfully resetting their password. This is accomplished by initiating Phoenix's authorization flow via the `user/authorize` endpoint over there.

#### How should this be reviewed?
This relies on the change made in DoSomething/phoenix#7168 to prevent a fatal exception if a user was already logged in to Drupal when arriving at the `user/authorize` redirect.

Would appreciate a sanity-check that this is an okay approach. ✌️

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd @angaither