### PR TITLE
Allow specifying either the registration or login page for gate.

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -77,10 +77,12 @@ class AuthController extends BaseController
         session(['referrer_uri' => request()->query('referrer_uri')]);
 
         if (! $this->auth->guard('web')->check()) {
+            $authorizationRoute = request()->query('mode') === 'register' ? 'register' : 'login';
             $destination = request()->query('destination', $client->getName());
             session(['destination' => $destination]);
 
-            return redirect()->guest('login');
+
+            return redirect()->guest($authorizationRoute);
         }
 
         $user = UserEntity::fromModel($this->auth->guard('web')->user());


### PR DESCRIPTION
#### What's this PR do?
This was left as a "todo" earlier, but seems reasonable to knock out alongside DoSomething/phoenix#7212. Requests to Northstar's `/authorize` route may now optionally include a query string to specify which route to show for the authorization gate. 

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @angaither