### PR TITLE
Log password changes.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -74,7 +74,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     protected $fillable = [
-        'email', 'mobile', 'password', 'drupal_password', 'role',
+        'email', 'mobile', 'password', 'role',
 
         'first_name', 'last_name', 'birthdate', 'photo', 'interests',
         'race', 'religion',
@@ -98,7 +98,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $internal = [
-        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'drupal_password', 'role', 'facebook_id', 'slack_id',
+        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'role', 'facebook_id', 'slack_id',
     ];
 
     /**
@@ -222,23 +222,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         $ids = is_array($value) ? $value : array_map('trim', explode(',', $value));
 
         $this->push('parse_installation_ids', $ids, true);
-    }
-
-    /**
-     * Mutator to remove any existing password if we migrate a hashed password.
-     * This is a one-time thing for syncing users from Phoenix and ensuring that
-     * we *only* keep their latest hashed Drupal password.
-     *
-     * @param string $value
-     */
-    public function setDrupalPasswordAttribute($value)
-    {
-        if (isset($this->password)) {
-            $this->drop('password');
-        }
-
-        // The Drupal password is already hashed, don't do it again!
-        $this->attributes['drupal_password'] = $value;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -236,6 +236,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             $this->drop('drupal_password');
         }
 
+        logger('Saving a new password for '.$this->id.' via '.client_id());
         $this->attributes['password'] = bcrypt($value);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -236,7 +236,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             $this->drop('drupal_password');
         }
 
-        logger('Saving a new password for '.$this->id.' via '.client_id());
+        if (! empty($this->attributes['password'])) {
+            logger('Saving a new password for '.$this->id.' via '.client_id());
+        }
+
         $this->attributes['password'] = bcrypt($value);
     }
 

--- a/tests/Auth/DrupalPasswordHashTest.php
+++ b/tests/Auth/DrupalPasswordHashTest.php
@@ -10,7 +10,7 @@ class DrupalPasswordHashTest extends TestCase
      */
     public function testAuthenticatingWithDrupalPassword()
     {
-        $user = User::create([
+        $user = User::forceCreate([
             'email' => 'dries.buytaert@example.com',
             'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
         ]);


### PR DESCRIPTION
#### What's this PR do?
We've had intermittent issues where users end up with "invalid credentials" errors and can't log into their accounts. They're able to log in by resetting their passwords, but this is obviously not ideal.

This pull request adds logging so we can track when & how these accounts' passwords were changed, and also removes the ability to directly set a pre-hashed `drupal_password` on an account.

References #335.

#### How should this be reviewed?
Tests should continue to pass.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  