### PR TITLE
Remove invalid content in the birthdate field.

### DIFF
--- a/app/Console/Commands/FixMongoDatesCommand.php
+++ b/app/Console/Commands/FixMongoDatesCommand.php
@@ -54,6 +54,18 @@ class FixMongoDatesCommand extends Command
             /** @var \Carbon\Carbon $carbon */
             $carbon = $user->{$field};
 
+            // If we get null from the getter, explicitly set that to the field.
+            if (! $carbon) {
+                /** @var \Jenssegers\Mongodb\Query\Builder $collection */
+                $collection = app('db')->collection('users');
+                $collection->where('_id', $user->id)
+                    ->update([$field => null]);
+
+                $this->warn('Removed invalid `'.$field.'` field for '.$user->id.'!');
+
+                continue;
+            }
+
             /** @var \Jenssegers\Mongodb\Query\Builder $collection */
             $collection = app('db')->collection('users');
             $success = $collection

--- a/tests/Console/FixMongoDatesCommandTest.php
+++ b/tests/Console/FixMongoDatesCommandTest.php
@@ -18,6 +18,7 @@ class FixMongoDatesCommandTest extends TestCase
             ['first_name' => 'Bob', 'birthdate' => '10/25/1990'],
             ['first_name' => 'Phil', 'updated_at' => new UTCDateTime('1472809248000'), 'created_at' => '2016-12-06T13:58:59+0000'],
             ['first_name' => 'Luis', 'updated_at' => '2016-11-01T13:58:59+0000', 'created_at' => '2016-11-05T13:58:59+0000'],
+            ['first_name' => 'Frank', 'birthdate' => 'dog'],
         ]);
 
         // Run the magic command on our messy data.
@@ -27,5 +28,6 @@ class FixMongoDatesCommandTest extends TestCase
         $this->seeInDatabase('users', ['first_name' => 'Bob', 'birthdate' => new UTCDateTime('656812800000')]);
         $this->seeInDatabase('users', ['first_name' => 'Phil', 'updated_at' => new UTCDateTime('1472809248000'), 'created_at' => new UTCDateTime('1481032739000')]);
         $this->seeInDatabase('users', ['first_name' => 'Luis', 'updated_at' => new UTCDateTime('1478008739000'), 'created_at' => new UTCDateTime('1478354339000')]);
+        $this->seeInDatabase('users', ['first_name' => 'Frank', 'birthdate' => null]);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Fixes #517. This updates the date casting script to handle situations where the field cannot be salvaged (for example, from when we allowed raw user input to be stored to that field). If something isn't able to be casted, it will now just save as `null`. 

#### How should this be reviewed?
👀 & 🚥 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  


