### PR TITLE
Fix empty date formatter

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -37,6 +37,10 @@ function normalize($type = null, $value = null)
  */
 function format_date($date, $format = 'M j, Y')
 {
+    if (is_null($date)) {
+        return null;
+    }
+
     try {
         $date = new Carbon($date);
     } catch (InvalidArgumentException $e) {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,9 +1,25 @@
 <?php
 
+use Carbon\Carbon;
 use Northstar\Models\Client;
 
 class HelpersTest extends TestCase
 {
+    /** @test */
+    public function testFormatDate()
+    {
+        // It should format strings that PHP can parse as DateTimes.
+        $this->assertEquals(format_date('10/25/1990'), 'Oct 25, 1990');
+        $this->assertEquals(format_date('1990-10-25'), 'Oct 25, 1990');
+
+        // It should also format Carbon objects.
+        $carbonDate = Carbon::create(1990, 10, 25);
+        $this->assertEquals(format_date($carbonDate), 'Oct 25, 1990');
+
+        // It should return null if null is passed.
+        $this->assertEquals(format_date(null), null);
+    }
+
     /** @test */
     public function testRouteHasAttachedMiddleware()
     {


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes an issue where the `format_date()` helper function would print today's date if given `null` rather than an actual time string or object. I noticed this when testing the Mobile Commons syncer, since many of those users do not have birthdates.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  