### PR TITLE
Add a script for casting string dates to ISODates.

### DIFF
--- a/app/Console/Commands/FixMongoDatesCommand.php
+++ b/app/Console/Commands/FixMongoDatesCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Illuminate\Console\Command;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Collection;
+use Northstar\Models\User;
+
+class FixMongoDatesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:fix_mongo_dates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Convert any string dates to ISODate objects.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $dateFields = ['birthdate', 'created_at', 'updated_at'];
+
+        foreach ($dateFields as $field) {
+            $this->reformatField($field);
+        }
+    }
+
+    /**
+     * Find records where the given field is a string, and
+     * re-cast as an ISODate.
+     *
+     * @param $field
+     */
+    public function reformatField($field)
+    {
+
+        // Find all users where the given field is stored as a string type.
+        // @see: https://docs.mongodb.com/manual/reference/operator/query/type/#op._S_type
+        $users = User::where($field, 'type', 2)->get();
+
+        foreach ($users as $user) {
+            /** @var \Carbon\Carbon $carbon */
+            $carbon = $user->{$field};
+
+            /** @var \Jenssegers\Mongodb\Query\Builder $collection */
+            $collection = app('db')->collection('users');
+            $success = $collection
+                ->where('_id', $user->id)
+                ->update([$field => new UTCDateTime($carbon->getTimestamp() * 1000)]);
+
+            if ($success === 1) {
+                $this->info('Updated `'.$field.'` field for '.$user->id.'!');
+            } else {
+                $this->warn('Could not update `'.$field.'` field for '.$user->id.'!');
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
+        \Northstar\Console\Commands\FixMongoDatesCommand::class,
     ];
 
     /**

--- a/tests/Console/FixMongoDatesCommandTest.php
+++ b/tests/Console/FixMongoDatesCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use MongoDB\BSON\UTCDateTime;
+
+class FixMongoDatesCommandTest extends TestCase
+{
+    /**
+     * Test that it does the thing its supposed to.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testThatItDoesTheThings()
+    {
+        /** @var \Jenssegers\Mongodb\Query\Builder $collection */
+        $collection = app('db')->collection('users');
+        $collection->insert([
+            ['first_name' => 'Bob', 'birthdate' => '10/25/1990'],
+            ['first_name' => 'Phil', 'updated_at' => new UTCDateTime('1472809248000'), 'created_at' => '2016-12-06T13:58:59+0000'],
+            ['first_name' => 'Luis', 'updated_at' => '2016-11-01T13:58:59+0000', 'created_at' => '2016-11-05T13:58:59+0000'],
+        ]);
+
+        // Run the magic command on our messy data.
+        $this->artisan('northstar:fix_mongo_dates');
+
+        // We should now see only nicely formatted UTCDateTimes!
+        $this->seeInDatabase('users', ['first_name' => 'Bob', 'birthdate' => new UTCDateTime('656812800000')]);
+        $this->seeInDatabase('users', ['first_name' => 'Phil', 'updated_at' => new UTCDateTime('1472809248000'), 'created_at' => new UTCDateTime('1481032739000')]);
+        $this->seeInDatabase('users', ['first_name' => 'Luis', 'updated_at' => new UTCDateTime('1478008739000'), 'created_at' => new UTCDateTime('1478354339000')]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a little script for casting string dates to ISODate objects on MongoDB records. This will retroactively fix any records that were affected by #513, so the data team can run timeframe queries against them.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
