### PR TITLE
Add birthdate to userinfo endpoint.

### DIFF
--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -21,6 +21,7 @@ class UserInfoTransformer extends TransformerAbstract
             'family_name' => $user->last_name,
             'email' => $user->email,
             'phone_number' => $user->mobile,
+            'birthdate' => format_date($user->birthdate, 'Y-m-d'),
 
             'address' => [
                 'street_address' => implode(PHP_EOL, [$user->addr_street1, $user->addr_street2]),

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -289,6 +289,7 @@ curl -X GET \
     "family_name": null,
     "email": "test@dosomething.org",
     "phone_number": "3294927429",
+    "birthdate": "1990-10-25",
     "address": {
       "street_address": "518 Lorenza Creek Suite 862\n",
       "locality": null,

--- a/tests/Http/OAuthTest.php
+++ b/tests/Http/OAuthTest.php
@@ -360,6 +360,7 @@ class OAuthTest extends TestCase
                 'family_name',
                 'email',
                 'phone_number',
+                'birthdate',
 
                 'address' => [
                     'street_address',


### PR DESCRIPTION
#### What's this PR do?
This pull request adds the user's birthdate to the [User Info](https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/auth.md#get-user-info) endpoint. This allows OpenID Connect clients to pull a user's birthday on login, rather than relying on a manual sync to occur.

This is not normally an issue, since Northstar syncs new accounts to the relevant Phoenix instance upon creation. It does mean that changes to a user's profile after initial registration will not be synced into the Phoenix database which was causing some unexpected behavior when working on DoSomething/phoenix#7283.

#### How should this be reviewed?
👀

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  