### PR TITLE
Facebooks bad

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -62,9 +62,8 @@ class Registrar
 
         $existingId = isset($user->id) ? $user->id : 'null';
         $rules = [
-            'email' => 'email|unique:users,email,'.$existingId.',_id|required_without_all:mobile,facebook_id',
-            'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id|required_without_all:email,facebook_id',
-            'facebook_id' => 'numeric|unique:users,facebook_id,'.$existingId.',_id|required_without_all:email,mobile',
+            'email' => 'email|unique:users,email,'.$existingId.',_id|required_without:mobile',
+            'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id|required_without:email',
             'drupal_id' => 'unique:users,drupal_id,'.$existingId.',_id',
             'birthdate' => 'date',
         ];

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -162,10 +162,10 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
-        $existing = $this->registrar->resolve($request);
-
         // If a user exists but has not set a password yet, allow them to
         // "register" to set a new password on their account.
+        $existing = $this->registrar->resolve($request);
+
         if ($existing && $existing->hasPassword()) {
             throw new NorthstarValidationException(['email' => 'A user with that email or mobile has already been registered.']);
         }

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -162,9 +162,10 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
+        $existing = $this->registrar->resolve($request);
+
         // If a user exists but has not set a password yet, allow them to
         // "register" to set a new password on their account.
-        $existing = $this->registrar->resolve($request);
         if ($existing && $existing->hasPassword()) {
             throw new NorthstarValidationException(['email' => 'A user with that email or mobile has already been registered.']);
         }
@@ -172,6 +173,8 @@ class AuthController extends BaseController
         $this->registrar->validate($request, $existing, [
             'first_name' => 'required',
             'birthdate' => 'required|date',
+            'email' => 'required|email|unique:users,email,null,_id',
+            'mobile' => 'mobile|unique:users,mobile,null,_id',
             'password' => 'required|confirmed|min:6',
         ]);
 

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -170,11 +170,13 @@ class AuthController extends BaseController
             throw new NorthstarValidationException(['email' => 'A user with that email or mobile has already been registered.']);
         }
 
+        $existingId = isset($existing->id) ? $existing->id : 'null';
+
         $this->registrar->validate($request, $existing, [
             'first_name' => 'required',
             'birthdate' => 'required|date',
-            'email' => 'required|email|unique:users,email,null,_id',
-            'mobile' => 'mobile|unique:users,mobile,null,_id',
+            'email' => 'required|email|unique:users,email,'.$existingId.',_id',
+            'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id',
             'password' => 'required|confirmed|min:6',
         ]);
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@dosomething/analytics": "^1.0.2",
     "@dosomething/forge": "^6.7.4",
     "dosomething-validation": "^0.2.4",
+    "jquery": "^3.1.1",
     "mailcheck": "^1.1.1"
   }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR updates some of the server side validation language to remove mentions of "Facebook id" which is not a field needed for the registration, and may only end up applying to the API.

It also corrects an earlier bug where I forgot to include the jQuery NPM package in the `package.json` file. Even though I had tested the client-side validation and was working fine locally, it is probably because it was adding a globally stored copy of jQuery. 😥 

Fixes #491

#### How should this be reviewed?
👁 

#### Checklist
- [ ] Tests added for new features/bug fixes.

---
For review: 
@angaither 

cc: @jessleenyc 
