### PR TITLE
Allow upserting created_at only if earlier.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -115,6 +115,14 @@ class UserController extends Controller
         $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lt(new Carbon($created_at));
         if ($created_at && ! $existingUserHasEarlierCreatedTimestamp) {
             $user->created_at = $created_at;
+            $user->source = $request->input('source') ?: client_id();
+
+            $user->save();
+        }
+
+        // Only save a source if not upserting a user (unless back-filling, see above).
+        if ($request->has('source') && ! $existingUser) {
+            $user->source = $request->input('source');
             $user->save();
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
 use Northstar\Auth\Role;
@@ -109,8 +110,11 @@ class UserController extends Controller
         $user = $this->registrar->register($request->except('role'), $existingUser);
 
         // Optionally, allow setting a custom "created_at" (useful for back-filling from other services).
-        if ($request->has('created_at')) {
-            $user->created_at = $request->input('created_at');
+        // We'll only update this value on existing records if it's earlier than the existing timestamp.
+        $created_at = $request->input('created_at');
+        $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lt(new Carbon($created_at));
+        if ($created_at && ! $existingUserHasEarlierCreatedTimestamp) {
+            $user->created_at = $created_at;
             $user->save();
         }
 

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -69,7 +69,7 @@ class AuthController extends BaseController
         $authRequest = $this->oauth->validateAuthorizationRequest($request);
         $client = $authRequest->getClient();
 
-        // Store the Client ID so we can store it on registrations.
+        // Store the Client ID so we can set user source on registrations.
         session(['authorize_client_id' => request()->query('client_id')]);
 
         if (! $this->auth->guard('web')->check()) {

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -69,6 +69,9 @@ class AuthController extends BaseController
         $authRequest = $this->oauth->validateAuthorizationRequest($request);
         $client = $authRequest->getClient();
 
+        // Store the Client ID so we can store it on registrations.
+        session(['authorize_client_id' => request()->query('client_id')]);
+
         if (! $this->auth->guard('web')->check()) {
             $destination = request()->query('destination', $client->getName());
             session(['destination' => $destination]);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -83,7 +83,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip',
         'country', 'language',
 
-        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'source', 'facebook_id',
+        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'facebook_id',
 
         'parse_installation_ids',
     ];
@@ -182,23 +182,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setMobileAttribute($value)
     {
         $this->attributes['mobile'] = normalize('mobile', $value);
-    }
-
-    /**
-     * Mutator to make the `source` field immutable (e.g. once a user has been assigned
-     * a source, that value cannot be changed). This allows applications to always
-     * pass their own identifier in the user's source, without overwriting that value
-     * for existing users.
-     *
-     * @param string $value
-     */
-    public function setSourceAttribute($value)
-    {
-        if (! empty($this->attributes['source'])) {
-            return;
-        }
-
-        $this->attributes['source'] = $value;
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Northstar\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Northstar\Models\User;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        User::creating(function ($user) {
+            // Set source automatically if not provided.
+            $user->source = $user->source ?: client_id();
+        });
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -86,5 +86,6 @@ function client_id()
         return $client->client_id;
     }
 
-    return 'northstar';
+    // If not an API request, use Client ID from `/authorize` call or just 'northstar'.
+    return session('authorize_client_id', 'northstar');
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Northstar\Auth\Normalizer;
+use Northstar\Models\Client;
 
 /**
  * Normalize the given value.
@@ -64,4 +65,26 @@ function has_middleware($middleware = null)
     }
 
     return $currentRoute->middleware() ? true : false;
+}
+
+/**
+ * Get the name of the client executing the current request.
+ *
+ * @return string
+ */
+function client_id()
+{
+    $oauthClientId = request()->attributes->get('oauth_client_id');
+    if (! empty($oauthClientId)) {
+        return $oauthClientId;
+    }
+
+    // Otherwise, try to get the client from the legacy X-DS-REST-API-Key header.
+    $client_secret = request()->header('X-DS-REST-API-Key');
+    $client = Client::where('client_secret', $client_secret)->first();
+    if ($client) {
+        return $client->client_id;
+    }
+
+    return 'northstar';
 }

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -147,7 +147,7 @@ Either a mobile number or email is required.
   drupal_id: String
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
-  source: String // Immutable (can only be set if existing value is `null`)
+  source: String // Will only be set on new records, or if being provided an earlier `created_at`. 
 
   // Hidden fields (optional):
   race: String
@@ -297,7 +297,6 @@ PUT /v1/users/drupal_id/<drupal_id>
   drupal_id: String
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
-  source: String // Immutable (can only be set if existing value is `null`)
   role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
 
   // Hidden fields (optional):

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Northstar\Models\Client;
+
 class HelpersTest extends TestCase
 {
     /** @test */
     public function testRouteHasAttachedMiddleware()
     {
-        $request = $this->get('/login');
+        $this->get('/login');
 
         // It should be able to check if in a middleware group.
         $this->assertTrue(has_middleware('web'));
@@ -13,5 +15,29 @@ class HelpersTest extends TestCase
 
         // ...or just if it has any middleware at all!
         $this->assertTrue(has_middleware());
+    }
+
+    /** @test */
+    public function testGetClientId()
+    {
+        // Web requests should report as 'northstar'.
+        $this->get('/register');
+        $this->assertEquals(client_id(), 'northstar');
+
+        // Make a request using legacy API header.
+        $client = Client::create(['client_id' => 'legacy_client', 'scope' => 'user']);
+        $this->withLegacyApiKey($client)->json('POST', '/v1/auth/register', [
+            'email' => $this->faker->safeEmail,
+            'password' => $this->faker->password,
+        ]);
+        $this->assertEquals(client_id(), 'legacy_client');
+
+
+        // And make a request using OAuth.
+        $this->asNormalUser()->json('POST', '/v1/auth/register', [
+            'email' => $this->faker->safeEmail,
+            'password' => $this->faker->password,
+        ]);
+        $this->assertEquals(client_id(), 'phpunit');
     }
 }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -215,7 +215,7 @@ class UserTest extends TestCase
 
     /**
      * Test that an admin can update a user's profile, including their role.
-     * GET /users/:term/:id
+     * POST /v1/users/
      *
      * @return void
      */
@@ -231,6 +231,33 @@ class UserTest extends TestCase
             'data' => [
                 'last_name' => '└(^o^)┘',
                 'last_initial' => '└',
+            ],
+        ]);
+    }
+
+    /**
+     * Test that we can only upsert created_at to be earlier.
+     * POST /v1/users/
+     *
+     * @return void
+     */
+    public function testUpsertCreatedAtField()
+    {
+        $user = factory(User::class)->create(['first_name' => 'Daisy', 'last_name' => 'Johnson']);
+
+        // We finally read Secret War #2, and want to update her 'created_at' date to match her first appearance.
+        $this->asAdminUser()->json('POST', 'v1/users', [
+            'email' => $user->email,
+            'first_name' => 'Daisy',
+            'created_at' => '7/1/2004', // first appearance!
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonSubset([
+            'data' => [
+                'email' => $user->email,
+                'first_name' => 'Daisy',
+                'created_at' => '2004-07-01T00:00:00+0000',
             ],
         ]);
     }

--- a/tests/LegacyHttp/AuthTest.php
+++ b/tests/LegacyHttp/AuthTest.php
@@ -277,9 +277,10 @@ class AuthTest extends TestCase
     {
         // Given an account that doesn't have a password (for example,
         // someone who voted in Celebs Gone Good).
-        $user = User::create([
+        $user = factory(User::class)->create([
             'email' => 'poe.dameron@resistance.org',
             'first_name' => 'Poe',
+            'password' => null,
             'source' => 'cgg',
         ]);
 

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -557,8 +557,9 @@ class LegacyUserTest extends TestCase
      */
     public function testUpsertUser()
     {
-        User::create([
+        factory(User::class)->create([
             'email' => 'upsert-me@dosomething.org',
+            'mobile' => null,  // <-- overriding factory so we can add it via upsert
             'source' => 'database',
         ]);
 
@@ -582,7 +583,7 @@ class LegacyUserTest extends TestCase
                 'first_name' => 'Puppet',
                 'mobile' => '5556667777',
 
-                // Ensure the `source` field is immutable (since we tried to update to 'phpunit'):
+                // Ensure the `source` field is immutable (since we did not provide an earlier creation date):
                 'source' => 'database',
 
                 // The role should *not* be changed by upsert (since that'd make it easily to accidentally grant!)


### PR DESCRIPTION
#### What's this PR do?
This pull request adds some conditional logic that allows the `created_at` field on a user to be updated, but only to be earlier than it already is. This will allow us to store the user's actual "registration date" when backfilling users who joined by first texting in via SMS, but were already backfilled by their linked Phoenix account.

This PR also refactors how source is set – a manual source can be provided when creating or backfilling a user via the `POST /v1/users` endpoint, but otherwise it is automatically set based on the active OAuth Client ID.

Fixes #470.
Fixes #321.

#### How should this be reviewed?
:eyes: and the included test case/documentation.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd @angaither 
