### PR TITLE
Adding auth db name to connections config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -56,7 +56,7 @@ return [
             'options'  => [
                 env('DB_REPL_SET_NAME') ? ['replicaSet' => env('DB_REPL_SET_NAME', 'rs0')] : [],
                 'database' => env('DB_NAME', 'userapi'),
-            ] ,
+            ],
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -54,7 +54,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'database' => env('DB_NAME', 'userapi'),
             'options'  => [
-                env('DB_REPL_SET_NAME') ? ['replicaSet' => env('DB_REPL_SET_NAME', 'rs0')] : [],
+                'replicaSet' => env('DB_REPL_SET_NAME', 'rs0'),
                 'database' => env('DB_NAME', 'userapi'),
             ],
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -54,7 +54,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'database' => env('DB_NAME', 'userapi'),
             'options'  => [
-                'replicaSet' => env('DB_REPL_SET_NAME', 'rs0'),
+                env('DB_REPL_SET_NAME') ? ['replicaSet' => env('DB_REPL_SET_NAME', 'rs0')] : [],
                 'database' => env('DB_NAME', 'userapi'),
             ],
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -54,7 +54,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'database' => env('DB_NAME', 'userapi'),
             'options'  => [
-                env('DB_REPL_SET_NAME') ? ['replicaSet' => env('DB_REPL_SET_NAME', 'rs0')] : [],
+                'replicaSet' => env('DB_REPL_SET_NAME'),
                 'database' => env('DB_NAME', 'userapi'),
             ],
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,10 @@ return [
             'username' => env('DB_USERNAME', ''),
             'password' => env('DB_PASSWORD', ''),
             'database' => env('DB_NAME', 'userapi'),
-            'options'  => env('DB_REPL_SET_NAME') ? ['replicaSet' => env('DB_REPL_SET_NAME', 'rs0')] : [],
+            'options'  => [
+                env('DB_REPL_SET_NAME') ? ['replicaSet' => env('DB_REPL_SET_NAME', 'rs0')] : [],
+                'database' => env('DB_NAME', 'userapi'),
+            ] ,
         ],
 
     ],


### PR DESCRIPTION
#### What's this PR do?
This fixes this ticket https://github.com/DoSomething/devops/issues/236 where QA Northstar deploys were failing because of the update to the MongoDB package. I updated the format of the database options array to explicitly include authenticating against the db rather than the default admin db.

#### How should this be reviewed?
Check out this deploy https://app.wercker.com/deploystep/589252cb2da796010073b335. This issue here led to a solution. https://github.com/jenssegers/laravel-mongodb/issues/772




