### PR TITLE
Use admin API account when registering Phoenix users.

### DIFF
--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -117,7 +117,7 @@ class Phoenix
         $payload = $user->toArray();
 
         // Format user object for consumption by Drupal API.
-        $payload['birthdate'] = date('Y-m-d', strtotime($user->birthdate));
+        $payload['birthdate'] = format_date($user->birthdate, 'Y-m-d');
         $payload['user_registration_source'] = $user->source;
         $payload['password'] = $password;
 

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -126,6 +126,10 @@ class Phoenix
                 'forward' => false,
             ],
             'json' => $payload,
+            'cookies' => $this->getAuthenticationCookie(),
+            'headers' => [
+                'X-CSRF-Token' => $this->getAuthenticationToken(),
+            ],
         ]);
 
         $json = json_decode($response->getBody()->getContents(), true);


### PR DESCRIPTION
#### What's this PR do?
This updates our Phoenix API wrapper to use admin API credentials when registering new users, because we're lockin' it down in DoSomething/phoenix#7208. This will prevent rapscallions from sending bogus data to that endpoint!

Must be deployed before merging DoSomething/phoenix#7208.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …