### PR TITLE
Always prepare a mock Phoenix API client.

### DIFF
--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -177,7 +177,6 @@ class AuthController extends Controller
             $user->save();
         }
 
-
         // Create a legacy token & set the user for this request.
         $token = Token::create(['user_id' => $user->id]);
         $this->auth->setUser($user);

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -81,7 +81,6 @@ class AuthController extends BaseController
             $destination = request()->query('destination', $client->getName());
             session(['destination' => $destination]);
 
-
             return redirect()->guest($authorizationRoute);
         }
 

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -32,7 +32,6 @@ class HelpersTest extends TestCase
         ]);
         $this->assertEquals(client_id(), 'legacy_client');
 
-
         // And make a request using OAuth.
         $this->asNormalUser()->json('POST', '/v1/auth/register', [
             'email' => $this->faker->safeEmail,

--- a/tests/LegacyHttp/AuthTest.php
+++ b/tests/LegacyHttp/AuthTest.php
@@ -253,7 +253,7 @@ class AuthTest extends TestCase
     {
         $this->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/auth/register', [
             'email' => 'test-registration@dosomething.org',
-            'drupal_id' => '123456', // <-- we should ignore this!
+            'drupal_id' => 'secret_dries_admin_id', // <-- we should ignore this!
             'password' => 'secret',
             'role' => 'admin',
         ]);
@@ -261,7 +261,7 @@ class AuthTest extends TestCase
         $this->assertResponseStatus(200);
 
         // The provided `drupal_id` and `role` should have been ignored.
-        $this->assertEquals(null, $this->decodeResponseJson()['data']['user']['data']['drupal_id']);
+        $this->assertNotEquals('secret_dries_admin_id', $this->decodeResponseJson()['data']['user']['data']['drupal_id']);
         $this->assertEquals('user', $this->decodeResponseJson()['data']['user']['data']['role']);
     }
 
@@ -413,7 +413,7 @@ class AuthTest extends TestCase
     {
         $user = User::create(['email' => $this->faker->email, 'drupal_id' => '12345']);
 
-        $this->mock(Phoenix::class)
+        $this->phoenixMock
             ->shouldReceive('createMagicLogin')
             ->with('12345')->once()
             ->andReturn([

--- a/tests/LegacyHttp/ReportbackTest.php
+++ b/tests/LegacyHttp/ReportbackTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Northstar\Models\User;
-use Northstar\Services\Phoenix;
 
 class ReportbackTest extends TestCase
 {
@@ -16,9 +15,8 @@ class ReportbackTest extends TestCase
         $user = User::create(['drupal_id' => '512312']);
 
         // For testing, we'll mock successful Phoenix API responses.
-        $phoenix = $this->mock(Phoenix::class);
-        $phoenix->shouldReceive('createReportback')->once()->andReturn(['127']);
-        $phoenix->shouldReceive('getReportback')->once()->andReturn([
+        $this->phoenixMock->shouldReceive('createReportback')->once()->andReturn(['127']);
+        $this->phoenixMock->shouldReceive('getReportback')->once()->andReturn([
             'data' => [
                 'id' => 127,
                 // ...

--- a/tests/LegacyHttp/SignupTest.php
+++ b/tests/LegacyHttp/SignupTest.php
@@ -17,7 +17,7 @@ class SignupTest extends TestCase
         $user2 = User::create(['drupal_id' => '100002', 'first_name' => 'Dave']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
+        $this->phoenixMock->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
@@ -62,7 +62,7 @@ class SignupTest extends TestCase
         $user2 = User::create(['drupal_id' => '100002', 'first_name' => 'Dave']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
+        $this->phoenixMock->shouldReceive('getSignupIndex')->with(['users' => ['100001', '100002']])->once()->andReturn([
             'data' => [
                 [
                     'id' => '243',
@@ -90,7 +90,7 @@ class SignupTest extends TestCase
         $user = User::create(['drupal_id' => '100003', 'first_name' => 'Name']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignupIndex')->with(['users' => ['100003']])->once()->andReturn([
+        $this->phoenixMock->shouldReceive('getSignupIndex')->with(['users' => ['100003']])->once()->andReturn([
             'data' => [
                 [
                     'user' => [
@@ -116,7 +116,7 @@ class SignupTest extends TestCase
     public function testGetSignup()
     {
         // For testing, we'll mock a successful Phoenix API response.
-        $this->mock(Phoenix::class)->shouldReceive('getSignup')->once()->andReturn([
+        $this->phoenixMock->shouldReceive('getSignup')->once()->andReturn([
             'data' => [
                 'id' => '42',
                 'user' => [
@@ -143,9 +143,8 @@ class SignupTest extends TestCase
         $user = User::create(['drupal_id' => '123451']);
 
         // For testing, we'll mock a successful Phoenix API response.
-        $mock = $this->mock(Phoenix::class);
-        $mock->shouldReceive('createSignup')->with('123451', '123', 'test')->once()->andReturn(['1307']);
-        $mock->shouldReceive('getSignup')->with('1307')->once()->andReturn([
+        $this->phoenixMock->shouldReceive('createSignup')->with('123451', '123', 'test')->once()->andReturn(['1307']);
+        $this->phoenixMock->shouldReceive('getSignup')->with('1307')->once()->andReturn([
             'data' => [
                 'id' => '1307',
                 // ...

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Northstar\Auth\Scope;
 use Northstar\Models\Client;
 use Northstar\Models\Token;
 use Northstar\Models\User;
+use Northstar\Services\Phoenix;
 
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
@@ -24,6 +25,13 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      * @var \Faker\Generator
      */
     protected $faker;
+
+    /**
+     * The Phoenix API client mock.
+     *
+     * @var Mockery\Mock
+     */
+    protected $phoenixMock;
 
     /**
      * Make a new authenticated web user.
@@ -51,6 +59,11 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
+
+        $this->phoenixMock = $this->mock(Phoenix::class);
+        $this->phoenixMock->shouldReceive('register')->andReturnUsing(function() {
+            return $this->faker->unique()->numberBetween(1, 30000000);
+        });
 
         // Reset the testing database & run migrations.
         $this->app->make('db')->getMongoDB()->drop();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,7 +61,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $this->faker = app(\Faker\Generator::class);
 
         $this->phoenixMock = $this->mock(Phoenix::class);
-        $this->phoenixMock->shouldReceive('register')->andReturnUsing(function() {
+        $this->phoenixMock->shouldReceive('register')->andReturnUsing(function () {
             return $this->faker->unique()->numberBetween(1, 30000000);
         });
 


### PR DESCRIPTION
#### What's this PR do?
When #406 is implemented, we'll be making registration requests to the Phoenix API left and right (because we'll be trying to create a Phoenix account whenever a user doesn't have the `drupal_id` property set on their profile, which is _all the time_ in the test suite). 

Rather than mock those case-by-case, let's just always prepare a mock whether or not we need it. (We can always override the prepared mock with one that asserts an argument or expected number of calls.)

#### How should this be reviewed?
Tests should continue to pass.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd 
