### PR TITLE
Expose API for creating password reset links.

### DIFF
--- a/app/Http/Controllers/ResetController.php
+++ b/app/Http/Controllers/ResetController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+use Jenssegers\Mongodb\Auth\DatabaseTokenRepository;
+use Northstar\Models\User;
+use Illuminate\Http\Request;
+
+class ResetController extends Controller
+{
+    /**
+     * Make a new ResetController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
+    public function __construct()
+    {
+        $this->middleware('role:admin');
+    }
+
+    /**
+     * Create a new password reset token.
+     * POST /users
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function store(Request $request)
+    {
+        $this->validate($request, [
+            'id' => 'required',
+        ]);
+
+        /** @var \Northstar\Models\User $user */
+        $user = User::findOrFail($request['id']);
+
+        $tokenRepository = $this->createTokenRepository();
+        $token = $tokenRepository->create($user);
+        $email = $user->getEmailForPasswordReset();
+
+        return [
+            'url' => url('password/reset/'.$token.'?email='.urlencode($email)),
+        ];
+    }
+
+    /**
+     * Create a token repository instance based on the given configuration.
+     *
+     * @return DatabaseTokenRepository
+     */
+    protected function createTokenRepository()
+    {
+        return new DatabaseTokenRepository(
+            app('db')->connection(),
+            config('auth.passwords.users.table'),
+            config('app.key'),
+            config('auth.passwords.users.expire')
+        );
+    }
+}

--- a/app/Http/Controllers/ResetController.php
+++ b/app/Http/Controllers/ResetController.php
@@ -5,15 +5,28 @@ namespace Northstar\Http\Controllers;
 use Jenssegers\Mongodb\Auth\DatabaseTokenRepository;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
+use Northstar\Services\Phoenix;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ResetController extends Controller
 {
     /**
+     * Phoenix Drupal API wrapper.
+     *
+     * @var Phoenix
+     */
+    protected $phoenix;
+
+    /**
      * Make a new ResetController, inject dependencies,
      * and set middleware for this controller's methods.
+     *
+     * @param Phoenix $phoenix
      */
-    public function __construct()
+    public function __construct(Phoenix $phoenix)
     {
+        $this->phoenix = $phoenix;
+
         $this->middleware('role:admin');
     }
 
@@ -32,6 +45,17 @@ class ResetController extends Controller
 
         /** @var \Northstar\Models\User $user */
         $user = User::findOrFail($request['id']);
+
+        // If Northstar's password reset flow isn't enabled, send this request to Drupal.
+        if (! config('features.password-reset')) {
+            if (! $user->drupal_id) {
+                throw new HttpException(401, 'The user must have a Drupal ID to reset their Phoenix password.');
+            }
+
+            return [
+                'url' => $this->phoenix->createPasswordResetLink($user->drupal_id),
+            ];
+        }
 
         $tokenRepository = $this->createTokenRepository();
         $token = $tokenRepository->create($user);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -57,7 +57,7 @@ $router->group(['prefix' => 'v2', 'middleware' => ['api']], function () use ($ro
     $router->resource('clients', 'ClientController');
 
     // Password Reset
-    $router->resource('resets', 'ResetController');
+    $router->resource('resets', 'ResetController', ['only' => 'store']);
 
     // Public Key
     $router->get('key', 'KeyController@show');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -56,6 +56,9 @@ $router->group(['prefix' => 'v2', 'middleware' => ['api']], function () use ($ro
     // OAuth Clients
     $router->resource('clients', 'ClientController');
 
+    // Password Reset
+    $router->resource('resets', 'ResetController');
+
     // Public Key
     $router->get('key', 'KeyController@show');
 

--- a/app/Services/Phoenix.php
+++ b/app/Services/Phoenix.php
@@ -352,4 +352,25 @@ class Phoenix
 
         return json_decode($response->getBody()->getContents(), true);
     }
+
+    /**
+     * Get a password reset link for the given user.
+     * @see: https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/users.md#create-password-reset-url
+     *
+     * @param $drupal_id - UID of user on the Drupal site
+     *
+     * @return string - password reset URL
+     * @throws Exception
+     */
+    public function createPasswordResetLink($drupal_id)
+    {
+        $response = $this->client->post('users/'.$drupal_id.'/password_reset_url', [
+            'cookies' => $this->getAuthenticationCookie(),
+            'headers' => [
+                'X-CSRF-Token' => $this->getAuthenticationToken(),
+            ],
+        ]);
+
+        return json_decode($response->getBody()->getContents(), true)[0];
+    }
 }

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -58,6 +58,11 @@ Endpoint                                     | Functionality                    
 
 > __Note:__ These endpoints are lightweight proxies to their Phoenix equivalents.
 
+#### Resets
+Endpoint                                     | Functionality                                            | Required Scope
+-------------------------------------------- | -------------------------------------------------------- | --------------
+`POST v2/resets`                             | [Create a Password Reset Link](endpoints/resets.md#create-a-password-reset-link) | `role:admin` or `admin`
+
 #### Clients
 Endpoint                                     | Functionality                                                       | Required Scope
 -------------------------------------------- | ------------------------------------------------------------------- | --------------

--- a/documentation/endpoints/resets.md
+++ b/documentation/endpoints/resets.md
@@ -1,0 +1,33 @@
+# Reset Endpoints
+
+## Create a Password Reset Link
+Create a new password reset link for the provided user ID. This requires admin privileges.
+
+```
+POST /v2/resets
+```
+
+<details>
+<summary>**Example Request**</summary>
+
+```sh
+curl -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "{\"id\" : \"5846c3949a8920472d4c8793\"}"
+  https://northstar.dosomething.org/v2/resets
+```
+</details>
+
+<details>
+<summary>**Example Response**</summary>
+
+```js
+// 200 OK
+
+{
+  "url": "http:\/\/northstar.dev:8000\/password\/reset\/5d8c35cb8d5151ec2fa8b278fd17e0ba19f1a52a3c01ffc9c2e454961038fb1d?email=passwordless-fool92%40dosomething.org"
+}
+```
+</details>
+

--- a/tests/Http/ResetTest.php
+++ b/tests/Http/ResetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Northstar\Models\User;
+
+class ResetTest extends TestCase
+{
+    /**
+     * Test that anonymous and non-admin keys/users cannot create
+     * password reset links.
+     * POST /resets
+     *
+     * @test
+     */
+    public function testResetNotAccessibleByNonAdmin()
+    {
+        $this->post('v2/resets');
+        $this->assertResponseStatus(401);
+
+        $this->asNormalUser()->post('v2/resets');
+        $this->assertResponseStatus(401);
+
+        $this->asStaffUser()->post('v2/resets');
+        $this->assertResponseStatus(401);
+    }
+
+    /**
+     * Test creating a new password reset link.
+     * POST /resets
+     *
+     * @test
+     */
+    public function testCreatePasswordResetLink()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asAdminUser()->post('v2/resets', ['id' => $user->id]);
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure(['url']);
+
+        $this->seeInDatabase('password_resets', ['email' => $user->email]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This pull request adds an endpoint which will allow other DoSomething.org services (for example, the Niche import script) to create password reset links. If the Northstar password reset flow is not enabled, this will proxy to the existing Drupal endpoint.

#### How should this be reviewed?
:eyes:

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  


