### PR TITLE
More cleanup.

### DIFF
--- a/app/Auth/Entities/UserEntity.php
+++ b/app/Auth/Entities/UserEntity.php
@@ -4,8 +4,23 @@ namespace Northstar\Auth\Entities;
 
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class UserEntity implements UserEntityInterface
 {
     use EntityTrait;
+
+    /**
+     * Make a new UserEntity from an Eloquent model.
+     *
+     * @param Authenticatable $user
+     * @return self
+     */
+    public static function fromModel(Authenticatable $user)
+    {
+        $entity = new UserEntity();
+        $entity->setIdentifier($user->getAuthIdentifier());
+
+        return $entity;
+    }
 }

--- a/app/Auth/Entities/UserEntity.php
+++ b/app/Auth/Entities/UserEntity.php
@@ -18,7 +18,7 @@ class UserEntity implements UserEntityInterface
      */
     public static function fromModel(Authenticatable $user)
     {
-        $entity = new UserEntity();
+        $entity = new self();
         $entity->setIdentifier($user->getAuthIdentifier());
 
         return $entity;

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -4,6 +4,10 @@ namespace Northstar\Http\Controllers;
 
 class KeyController extends Controller
 {
+    /**
+     * Make a new KeyController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
     public function __construct()
     {
         $this->middleware('role:admin');

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Northstar\Auth\Encrypter;
-use Northstar\Auth\Entities\UserEntity;
 use Northstar\Http\Transformers\UserInfoTransformer;
 use Northstar\Models\RefreshToken;
 use Psr\Http\Message\ResponseInterface;

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -2,8 +2,9 @@
 
 namespace Northstar\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Http\Request;
+use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Northstar\Auth\Encrypter;
 use Northstar\Auth\Entities\UserEntity;
@@ -11,7 +12,6 @@ use Northstar\Http\Transformers\UserInfoTransformer;
 use Northstar\Models\RefreshToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use League\OAuth2\Server\AuthorizationServer;
 
 class OAuthController extends Controller
 {
@@ -50,40 +50,6 @@ class OAuthController extends Controller
         $this->encrypter = $encrypter;
 
         $this->middleware('auth:api', ['only' => ['info', 'invalidateToken']]);
-    }
-
-    /**
-     * Show the login form for authenticating a user using one of the
-     * authentication code grant.
-     *
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface $response
-     * @return ResponseInterface|\Illuminate\Http\RedirectResponse
-     */
-    public function authorize(ServerRequestInterface $request, ResponseInterface $response)
-    {
-        // Validate the HTTP request and return an AuthorizationRequest.
-        $authRequest = $this->oauth->validateAuthorizationRequest($request);
-        $client = $authRequest->getClient();
-
-        if (! $this->auth->guard('web')->check()) {
-            $destination = request()->query('destination', $client->getName());
-            session(['destination' => $destination]);
-
-            return redirect()->guest('login');
-        }
-
-        $entity = new UserEntity();
-        $userId = $this->auth->guard('web')->user()->getAuthIdentifier();
-        $entity->setIdentifier($userId);
-        $authRequest->setUser($entity);
-
-        // Clients are all our own at the moment, so they will always be approved.
-        // @TODO: Add an explicit "DoSomething.org app" boolean to the Client model.
-        $authRequest->setAuthorizationApproved(true);
-
-        // Return the HTTP redirect response.
-        return $this->oauth->completeAuthorizationRequest($authRequest, $response);
     }
 
     /**

--- a/app/Http/Controllers/ScopeController.php
+++ b/app/Http/Controllers/ScopeController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+use Northstar\Auth\Scope;
+
+class ScopeController extends Controller
+{
+    /**
+     * Make a new ScopeController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
+    public function __construct()
+    {
+        // ...
+    }
+
+    /**
+     * Return the list of available scopes.
+     * GET /key
+     *
+     * @return array
+     */
+    public function index()
+    {
+        return Scope::all();
+    }
+}

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace Northstar\Http\Controllers\Web;
 
+use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Contracts\Auth\Factory as Auth;
 use Northstar\Auth\Registrar;
 use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Models\User;
 
-class WebController extends BaseController
+class AuthController extends BaseController
 {
     use ValidatesRequests;
 
@@ -32,7 +32,7 @@ class WebController extends BaseController
      * Make a new WebController, inject dependencies,
      * and set middleware for this controller's methods.
      *
-     * @param \Illuminate\Contracts\Auth\Factory $auth
+     * @param Auth $auth
      * @param Registrar $registrar
      */
     public function __construct(Auth $auth, Registrar $registrar)

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -6,13 +6,24 @@ use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use League\OAuth2\Server\AuthorizationServer;
+use Northstar\Auth\Entities\UserEntity;
 use Northstar\Auth\Registrar;
 use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Models\User;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class AuthController extends BaseController
 {
     use ValidatesRequests;
+
+    /**
+     * The OAuth authorization server.
+     *
+     * @var AuthorizationServer
+     */
+    protected $oauth;
 
     /**
      * The authentication factory.
@@ -34,13 +45,46 @@ class AuthController extends BaseController
      *
      * @param Auth $auth
      * @param Registrar $registrar
+     * @param AuthorizationServer $oauth
      */
-    public function __construct(Auth $auth, Registrar $registrar)
+    public function __construct(Auth $auth, Registrar $registrar, AuthorizationServer $oauth)
     {
         $this->auth = $auth;
         $this->registrar = $registrar;
+        $this->oauth = $oauth;
 
         $this->middleware('guest:web', ['only' => ['getLogin', 'postLogin', 'getRegister', 'postRegister']]);
+    }
+
+    /**
+     * Authorize an application via OAuth 2.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface|\Illuminate\Http\RedirectResponse
+     */
+    public function authorize(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        // Validate the HTTP request and return an AuthorizationRequest.
+        $authRequest = $this->oauth->validateAuthorizationRequest($request);
+        $client = $authRequest->getClient();
+
+        if (! $this->auth->guard('web')->check()) {
+            $destination = request()->query('destination', $client->getName());
+            session(['destination' => $destination]);
+
+            return redirect()->guest('login');
+        }
+
+        $user = UserEntity::fromModel($this->auth->guard('web')->user());
+        $authRequest->setUser($user);
+
+        // Clients are all our own at the moment, so they will always be approved.
+        // @TODO: Add an explicit "DoSomething.org app" boolean to the Client model.
+        $authRequest->setAuthorizationApproved(true);
+
+        // Return the HTTP redirect response.
+        return $this->oauth->completeAuthorizationRequest($authRequest, $response);
     }
 
     /**

--- a/app/Http/Controllers/Web/PasswordController.php
+++ b/app/Http/Controllers/Web/PasswordController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace Northstar\Http\Controllers\Web;
 
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Routing\Controller as BaseController;

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -62,9 +62,7 @@ $router->group(['prefix' => 'v2', 'middleware' => ['api']], function () use ($ro
     $router->get('key', 'KeyController@show');
 
     // Scopes
-    $router->get('scopes', function () {
-        return \Northstar\Auth\Scope::all();
-    });
+    $router->get('scopes', 'ScopeController@index');
 });
 
 // API experience for https://northstar.dosomething.org/v1/

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -8,26 +8,22 @@
  */
 
 // Web Experience for https://northstar.dosomething.org/
+
 $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']], function () use ($router) {
     $router->get('/', 'UserController@home');
 
-    // @NOTE: disabling /index, /create, /delete for now.
-    $router->resource('users', 'UserController', ['except' => ['index', 'create', 'delete']]);
-});
-
-// @TODO: move these into above group, seperate into Web\AuthController.
-$router->group(['guard' => 'web', 'middleware' => ['web']], function () use ($router) {
     // Authorization flow for the Auth Code OAuth grant.
     $router->get('authorize', 'OAuthController@authorize');
+    $router->resource('users', 'UsersController', ['except' => ['index', 'create', 'delete']]);
 
     // Login & Logout
-    $router->get('login', 'WebController@getLogin');
-    $router->post('login', 'WebController@postLogin');
-    $router->get('logout', 'WebController@getLogout');
+    $router->get('login', 'AuthController@getLogin');
+    $router->post('login', 'AuthController@postLogin');
+    $router->get('logout', 'AuthController@getLogout');
 
     // Registration
-    $router->get('register', 'WebController@getRegister');
-    $router->post('register', 'WebController@postRegister');
+    $router->get('register', 'AuthController@getRegister');
+    $router->post('register', 'AuthController@postRegister');
 
     // Password Reset
     if (config('features.password-reset')) {
@@ -40,6 +36,11 @@ $router->group(['guard' => 'web', 'middleware' => ['web']], function () use ($ro
             return redirect(config('services.drupal.url').'/user/password');
         });
     }
+});
+
+$router->group(['guard' => 'web', 'middleware' => ['web']], function() use ($router) {
+    // Authorization flow for the Auth Code OAuth grant.
+    $router->get('authorize', 'OAuthController@authorize');
 });
 
 // API experience for https://nortstar.dosomething.org/v2/

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -16,6 +16,9 @@ $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']]
     $router->get('authorize', 'OAuthController@authorize');
     $router->resource('users', 'UsersController', ['except' => ['index', 'create', 'delete']]);
 
+    // Authorization flow for the Auth Code OAuth grant.
+    $router->get('authorize', 'AuthController@authorize');
+
     // Login & Logout
     $router->get('login', 'AuthController@getLogin');
     $router->post('login', 'AuthController@postLogin');
@@ -36,11 +39,6 @@ $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']]
             return redirect(config('services.drupal.url').'/user/password');
         });
     }
-});
-
-$router->group(['guard' => 'web', 'middleware' => ['web']], function() use ($router) {
-    // Authorization flow for the Auth Code OAuth grant.
-    $router->get('authorize', 'OAuthController@authorize');
 });
 
 // API experience for https://nortstar.dosomething.org/v2/

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -12,9 +12,8 @@
 $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']], function () use ($router) {
     $router->get('/', 'UserController@home');
 
-    // Authorization flow for the Auth Code OAuth grant.
-    $router->get('authorize', 'OAuthController@authorize');
-    $router->resource('users', 'UsersController', ['except' => ['index', 'create', 'delete']]);
+    // Users
+    $router->resource('users', 'UserController', ['except' => ['index', 'create', 'delete']]);
 
     // Authorization flow for the Auth Code OAuth grant.
     $router->get('authorize', 'AuthController@authorize');


### PR DESCRIPTION
#### What's this PR do?
More cleanup to wrap up the sprint.

📦 Renames `WebController` to `AuthController` because we've got other web routes now. Then moves it and `PasswordController` into `Web\` namespace alongside the `UserController` added in #469. (beb38d6)

🔒 Moves the `authorize/` route into web AuthController, since it will then get web middleware, and unprefixed route. (7f29b90)

🔭 Finally, a nice little bare-bones `ScopeController` for that one lonely closure route. (80ae9f0)

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …