### PR TITLE
Add a command to backfill missing Drupal accounts.

### DIFF
--- a/app/Console/Commands/BackfillPhoenixAccounts.php
+++ b/app/Console/Commands/BackfillPhoenixAccounts.php
@@ -30,8 +30,7 @@ class BackfillPhoenixAccounts extends Command
      */
     public function fire(Registrar $registrar)
     {
-        // Find all users where the given field is stored as a string type.
-        // @see: https://docs.mongodb.com/manual/reference/operator/query/type/#op._S_type
+        // Find all users with a null `drupal_id` but a non-null `mobile`.
         $users = User::whereNull('drupal_id')
             ->whereNotNull('mobile')
             ->forPage(1, 100000)

--- a/app/Console/Commands/BackfillPhoenixAccounts.php
+++ b/app/Console/Commands/BackfillPhoenixAccounts.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Illuminate\Console\Command;
+use Northstar\Auth\Registrar;
+use Northstar\Models\User;
+
+class BackfillPhoenixAccounts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:backfill_phoenix';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Backfill accounts for any users without a drupal_id.';
+
+    /**
+     * Execute the console command.
+     *
+     * @param Registrar $registrar
+     * @return mixed
+     */
+    public function fire(Registrar $registrar)
+    {
+        // Find all users where the given field is stored as a string type.
+        // @see: https://docs.mongodb.com/manual/reference/operator/query/type/#op._S_type
+        $users = User::whereNull('drupal_id')
+            ->whereNotNull('mobile')
+            ->forPage(1, 100000)
+            ->options(['allowDiskUse' => true])
+            ->get();
+
+        foreach ($users as $user) {
+            /** @var User $user */
+            $user = $registrar->createDrupalUser($user);
+            $user->save();
+
+            if ($user->drupal_id) {
+                $this->info('Created/linked Phoenix account for '.$user->id.' → '.$user->drupal_id);
+            } else {
+                $this->warn('Could not create Phoenix account for '.$user->id);
+            }
+        }
+
+        $this->line('Nice job, we\'re done!');
+    }
+}

--- a/app/Console/Commands/BackfillPhoenixAccounts.php
+++ b/app/Console/Commands/BackfillPhoenixAccounts.php
@@ -38,6 +38,8 @@ class BackfillPhoenixAccounts extends Command
             ->options(['allowDiskUse' => true])
             ->get();
 
+        $this->comment('Found '.count($users).' with a mobile but no Phoenix account! :(');
+
         foreach ($users as $user) {
             /** @var User $user */
             $user = $registrar->createDrupalUser($user);
@@ -50,6 +52,6 @@ class BackfillPhoenixAccounts extends Command
             }
         }
 
-        $this->line('Nice job, we\'re done!');
+        $this->line('Nice job, we\'re done! :)');
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
         \Northstar\Console\Commands\FixMongoDatesCommand::class,
+        \Northstar\Console\Commands\BackfillPhoenixAccounts::class,
     ];
 
     /**

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\UTCDateTime;
  * Base model class
  *
  * @method static \Jenssegers\Mongodb\Query\Builder where(string $field, string $comparison = '=', string $value)
+ * @method static \Jenssegers\Mongodb\Query\Builder whereNull(string $field)
  * @method static \Jenssegers\Mongodb\Query\Builder find(string $id, array $columns=['*'])
  * @method static \Jenssegers\Mongodb\Query\Builder findMany(array $ids)
  * @method static \Jenssegers\Mongodb\Query\Builder findOrFail(string $id, array $columns=['*'])

--- a/tests/Console/BackfillPhoenixAccountsTest.php
+++ b/tests/Console/BackfillPhoenixAccountsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Northstar\Models\User;
+
+class BackfillPhoenixAccountsTest extends TestCase
+{
+    /**
+     * Test that it does the thing its supposed to.
+     * GET /users
+     *
+     * @return void
+     */
+    public function testThatItDoesTheThings()
+    {
+        // Make a ton of test accounts (without Drupal IDs).
+        factory(User::class, 10)->create();
+        $this->assertEquals(10, User::whereNull('drupal_id')->count());
+
+        // Run the magic command on our messy data.
+        $this->artisan('northstar:backfill_phoenix');
+
+        // After running the command, there should be no more empty Drupal IDs.
+        $this->assertEquals(0, User::whereNull('drupal_id')->count());
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This command should (?!) create or link Drupal accounts for any Northstar users who have a `mobile ` but not a `drupal_id` set on their profile. This will prevent fatal Gambit errors for users who were created before #507 was deployed.

#### How should this be reviewed?
Check out the new Artisan command & the included test case. Are there ways this could break things that I haven't thought of? This is so exciting! 🔥

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  