### PR TITLE
Adding new PHP to JS vars package and making a better back button.

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -54,7 +54,7 @@ class AuthController extends BaseController
         $this->oauth = $oauth;
 
         $this->middleware('guest:web', ['only' => ['getLogin', 'postLogin', 'getRegister', 'postRegister']]);
-        $this->middleware('sessionVars');
+        $this->middleware('session_vars');
     }
 
     /**

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -72,6 +72,9 @@ class AuthController extends BaseController
         // Store the Client ID so we can set user source on registrations.
         session(['authorize_client_id' => request()->query('client_id')]);
 
+        // Store the referrer URI so we can redirect back to it if necessary.
+        session(['referrer_uri' => request()->query('referrer_uri')]);
+
         if (! $this->auth->guard('web')->check()) {
             $destination = request()->query('destination', $client->getName());
             session(['destination' => $destination]);
@@ -97,6 +100,10 @@ class AuthController extends BaseController
      */
     public function getLogin()
     {
+        app('JavaScript')->put([
+            'referrerUri' => session('referrer_uri'),
+        ]);
+
         return view('auth.login');
     }
 

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -54,6 +54,7 @@ class AuthController extends BaseController
         $this->oauth = $oauth;
 
         $this->middleware('guest:web', ['only' => ['getLogin', 'postLogin', 'getRegister', 'postRegister']]);
+        $this->middleware('sessionVars');
     }
 
     /**
@@ -100,10 +101,6 @@ class AuthController extends BaseController
      */
     public function getLogin()
     {
-        app('JavaScript')->put([
-            'referrerUri' => session('referrer_uri'),
-        ]);
-
         return view('auth.login');
     }
 

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -30,6 +30,7 @@ class UserController extends BaseController
 
         $this->middleware('auth:web');
         $this->middleware('role:admin,staff', ['only' => ['show']]);
+        $this->middleware('sessionVars');
     }
 
     /**

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -30,7 +30,7 @@ class UserController extends BaseController
 
         $this->middleware('auth:web');
         $this->middleware('role:admin,staff', ['only' => ['show']]);
-        $this->middleware('sessionVars');
+        $this->middleware('session_vars');
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,6 +43,6 @@ class Kernel extends HttpKernel
         'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
         'scope' => \Northstar\Http\Middleware\RequireScope::class,
         'role' => \Northstar\Http\Middleware\RequireRole::class,
-        'sessionVars' => \Northstar\Http\Middleware\SessionVariablesToJavaScript::class,
+        'session_vars' => \Northstar\Http\Middleware\SessionVariablesToJavaScript::class,
     ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,5 +43,6 @@ class Kernel extends HttpKernel
         'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
         'scope' => \Northstar\Http\Middleware\RequireScope::class,
         'role' => \Northstar\Http\Middleware\RequireRole::class,
+        'sessionVars' => \Northstar\Http\Middleware\SessionVariablesToJavaScript::class,
     ];
 }

--- a/app/Http/Middleware/SessionVariablesToJavaScript.php
+++ b/app/Http/Middleware/SessionVariablesToJavaScript.php
@@ -27,5 +27,4 @@ class SessionVariablesToJavaScript
 
         return $next($request);
     }
-
 }

--- a/app/Http/Middleware/SessionVariablesToJavaScript.php
+++ b/app/Http/Middleware/SessionVariablesToJavaScript.php
@@ -17,7 +17,7 @@ class SessionVariablesToJavaScript
      */
     public function handle($request, Closure $next)
     {
-        foreach($this->sessionVariables as $variable) {
+        foreach ($this->sessionVariables as $variable) {
             if (session($variable)) {
                 app('JavaScript')->put([
                     camel_case($variable) => session($variable),

--- a/app/Http/Middleware/SessionVariablesToJavaScript.php
+++ b/app/Http/Middleware/SessionVariablesToJavaScript.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use Closure;
+
+class SessionVariablesToJavaScript
+{
+    protected $sessionVariables = ['referrer_uri'];
+
+    /**
+     * Run the request filter after the request is handled by the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Illuminate\Http\Request  $request
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach($this->sessionVariables as $variable) {
+            if (session($variable)) {
+                app('JavaScript')->put([
+                    camel_case($variable) => session($variable),
+                ]);
+            }
+        }
+
+        return $next($request);
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "league/oauth2-server": "^5.1.2",
     "dosomething/stathat": "^2.0.0",
     "symfony/psr-http-message-bridge": "^0.2.0",
-    "zendframework/zend-diactoros": "^1.3"
+    "zendframework/zend-diactoros": "^1.3",
+    "laracasts/utilities": "^2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b2ff64c798d6d5b92ebd9dba1eb9b3f4",
-    "content-hash": "46471e178260ad8db96d164fa7e0a6cc",
+    "hash": "9e253deb0cfed37a0807135a0012f1bb",
+    "content-hash": "c8d056fe00a7fc2f37f14053c1cea4aa",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -656,6 +656,50 @@
                 "tokenizer"
             ],
             "time": "2015-12-05 17:17:57"
+        },
+        {
+            "name": "laracasts/utilities",
+            "version": "2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laracasts/PHP-Vars-To-Js-Transformer.git",
+                "reference": "4402a0ed774f8eb36ea7ba169341d9d5b6049378"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laracasts/PHP-Vars-To-Js-Transformer/zipball/4402a0ed774f8eb36ea7ba169341d9d5b6049378",
+                "reference": "4402a0ed774f8eb36ea7ba169341d9d5b6049378",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laracasts\\Utilities\\JavaScript\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeffrey Way",
+                    "email": "jeffrey@laracasts.com"
+                }
+            ],
+            "description": "Transform your PHP to JavaScript",
+            "keywords": [
+                "javascript",
+                "laravel"
+            ],
+            "time": "2015-10-01 05:16:28"
         },
         {
             "name": "laravel/framework",

--- a/config/app.php
+++ b/config/app.php
@@ -154,6 +154,7 @@ return [
         Jenssegers\Mongodb\MongodbServiceProvider::class,
         Jenssegers\Mongodb\Auth\PasswordResetServiceProvider::class,
         DoSomething\StatHat\StatHatServiceProvider::class,
+        Laracasts\Utilities\JavaScript\JavaScriptServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/config/javascript.php
+++ b/config/javascript.php
@@ -25,6 +25,6 @@ return [
     | That way, you can access vars, like "SomeNamespace.someVariable."
     |
     */
-    'js_namespace' => 'Northstar'
+    'js_namespace' => 'Northstar',
 
 ];

--- a/config/javascript.php
+++ b/config/javascript.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | View to Bind JavaScript Vars To
+    |--------------------------------------------------------------------------
+    |
+    | Set this value to the name of the view (or partial) that
+    | you want to prepend all JavaScript variables to.
+    | This can be a single view, or an array of views.
+    | Example: 'footer' or ['footer', 'bottom']
+    |
+    */
+    'bind_js_vars_to_this_view' => 'layouts.variables',
+
+    /*
+    |--------------------------------------------------------------------------
+    | JavaScript Namespace
+    |--------------------------------------------------------------------------
+    |
+    | By default, we'll add variables to the global window object. However,
+    | it's recommended that you change this to some namespace - anything.
+    | That way, you can access vars, like "SomeNamespace.someVariable."
+    |
+    */
+    'js_namespace' => 'Northstar'
+
+];

--- a/resources/assets/js/utilities/DeLorean.js
+++ b/resources/assets/js/utilities/DeLorean.js
@@ -11,8 +11,12 @@ function init(element = 'back') {
     let backLink = document.getElementById(element);
     let referrerUri = document.referrer;
 
-    if (isSpecifiedRoute('/login') && Northstar) {
-      referrerUri = Northstar.referrerUri;
+    if (isSpecifiedRoute('/login') || isSpecifiedRoute('/')) {
+      if (window.Northstar) {
+        referrerUri = Northstar.referrerUri;
+      } else {
+        return;
+      }
     }
 
     if (backLink && referrerUri) {

--- a/resources/assets/js/utilities/DeLorean.js
+++ b/resources/assets/js/utilities/DeLorean.js
@@ -1,15 +1,45 @@
+const $ = require('jquery');
+
 /**
  * Utility script to enable routing back to the last page,
  * as long as it's within the same top-level domain.
  */
 
 function init(element = 'back') {
-  let backLink = document.getElementById(element);
-  let originUri = document.referrer;
+  $(document).ready(() => {
 
-  if (backLink && originUri) {
-    backLink.setAttribute('href', originUri);
+    let backLink = document.getElementById(element);
+    let referrerUri = document.referrer;
+
+    if (isSpecifiedRoute('/login') && Northstar) {
+      referrerUri = Northstar.referrerUri;
+    }
+
+    if (backLink && referrerUri) {
+      return backLink.setAttribute('href', referrerUri);
+    }
+
+  });
+}
+
+/**
+ * Determine if the specified string matches the current pathname route.
+ *
+ * @param  {String}  pathname
+ * @return {Boolean}
+ */
+function isSpecifiedRoute(pathname) {
+  if (!pathname) {
+    console.error('Please provide a route path to check against in the isSpecifiedRoute() method.');
+
+    return false;
   }
+
+  if (window.location.pathname !== pathname) {
+    return false;
+  }
+
+  return true;
 }
 
 export default { init };

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -14,28 +15,28 @@
 </head>
 
 <body class="modernizr-no-js">
-<div class="chrome">
-    @if (session('status'))
-        <div class="messages">{{ session('status') }}</div>
-    @endif
-    <div class="wrapper">
-        @include('layouts.navigation')
+    <div class="chrome">
+        @if (session('status'))
+            <div class="messages">{{ session('status') }}</div>
+        @endif
+        <div class="wrapper">
+            @include('layouts.navigation')
 
-        <section class="container -framed">
+            <section class="container -framed">
 
-            <div class="wrapper">
+                <div class="wrapper">
 
-            @yield('content')
+                @yield('content')
 
-            </div>
-        </section>
+                </div>
+            </section>
 
+        </div>
     </div>
-</div>
+
+    @include('layouts.variables')
+    <script src="{{ asset('/dist/app.js') }}"></script>
+    @include('layouts.google_analytics')
 </body>
-
-<script src="{{ asset('/dist/app.js') }}"></script>
-
-@include('layouts.google_analytics')
 
 </html>


### PR DESCRIPTION
#### What's this PR do?
This PR snags the `referrer_uri` that was implemented in [Phoenix](https://github.com/DoSomething/phoenix/pull/7199) and uses it to help provide a more logical flow w/ the view flows presented to the user on Northstar. It helps send the user back to the last page they were on in Phoenix after they clicked "sign up" or "log in" (anything that would send them to Northstar for authentication), while also allowing them to use that same "back" link to navigate the current forms on Northstar; it only sends them back to the page they came from on Phoenix if they are on the `/login` or `/` routes in Northstar and click that "back" link.

It also implements the [PHP-Vars-To-Js-Transformer](https://github.com/laracasts/PHP-Vars-To-Js-Transformer) package by the all-knowing code sage, Jeff Way. This package allows us to set variables from PHP and pop them into a namespaced JS object accessible at `window.Northstar`, to help with passing information from the back-end to the front-end!

Fixes #495

#### How should this be reviewed?
👁 

#### Checklist
- [ ] Tests added for new features/bug fixes.

---
For review:
@angaither @sbsmith86 

cc: @jessleenyc 

@chloealee (pinging you since you seemed interested in the usage of the _PHP-Vars-To-Js-Transformer_ package 😄 

