### PR TITLE
Increases retained releases to 5

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,7 @@ set :use_sudo, false
 set :repository, "."
 set :scm, :none
 set :deploy_via, :copy
-set :keep_releases, 1
+set :keep_releases, 5
 
 ssh_options[:keys] = [ENV["CAP_PRIVATE_KEY"]]
 


### PR DESCRIPTION
#### What's this PR do?
Via the `:keep_releases` flag, tells Capistrano to retain 5 releases instead of just 1.

#### How should this be reviewed?
Test deploys to Thor and confirm that (a) 5 releases get retained, and (b) each deploy cleans up the 6th.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

