### PR TITLE
Update to profile access.

### DIFF
--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Northstar\Auth\Registrar;
 use Northstar\Models\User;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class UserController extends BaseController
 {
@@ -64,6 +65,10 @@ class UserController extends BaseController
     {
         $user = User::findOrFail($id);
 
+        if (! $user->can('editProfile', [auth()->guard('web')->user(), $user])) {
+            throw new AccessDeniedHttpException;
+        }
+
         return view('users.edit', ['user' => $user]);
     }
 
@@ -77,6 +82,10 @@ class UserController extends BaseController
     public function update(Request $request, $id)
     {
         $user = User::findOrFail($id);
+
+        if (! $user->can('editProfile', [auth()->guard('web')->user(), $user])) {
+            throw new AccessDeniedHttpException;
+        }
 
         $this->registrar->validate($request, $user, [
             'first_name' => 'required',

--- a/tests/Http/Web/WebUserTest.php
+++ b/tests/Http/Web/WebUserTest.php
@@ -60,4 +60,17 @@ class WebUserTest extends TestCase
         $this->assertEquals('Jean-Paul', $updatedUser->first_name);
         $this->assertEquals('Beaubier', $updatedUser->last_name);
     }
+
+    /**
+     * Test that auth user can not access another user's profile.
+     */
+    public function testProfileEditAccess()
+    {
+        $authUser = $this->makeAuthWebUser();
+
+        $randoUser = factory(User::class)->create();
+
+        $this->visit('users/'.$randoUser->id.'/edit')
+             ->seePageIs('/');
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR ensures that the profile edit form and the process of updating a profile is only accessible to the authenticated user and their own information. If the authenticated user tries to access edit form or perform an update on a profile other than their own, they are sent back to their own profile view while an exception is thrown in the background.

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Tests added for new features/bug fixes.

---
For review:
@DFurnes @angaither 

