### PR TITLE
Handle Phoenix server exceptions more gracefully.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -4,6 +4,7 @@ namespace Northstar\Auth;
 
 use Closure;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\Factory as Validation;
@@ -224,6 +225,9 @@ class Registrar
                 logger('Encountered error when creating Drupal user', ['user' => $user, 'error' => $e]);
                 app('stathat')->ezCount('error creating drupal uid for user');
             }
+        } catch (ServerException $e) {
+            logger('Encountered error when creating Drupal user', ['user' => $user, 'error' => $e]);
+            app('stathat')->ezCount('error creating drupal uid for user');
         }
 
         return $user;


### PR DESCRIPTION
#### What's this PR do?
If Phoenix returns a 500 error, we should log it and continue along. This is consistent with how we treat other errors (like 422s) from Phoenix.

Fixes #529.

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  