### PR TITLE
If a user doesn't have a password, ask them to reset it.

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -119,7 +119,7 @@ class AuthController extends BaseController
         ]);
 
         // Check if that user needs to reset their password in order to log in.
-        $user = $this->registrar->resolve($request);
+        $user = $this->registrar->resolve(['username' => $request['username']]);
         if ($user && ! $user->hasPassword()) {
             return redirect()->back()->withInput($request->only('username'))->with('request_reset', true);
         }

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -118,6 +118,13 @@ class AuthController extends BaseController
             'password' => 'required',
         ]);
 
+        // Check if that user needs to reset their password in order to log in.
+        $user = $this->registrar->resolve($request);
+        if ($user && ! $user->hasPassword()) {
+            return redirect()->back()->withInput($request->only('username'))->with('request_reset', true);
+        }
+
+        // Attempt to log in the user to Northstar!
         $credentials = $request->only('username', 'password');
         if (! $this->auth->guard('web')->attempt($credentials, true)) {
             return redirect()->back()

--- a/resources/assets/scss/_components/_messages.scss
+++ b/resources/assets/scss/_components/_messages.scss
@@ -1,0 +1,6 @@
+.messages {
+  &.-padded {
+    margin-top: - $section-spacing;
+    padding-top: $section-spacing * 1.5;
+  }
+}

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -16,6 +16,7 @@
 @import "_components/_key-value";
 @import "_components/_forms";
 @import "_components/_validation-error";
+@import "_components/_messages";
 
 // Regions - complete sections of an interface
 @import "_regions/_chrome";

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,6 +3,10 @@
 @section('title', 'Log In | DoSomething.org')
 
 @section('content')
+    @if (session('request_reset'))
+        <div class="messages -padded">You need to <a href="{{ url('password/reset') }}">reset your password</a> before you can log in.</div>
+    @endif
+
     <div class="container__block -centered">
         <h2 class="heading -alpha">Let's do this!</h2>
         <h3>Log in to continue to {{ session('destination', 'DoSomething.org') }}.</h3>

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -73,6 +73,24 @@ class WebAuthenticationTest extends TestCase
     }
 
     /**
+     * Test that users who do not have a password on their account
+     * are asked to reset it.
+     */
+    public function testLoginWithoutPasswordSet()
+    {
+        factory(User::class)->create(['email' => 'puppet-sloth@dosomething.org', 'password' => null]);
+
+        // Puppet Sloth doesn't have a DS.org password yet, but he tries to enter
+        // "next-question" because that's his password everywhere else.
+        $this->visit('login')->submitForm('Log In', [
+            'username' => 'puppet-sloth@dosomething.org',
+            'password' => 'next-question',
+        ]);
+
+        $this->seeText('You need to reset your password before you can log in.');
+    }
+
+    /**
      * Test that an authenticated user can log out.
      */
     public function testLogout()


### PR DESCRIPTION
#### What's this PR do?
This pull request adds some better messaging when a passwordless user (for example, someone who registered by voting for Celebs Gone Good) tries to log in to their account.

![screen shot 2016-12-08 at 11 09 02 am](https://cloud.githubusercontent.com/assets/583202/21017749/641fef0e-bd38-11e6-8400-73f595b4726e.png)

#### How should this be reviewed?
👀 and 🚥!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
