### PR TITLE
Remove ability to register over an account.

### DIFF
--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -159,17 +159,9 @@ class AuthController extends Controller
     {
         $request = normalize('credentials', $request);
 
-        // If a user exists but has not set a password yet, allow them to
-        // "register" to set a new password on their account.
-        $credentials = $request->only('email', 'mobile');
-        $existing = $this->registrar->resolve($credentials);
-        if ($existing && $existing->hasPassword()) {
-            throw new HttpException(422, 'A user with that email or mobile has already been registered.');
-        }
+        $this->registrar->validate($request, null, ['password' => 'required']);
 
-        $this->registrar->validate($request, $existing, ['password' => 'required']);
-
-        $user = $this->registrar->register($request->except(User::$internal), $existing);
+        $user = $this->registrar->register($request->except(User::$internal));
 
         // Create a legacy token & set the user for this request.
         $token = Token::create(['user_id' => $user->id]);

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -167,26 +167,16 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
-        // If a user exists but has not set a password yet, allow them to
-        // "register" to set a new password on their account.
-        $existing = $this->registrar->resolve($request);
-
-        if ($existing && $existing->hasPassword()) {
-            throw new NorthstarValidationException(['email' => 'A user with that email or mobile has already been registered.']);
-        }
-
-        $existingId = isset($existing->id) ? $existing->id : 'null';
-
-        $this->registrar->validate($request, $existing, [
+        $this->registrar->validate($request, null, [
             'first_name' => 'required',
             'birthdate' => 'required|date',
-            'email' => 'required|email|unique:users,email,'.$existingId.',_id',
-            'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id',
+            'email' => 'required|email|unique:users',
+            'mobile' => 'mobile|unique:users',
             'password' => 'required|confirmed|min:6',
         ]);
 
         // Register and login the user.
-        $user = $this->registrar->register($request->except(User::$internal), $existing);
+        $user = $this->registrar->register($request->except(User::$internal));
         $this->auth->guard('web')->login($user, true);
 
         return redirect()->intended('/');

--- a/tests/LegacyHttp/AuthTest.php
+++ b/tests/LegacyHttp/AuthTest.php
@@ -266,42 +266,6 @@ class AuthTest extends TestCase
     }
 
     /**
-     * Test that you can "register" to complete the registration
-     * flow for a user who has an email/mobile account but no
-     * password stored.
-     * POST /auth/register
-     *
-     * @return void
-     */
-    public function testRegisterExistingUserWithoutPassword()
-    {
-        // Given an account that doesn't have a password (for example,
-        // someone who voted in Celebs Gone Good).
-        $user = factory(User::class)->create([
-            'email' => 'poe.dameron@resistance.org',
-            'first_name' => 'Poe',
-            'password' => null,
-            'source' => 'cgg',
-        ]);
-
-        // Try to register to "complete" their profile.
-        $this->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/auth/register', [
-            'email' => 'Poe.Dameron@Resistance.org',
-            'password' => 'finn&p0e4ever',
-            'source' => 'phpunit',
-        ]);
-
-        $this->assertResponseStatus(200);
-
-        $user = $user->fresh();
-
-        // Ensure that we've stored new fields on the existing user record.
-        $this->assertEquals($user->first_name, 'Poe');
-        $this->assertEquals($user->source, 'cgg'); // Should be immutable.
-        $this->assertNotEmpty($user->password, 'Hashed password should be stored.');
-    }
-
-    /**
      * Test that you can't register a duplicate user.
      * POST /auth/register
      *


### PR DESCRIPTION
#### What's this PR do?
We had previously added the ability to "register over" an account if it didn't have a password. This was a little bandaid fix when users who had voted in CGG could not register last year. Now that we're authenticating users in Northstar, we can handle this more elegantly on the login page.

References #509.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
