### PR TITLE
Accept Date as timestamp, rather than date string.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -112,7 +112,7 @@ class UserController extends Controller
         // Optionally, allow setting a custom "created_at" (useful for back-filling from other services).
         // We'll only update this value on existing records if it's earlier than the existing timestamp.
         $created_at = $request->input('created_at');
-        $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lt(new Carbon($created_at));
+        $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lt(Carbon::createFromTimestamp($created_at));
         if ($created_at && ! $existingUserHasEarlierCreatedTimestamp) {
             $user->created_at = $created_at;
             $user->source = $request->input('source') ?: client_id();

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -148,6 +148,7 @@ Either a mobile number or email is required.
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Will only be set on new records, or if being provided an earlier `created_at`. 
+  created_at: Number // timestamp
 
   // Hidden fields (optional):
   race: String

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -249,7 +249,7 @@ class UserTest extends TestCase
         $this->asAdminUser()->json('POST', 'v1/users', [
             'email' => $user->email,
             'first_name' => 'Daisy',
-            'created_at' => '7/1/2004', // first comic book appearance!
+            'created_at' => '1088640000', // first comic book appearance!
             'source' => 'comic',
         ]);
 
@@ -278,7 +278,7 @@ class UserTest extends TestCase
         // We don't allow time-travelling (setting your created_at date to be later).
         $this->asAdminUser()->json('POST', 'v1/users', [
             'email' => $user->email,
-            'created_at' => '11/1/3001', // the fuuuuuuuuture!
+            'created_at' => '2540246400', // the fuuuuuuuuture!
         ]);
 
         $this->assertResponseStatus(200);


### PR DESCRIPTION
#### What's this PR do?
Fixes #486. Phoenix is sending the `created_at` field as a timestamp for reasons which is causing errors, because Carbon's default constructor/parse method doesn't work with those.

#### How should this be reviewed?
💥 👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd 