### PR TITLE
Add source_detail field.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -114,11 +114,13 @@ class UserController extends Controller
             if ($created_at && ! $existingUserHasEarlierCreatedTimestamp) {
                 $user->created_at = $created_at;
                 $user->source = $request->input('source') ?: client_id();
+                $user->source_detail = $request->input('source_detail');
             }
 
             // Only save a source if not upserting a user (unless back-filling, see above).
             if ($request->has('source') && ! $existingUser) {
                 $user->source = $request->input('source');
+                $user->source_detail = $request->input('source_detail');
             }
         });
 

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -45,6 +45,7 @@ class UserTransformer extends TransformerAbstract
 
             // Signup source (e.g. drupal, cgg, mobile...)
             $response['source'] = $user->source;
+            $response['source_detail'] = $user->source_detail;
 
             // Internal & third-party service IDs:
             $response['slack_id'] = $user->slack_id;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,7 @@ use Northstar\Auth\Role;
  * @property string $photo
  * @property array  $interests
  * @property string $source
+ * @property string $source_detail
  * @property string $role - The user's role, e.g. 'user', 'staff', or 'admin'
  *
  * @property string $addr_street1

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -149,6 +149,7 @@ Either a mobile number or email is required.
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Will only be set on new records, or if being provided an earlier `created_at`.
+  source_detail: String // Only accepted alongside a valid 'source'.
   created_at: Number // timestamp
 
   // Hidden fields (optional):


### PR DESCRIPTION
#### What's this PR do?
This pull request adds an optional `source_detail` field on the user document – this can be used to store extra data about where a user came from (for example, a campaign ID or a SMS opt-in path).

#### How should this be reviewed?
👀

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  