### PR TITLE
Progressively cast birthdates.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -66,6 +66,7 @@ class Registrar
             'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id|required_without_all:email,facebook_id',
             'facebook_id' => 'numeric|unique:users,facebook_id,'.$existingId.',_id|required_without_all:email,mobile',
             'drupal_id' => 'unique:users,drupal_id,'.$existingId.',_id',
+            'birthdate' => 'date',
         ];
 
         // If a user is provided, merge it into the request so we can validate

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -35,7 +35,7 @@ class UserTransformer extends TransformerAbstract
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = $user->interests;
-            $response['birthdate'] = $user->birthdate;
+            $response['birthdate'] = $user->birthdate ? $user->birthdate->format('Y-m-d') : null;
 
             $response['addr_street1'] = $user->addr_street1;
             $response['addr_street2'] = $user->addr_street2;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -35,7 +35,7 @@ class UserTransformer extends TransformerAbstract
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = $user->interests;
-            $response['birthdate'] = $user->birthdate ? $user->birthdate->format('Y-m-d') : null;
+            $response['birthdate'] = format_date($user->birthdate, 'Y-m-d');
 
             $response['addr_street1'] = $user->addr_street1;
             $response['addr_street2'] = $user->addr_street2;

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -2,6 +2,8 @@
 
 namespace Northstar\Models;
 
+use Carbon\Carbon;
+use InvalidArgumentException;
 use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
 
 /**
@@ -31,5 +33,36 @@ class Model extends BaseModel
         }
 
         return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * Convert a DateTime to a string that can be
+     * stored in the database.
+     *
+     * @param  \DateTime|int  $value
+     * @return string
+     */
+    public function fromDateTime($value)
+    {
+        $format = $this->getDateFormat();
+
+        $value = $this->asDateTime($value);
+
+        return $value->format($format);
+    }
+
+    /**
+     * Return a timestamp as DateTime object.
+     *
+     * @param  mixed  $value
+     * @return \DateTime|Carbon
+     */
+    protected function asDateTime($value)
+    {
+        try {
+            return parent::asDateTime($value);
+        } catch (InvalidArgumentException $e) {
+            return Carbon::parse($value);
+        }
     }
 }

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -74,7 +74,8 @@ class Model extends BaseModel
      * @param $value
      * @return Carbon|null
      */
-    protected function asDateTimeFallback($value) {
+    protected function asDateTimeFallback($value)
+    {
         try {
             return Carbon::parse($value);
         } catch (Exception $e) {

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -3,6 +3,7 @@
 namespace Northstar\Models;
 
 use Carbon\Carbon;
+use Exception;
 use InvalidArgumentException;
 use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
 
@@ -62,7 +63,22 @@ class Model extends BaseModel
         try {
             return parent::asDateTime($value);
         } catch (InvalidArgumentException $e) {
+            return $this->asDateTimeFallback($value);
+        }
+    }
+
+    /**
+     * Fallback to try to parse poorly formatted date strings, or
+     * return `null` if it's hopeless.
+     *
+     * @param $value
+     * @return Carbon|null
+     */
+    protected function asDateTimeFallback($value) {
+        try {
             return Carbon::parse($value);
+        } catch (Exception $e) {
+            return null;
         }
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -140,13 +140,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
-     * Indicates if the model should be timestamped.
-     *
-     * @var bool
-     */
-    public $timestamps = true;
-
-    /**
      * Computed last initial field, for public profiles.
      *
      * @return string

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -136,15 +136,15 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     protected $casts = [
         'cgg_id' => 'integer',
+        'birthdate' => 'date',
     ];
 
     /**
-     * The attributes which should be stored as MongoDate objects.
-     * @see https://github.com/jenssegers/laravel-mongodb#dates
+     * Indicates if the model should be timestamped.
      *
-     * @var array
+     * @var bool
      */
-    protected $dates = ['created_at', 'updated_at', 'birthdate'];
+    public $timestamps = true;
 
     /**
      * Computed last initial field, for public profiles.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,7 +23,7 @@ use Northstar\Auth\Role;
  * @property string $drupal_password - Hashed password imported from Phoenix
  * @property string $first_name
  * @property string $last_name
- * @property string $birthdate
+ * @property Carbon $birthdate
  * @property string $photo
  * @property array  $interests
  * @property string $source
@@ -144,7 +144,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @var array
      */
-    protected $dates = ['created_at', 'updated_at'];
+    protected $dates = ['created_at', 'updated_at', 'birthdate'];
 
     /**
      * Computed last initial field, for public profiles.
@@ -166,16 +166,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setEmailAttribute($value)
     {
         $this->attributes['email'] = normalize('email', $value);
-    }
-
-    /**
-     * Mutator to format the birthdate as a date string with time.
-     *
-     * @param string $value
-     */
-    public function setBirthdateAttribute($value)
-    {
-        $this->attributes['birthdate'] = format_date($value, 'Y-m-d H:i:s');
     }
 
     /**
@@ -285,6 +275,21 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         }
 
         $this->attributes['password'] = bcrypt($value);
+    }
+
+    /**
+     * Return a timestamp as DateTime object.
+     *
+     * @param  mixed  $value
+     * @return \DateTime|Carbon
+     */
+    protected function asDateTime($value)
+    {
+        try {
+            return parent::asDateTime($value);
+        } catch (\Exception $e) {
+            return Carbon::parse($value);
+        }
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -278,21 +278,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Return a timestamp as DateTime object.
-     *
-     * @param  mixed  $value
-     * @return \DateTime|Carbon
-     */
-    protected function asDateTime($value)
-    {
-        try {
-            return parent::asDateTime($value);
-        } catch (\Exception $e) {
-            return Carbon::parse($value);
-        }
-    }
-
-    /**
      * Does this user have a password set?
      *
      * @return bool

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -33,7 +33,7 @@ function normalize($type = null, $value = null)
  * @param  string $date
  * @return string
  */
-function format_date($date, $format = 'Y-m-d')
+function format_date($date, $format = 'm/d/Y')
 {
     $date = new Carbon($date);
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -31,11 +31,16 @@ function normalize($type = null, $value = null)
  * Format a Carbon date if available to a specified format.
  *
  * @param  string $date
- * @return string
+ * @param string $format
+ * @return null|string
  */
-function format_date($date, $format = 'm/d/Y')
+function format_date($date, $format = 'M j, Y')
 {
-    $date = new Carbon($date);
+    try {
+        $date = new Carbon($date);
+    } catch (InvalidArgumentException $e) {
+        return null;
+    }
 
     return $date->format($format);
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -47,10 +47,9 @@
                 <input type="text" id="mobile" class="text-field" name="mobile" value="{{ old('mobile') ?: $user->mobile }}" />
             </div>
 
-            {{-- @TODO: deal w/ the date input formatting --}}
             <div class="form-item">
                 <label for="birthdate" class="field-label">Birthday</label>
-                <input type="date" id="birthdate" class="text-field" name="birthdate" value="{{ old('birthdate') ?: format_date($user->birthdate) }}" />
+                <input type="text" id="birthdate" class="text-field" name="birthdate" value="{{ old('birthdate') ?: format_date($user->birthdate, 'm/d/Y') }}" />
             </div>
 
             <div class="form-item">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -26,7 +26,7 @@
             <dt>Mobile:</dt>
             <dd>{{ $user->mobile }}</dd>
             <dt>Birthday:</dt>
-            <dd>{{ format_date($user->birthdate) }}</dd>
+            <dd>{{ $user->birthdate ? $user->birthdate->toFormattedDateString() : '' }}</dd>
             <dt>Address:</dt>
             <dd>
                 <p>{{ $user->addr_street1 }}</p>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -26,7 +26,7 @@
             <dt>Mobile:</dt>
             <dd>{{ $user->mobile }}</dd>
             <dt>Birthday:</dt>
-            <dd>{{ $user->birthdate ? $user->birthdate->toFormattedDateString() : '' }}</dd>
+            <dd>{{ format_date($user->birthdate) }}</dd>
             <dt>Address:</dt>
             <dd>
                 <p>{{ $user->addr_street1 }}</p>


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for "progressive casting" for the birthdate field - any new values will be stored as `'Y-m-d H:i:s'`, but existing values stored as plaintext (for example, we've got plenty of values stored `MM/DD/YYYY` in this field on production) will still be read correctly.

Fixes #407.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …