### PR TITLE
Updating the expiration for password reset.

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -95,7 +95,7 @@ return [
             'provider' => 'users',
             'email' => 'auth.emails.password',
             'table' => 'password_resets',
-            'expire' => 60,
+            'expire' => 1440,
         ],
     ],
 


### PR DESCRIPTION
#### What's this PR do?
This PR simply extends the password reset expiration time from 1 hour (60 minutes) to 24 hours (1440 minutes).

#### How should this be reviewed?
👁 

Refs https://trello.com/c/5C2oV0GZ/189-as-a-user-i-want-the-resent-password-link-to-expire-in-24-hours-instead-of-1-hour-so-that-i-can-reset-it-even-if-i-don-t-see-the

---
For review:
@DFurnes 

