### PR TITLE
Restarting PHP after deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,9 +42,15 @@ namespace :deploy do
     run "cd #{release_path} && php artisan cache:clear"
   end
 
+  task :restart_php do
+    run "sudo /usr/sbin/service php7.0-fpm restart"
+  end
+
 end
 
 after "deploy:update", "deploy:cleanup"
 after "deploy:symlink", "deploy:link_folders"
 after "deploy:link_folders", "deploy:artisan_migrate"
 after "deploy:artisan_migrate", "deploy:artisan_cache_clear"
+after "deploy:artisan_cache_clear", "deploy:restart_php"
+


### PR DESCRIPTION
#### What's this PR do?  
This will restart PHP after the deploy to fix PHP pointing to the wrong release

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---

