### PR TITLE
Track failed user authentication attempts in StatHat.

### DIFF
--- a/app/Auth/Repositories/UserRepository.php
+++ b/app/Auth/Repositories/UserRepository.php
@@ -41,6 +41,8 @@ class UserRepository implements UserRepositoryInterface
         $user = $this->registrar->resolve($credentials);
 
         if (! $this->registrar->validateCredentials($user, $credentials)) {
+            event(\Illuminate\Auth\Events\Failed::class);
+
             return null;
         }
 

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -86,6 +86,8 @@ class AuthController extends Controller
         $user = $this->registrar->resolve($credentials);
 
         if (! $this->registrar->validateCredentials($user, $credentials)) {
+            event(\Illuminate\Auth\Events\Failed::class);
+
             throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 
@@ -112,6 +114,8 @@ class AuthController extends Controller
         $user = $this->registrar->resolve($credentials);
 
         if (! $this->registrar->validateCredentials($user, $credentials)) {
+            event(\Illuminate\Auth\Events\Failed::class);
+
             throw new UnauthorizedHttpException(null, 'Invalid credentials.');
         }
 

--- a/app/Listeners/FailedAuthenticationAttempt.php
+++ b/app/Listeners/FailedAuthenticationAttempt.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Northstar\Listeners;
+
+use DoSomething\StatHat\Client as StatHat;
+
+class FailedAuthenticationAttempt
+{
+    /**
+     * The StatHat client.
+     *
+     * @var StatHat
+     */
+    protected $stathat;
+
+    /**
+     * Create the event listener.
+     *
+     * @param StatHat $stathat
+     */
+    public function __construct(StatHat $stathat)
+    {
+        $this->stathat = $stathat;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->stathat->ezCount('failed user authentication attempt');
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace Northstar\Providers;
 
+use Illuminate\Auth\Events\Failed;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Routing\Events\RouteMatched;
+use Northstar\Listeners\FailedAuthenticationAttempt;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -14,7 +16,7 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        // ...
+        Failed::class => [FailedAuthenticationAttempt::class],
     ];
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This adds an event listener for Laravel's built-in "authentication failed" event, which is fired whenever a standard login `attempt()` fails. Since we also manually authenticate users via the Registrar for OAuth and legacy auth endpoints, I've also added triggers for the same event there.

Closes #504.

#### How should this be reviewed?
📉 👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
