### PR TITLE
Updating the back link to send back to origin uri if available.

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -18,9 +18,13 @@ window.Drupal = {
 
 // Utilities
 import Analytics from './utilities/Analytics';
+import DeLorean from './utilities/DeLorean';
 
 // Register validation rules.
 import './validators/auth';
 
 // Initialize analytics.
 Analytics.init();
+
+// Initialize routing back to last page.
+DeLorean.init();

--- a/resources/assets/js/utilities/DeLorean.js
+++ b/resources/assets/js/utilities/DeLorean.js
@@ -1,5 +1,5 @@
 /**
- * Utility script to enable routing back to last page,
+ * Utility script to enable routing back to the last page,
  * as long as it's within the same top-level domain.
  */
 

--- a/resources/assets/js/utilities/DeLorean.js
+++ b/resources/assets/js/utilities/DeLorean.js
@@ -1,0 +1,15 @@
+/**
+ * Utility script to enable routing back to last page,
+ * as long as it's within the same top-level domain.
+ */
+
+function init(element = 'back') {
+  let backLink = document.getElementById(element);
+  let originUri = document.referrer;
+
+  if (backLink && originUri) {
+    backLink.setAttribute('href', originUri);
+  }
+}
+
+export default { init };

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,5 +1,5 @@
 <nav class="navigation">
-    <a href="{{ config('services.drupal.url') }}" data-track-category="Redirect" data-track-action="Clicked" data-track-label="Back To DoSomething Site"><span>&lsaquo;</span> Back</a>
+    <a id="back" href="{{ config('services.drupal.url') }}" data-track-category="Redirect" data-track-action="Clicked" data-track-label="Back To DoSomething Site"><span>&lsaquo;</span> Back</a>
 
     <h1 class="logo"><span>DoSomething.org</span></h1>
 </nav>


### PR DESCRIPTION
#### What's this PR do?
This PR adds a simple script to manipulate the "Back" link on Northstar so that when a user arrives to the login page from a page on Phoenix, they can click the link and head back exactly to that last page on Phoenix.

#### How should this be reviewed?
👁 

#### Additional Info
So there _can_ be wonky behavior if only using Northstar... for example, if you go Northstar Login page, click to "create a new account", and go to the Registration page then click "back", you will go back to the Login page. But if you now click "back" on the login page, you go to the Registration page, and thus can end up going in a bit of a loop. This is the initial step to adding this functionality. I believe the next step is to pass an origin path from Phoenix that Northstar can use to then use when returning from different NS pages to the login page and then informing the login page which Phoenix page to go back to.

#### Checklist
- [ ] Tests added for new features/bug fixes.

---
For review: 
@sbsmith86 @angaither 

cc: @jessleenyc 
