### PR TITLE
Keep user passwords from unintentionally updating

### DIFF
--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -85,7 +85,10 @@ class UserController extends BaseController
             'password' => 'min:6|confirmed',
         ]);
 
-        $user->fill($request->all())->save();
+        // Remove fields with empty values.
+        $values = array_diff($request->all(), ['']);
+
+        $user->fill($values)->save();
 
         return redirect()->route('users.show', $user->id);
     }


### PR DESCRIPTION
#### What's this PR do?
Currently, if a user views their profile and edits the information, even if they don't edit their password and submit the form, their password is still submitted as being updated as an empty string. When they logout, they are basically locked out 🔒  of their account, since their new password is an empty string and the validation on the login form does not allow entering an empty string as a password.

This PR runs the array of fields through a quick function that removes any items where the value is an empty field (implying it wasn't updated). This way, if a user doesn't edit their password, it is not changed.

Fixes #481

#### How should this be reviewed?
👁 

#### Checklist
- [ ] Tests added for new features/bug fixes.

---
For review: 
@DFurnes @angaither 

CC: @jessleenyc 

