### PR TITLE
Correctly cast dates when saving to MongoDB.

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Exception;
 use InvalidArgumentException;
 use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
+use MongoDB\BSON\UTCDateTime;
 
 /**
  * Base model class
@@ -45,11 +46,9 @@ class Model extends BaseModel
      */
     public function fromDateTime($value)
     {
-        $format = $this->getDateFormat();
-
         $value = $this->asDateTime($value);
 
-        return $value->format($format);
+        return new UTCDateTime($value->getTimestamp() * 1000);
     }
 
     /**

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Northstar\Models\User;
 
 class UserTest extends TestCase
@@ -232,6 +233,34 @@ class UserTest extends TestCase
                 'last_name' => '└(^o^)┘',
                 'last_initial' => '└',
             ],
+        ]);
+    }
+
+    /**
+     * Test that users get created_at & updated_at fields.
+     * POST /v1/users/
+     *
+     * @return void
+     */
+    public function testSetCreatedAtField()
+    {
+        $this->asAdminUser()->json('POST', 'v1/users', [
+            'email' => 'alejandro@example.com',
+        ]);
+
+        $this->assertResponseStatus(201);
+
+        // Let's see what 'created_at' is returned in the response
+        $response = $this->decodeResponseJson();
+        $date = new Carbon($response['data']['created_at']);
+
+        // It should be today!
+        $this->assertTrue($date->isSameDay(Carbon::now()));
+
+        // And it should be stored as a ISODate in the actual database.
+        $this->seeInDatabase('users', [
+            'email' => 'alejandro@example.com',
+            'created_at' => new MongoDB\BSON\UTCDateTime($date->getTimestamp() * 1000),
         ]);
     }
 


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue where date fields (e.g. `created_at`, `updated_at`, `birthdate`) were being stored as ISO-8601 strings rather than `ISODate` objects. This meant that we couldn't query for date ranges with Mongo ("find me records made between these dates!") which is needed for data analysis.

Fixes #513. References #479.

#### How should this be reviewed?
I added a test in acaf5d7 which demonstrates the problem (it will fail since there isn't a record with a casted date). The fix in 0a8d169 fixes the problem (and the failing test!) by correctly casting dates in the base model class.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  