### PR TITLE
Always make a corresponding Phoenix account.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -208,7 +208,7 @@ class Registrar
             $user->drupal_id = $drupal_id;
         } catch (ClientException $e) {
             // If user already exists (403 Forbidden), try to find the user to get the UID.
-            if ($e->getCode() == 403) {
+            if ($e->getCode() === 403) {
                 $drupal_id = $this->phoenix->getDrupalIdForNorthstarUser($user);
                 $user->drupal_id = $drupal_id;
             }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Auth;
 
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\Factory as Validation;
@@ -185,23 +186,27 @@ class Registrar
         $user->fill($input);
         $user->save();
 
+        // If this user doesn't have a `drupal_id`, try to make one.
+        if (! $user->drupal_id) {
+            $user = $this->createDrupalUser($user);
+            $user->save();
+        }
+
         return $user;
     }
 
     /**
-     * Attempt to create a Drupal user for the given account.
+     * Create a Drupal user for the given account.
      *
      * @param User $user
-     * @param string $password
      * @return mixed
      */
-    public function createDrupalUser($user, $password)
+    public function createDrupalUser($user)
     {
-        // @TODO: we can't create a Drupal user without an email. Do we just create an @mobile one like we had done previously?
         try {
-            $drupal_id = $this->phoenix->register($user, $password);
+            $drupal_id = $this->phoenix->register($user);
             $user->drupal_id = $drupal_id;
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
+        } catch (ClientException $e) {
             // If user already exists (403 Forbidden), try to find the user to get the UID.
             if ($e->getCode() == 403) {
                 try {

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -209,12 +209,14 @@ class Registrar
         } catch (ClientException $e) {
             // If user already exists (403 Forbidden), try to find the user to get the UID.
             if ($e->getCode() == 403) {
-                try {
-                    $drupal_id = $this->phoenix->getUidByEmail($user->email);
-                    $user->drupal_id = $drupal_id;
-                } catch (\Exception $e) {
-                    // @TODO: still ok to just continue and allow the user to be saved?
-                }
+                $drupal_id = $this->phoenix->getDrupalIdForNorthstarUser($user);
+                $user->drupal_id = $drupal_id;
+            }
+
+            // Since getDrupalIdForNorthstarUser may still return null, track that here.
+            if (empty($user->drupal_id)) {
+                logger('Encountered error when creating Drupal user', ['user' => $user, 'error' => $e]);
+                app('stathat')->ezCount('error creating drupal uid for user');
             }
         }
 

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -204,7 +204,7 @@ class Registrar
     public function createDrupalUser($user)
     {
         try {
-            $drupal_id = $this->phoenix->register($user);
+            $drupal_id = $this->phoenix->createDrupalUser($user);
             $user->drupal_id = $drupal_id;
         } catch (ClientException $e) {
             // If user already exists (403 Forbidden), try to find the user to get the UID.

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -171,12 +171,6 @@ class AuthController extends Controller
 
         $user = $this->registrar->register($request->except(User::$internal), $existing);
 
-        // Should we try to make a Drupal account for this user?
-        if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {
-            $user = $this->registrar->createDrupalUser($user, $request->input('password'));
-            $user->save();
-        }
-
         // Create a legacy token & set the user for this request.
         $token = Token::create(['user_id' => $user->id]);
         $this->auth->setUser($user);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -126,12 +126,6 @@ class UserController extends Controller
             $user->save();
         }
 
-        // Should we try to make a Drupal account for this user?
-        if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {
-            $user = $this->registrar->createDrupalUser($user, $request->input('password'));
-            $user->save();
-        }
-
         $code = $upserting ? 200 : 201;
 
         return $this->item($user, $code);
@@ -182,7 +176,7 @@ class UserController extends Controller
             Role::gate(['admin']);
         }
 
-        $user->fill($request->all());
+        $this->registrar->register($request->all(), $user);
 
         // Should we try to make a Drupal account for this user?
         if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -178,13 +178,6 @@ class UserController extends Controller
 
         $this->registrar->register($request->all(), $user);
 
-        // Should we try to make a Drupal account for this user?
-        if ($request->has('create_drupal_user') && $request->has('password') && ! $user->drupal_id) {
-            $user = $this->registrar->createDrupalUser($user, $request->input('password'));
-        }
-
-        $user->save();
-
         return $this->item($user);
     }
 

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -108,18 +108,16 @@ class Phoenix
      * @see: https://github.com/DoSomething/dosomething/wiki/API#create-a-user
      *
      * @param \Northstar\Models\User $user - User to be registered on Drupal site
-     * @param string $password - Password to register with
      *
      * @return int - Created Drupal user UID
      */
-    public function register($user, $password)
+    public function register($user)
     {
         $payload = $user->toArray();
 
         // Format user object for consumption by Drupal API.
         $payload['birthdate'] = format_date($user->birthdate, 'Y-m-d');
         $payload['user_registration_source'] = $user->source;
-        $payload['password'] = $password;
 
         $response = $this->client->post('users', [
             'query' => [

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Str;
+use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Cache;
 
@@ -119,6 +120,11 @@ class Phoenix
         $payload['birthdate'] = format_date($user->birthdate, 'Y-m-d');
         $payload['user_registration_source'] = $user->source;
 
+        // Drupal requires an email on every account, but Northstar does not.
+        if (empty($payload['email'])) {
+            $payload['email'] = $user->id.'@dosomething.import';
+        }
+
         $response = $this->client->post('users', [
             'query' => [
                 'forward' => false,
@@ -139,16 +145,19 @@ class Phoenix
      * Get a user uid by email.
      * @see: https://github.com/DoSomething/dosomething/wiki/API#find-a-user
      *
-     * @param string $email - Email of user to search for
+     * @param User $user
      *
-     * @return string - Drupal User ID
+     * @return string|null - Drupal User ID
      * @throws Exception
      */
-    public function getUidByEmail($email)
+    public function getDrupalIdForNorthstarUser($user)
     {
+        // Phoenix supports lookup by either email or mobile
+        $primaryField = ! empty($user->email) ? 'email' : 'mobile';
+
         $response = $this->client->get('users', [
             'query' => [
-                'parameters[email]' => $email,
+                'parameters['.$primaryField.']' => $user->{$primaryField},
             ],
             'cookies' => $this->getAuthenticationCookie(),
             'headers' => [
@@ -158,11 +167,7 @@ class Phoenix
 
         $json = json_decode($response->getBody()->getContents(), true);
 
-        if (count($json) > 0) {
-            return $json[0]['uid'];
-        } else {
-            throw new Exception('Drupal user not found.', $response->getStatusCode());
-        }
+        return data_get($json, '0.uid');
     }
 
     /**

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -111,7 +111,7 @@ class Phoenix
      *
      * @return int - Created Drupal user UID
      */
-    public function register($user)
+    public function createDrupalUser($user)
     {
         $payload = $user->toArray();
 

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -166,7 +166,6 @@ Either a mobile number or email is required.
 
 **Additional Query Parameters:**
 
-- `create_drupal_user`: Will send a request to create a drupal user in the main DS app.
 - `upsert`: Should this request upsert an existing account, if matched? Defaults to `true`.
 
 <details>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,7 +29,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
     /**
      * The Phoenix API client mock.
      *
-     * @var Mockery\Mock
+     * @var \Mockery\MockInterface
      */
     protected $phoenixMock;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,7 +61,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $this->faker = app(\Faker\Generator::class);
 
         $this->phoenixMock = $this->mock(Phoenix::class);
-        $this->phoenixMock->shouldReceive('register')->andReturnUsing(function () {
+        $this->phoenixMock->shouldReceive('createDrupalUser')->andReturnUsing(function () {
             return $this->faker->unique()->numberBetween(1, 30000000);
         });
 


### PR DESCRIPTION
#### What's this PR do?
A lot of functionality still relies on a Phoenix account existing for every user. Now that we've shipped Northstar authentication, we don't need every Phoenix account to have a password in Phoenix which simplifies things a lot!

Alongside DoSomething/phoenix#7229, this should ensure all Northstar accounts will have a Drupal ID.

#### How should this be reviewed?
This shouldn't cause any issues, but we should do some thorough testing just in case!

~Relies on DoSomething/phoenix#7229.~ Merged! ✅ 
References #406.

#### Checklist
- [x] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @angaither @weerd