### PR TITLE
Adds Localization middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -27,7 +27,7 @@ class Kernel extends HttpKernel
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Northstar\Http\Middleware\VerifyCsrfToken::class,
-            \Northstar\Http\Middleware\Localization::class,
+            \Northstar\Http\Middleware\SetLanguageFromHeader::class,
         ],
         'api' => [
             \Northstar\Http\Middleware\ParseOAuthHeader::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends HttpKernel
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Northstar\Http\Middleware\VerifyCsrfToken::class,
+            \Northstar\Http\Middleware\localization::class,
         ],
         'api' => [
             \Northstar\Http\Middleware\ParseOAuthHeader::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -27,7 +27,7 @@ class Kernel extends HttpKernel
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Northstar\Http\Middleware\VerifyCsrfToken::class,
-            \Northstar\Http\Middleware\localization::class,
+            \Northstar\Http\Middleware\Localization::class,
         ],
         'api' => [
             \Northstar\Http\Middleware\ParseOAuthHeader::class,

--- a/app/Http/Middleware/Localization.php
+++ b/app/Http/Middleware/Localization.php
@@ -8,20 +8,6 @@ use Illuminate\Support\Facades\Request;
 
 class Localization
 {
-
-    /**
-     * Map the given two letter ISO country code to
-     * one of our supported languages or the fallback language.
-     *
-     * @param  String $countryCode
-     * @return String
-     */
-    public function mapCountryToLanguage($countryCode) {
-        $countryCode = strtolower($countryCode);
-
-
-    }
-
     /**
      * Handle an incoming request.
      *

--- a/app/Http/Middleware/Localization.php
+++ b/app/Http/Middleware/Localization.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use Closure;
+use App;
+use Illuminate\Support\Facades\Request;
+
+class Localization
+{
+
+    /**
+     * Map the given two letter ISO country code to
+     * one of our supported languages or the fallback language.
+     *
+     * @param  String $countryCode
+     * @return String
+     */
+    public function mapCountryToLanguage($countryCode) {
+        $countryCode = strtolower($countryCode);
+
+
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $countryCode = Request::server('HTTP_X_FASTLY_COUNTRY_CODE');
+        if ($countryCode) {
+            switch ($countryCode) {
+                case 'us':
+                    App::setLocale('en');
+                    break;
+                case 'mx':
+                    App::setLocale('es-mx');
+                    break;
+                default:
+                    App::setLocale('en');
+                    break;
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -17,7 +17,7 @@ class SetLanguageFromHeader
      */
     public function handle($request, Closure $next)
     {
-        $countryCode = $request->header('X-Fastly-Country-Code');
+        $countryCode = strtolower($request->header('X-Fastly-Country-Code'));
         if ($countryCode) {
             switch ($countryCode) {
                 case 'us':

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -18,6 +18,7 @@ class SetLanguageFromHeader
     public function handle($request, Closure $next)
     {
         $countryCode = strtolower($request->header('X-Fastly-Country-Code'));
+        $language = 'en';
 
         if ($countryCode) {
             switch ($countryCode) {

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -17,7 +17,7 @@ class Localization
      */
     public function handle($request, Closure $next)
     {
-        $countryCode = Request::server('HTTP_X_FASTLY_COUNTRY_CODE');
+        $countryCode = $request->header('X-Fastly-Country-Code');
         if ($countryCode) {
             switch ($countryCode) {
                 case 'us':

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -19,29 +19,18 @@ class SetLanguageFromHeader
     public function handle($request, Closure $next)
     {
         $countryCode = strtolower($request->header('X-Fastly-Country-Code'));
-        $language = 'en';
 
-        if ($countryCode) {
-            switch ($countryCode) {
-                case 'us':
-                    $language = 'en';
-                    break;
-                case 'mx':
-                    $language = 'es-mx';
-                    break;
-                default:
-                    $language = 'en';
-                    break;
-            }
+        switch ($countryCode) {
+            case 'us':
+                App::setLocale('en');
+                break;
+            case 'mx':
+                App::setLocale('es-mx');
+                break;
+            default:
+                App::setLocale('en');
+                break;
         }
-
-        App::setLocale($language);
-
-        app('JavaScript')->put([
-            'language' => $language,
-        ]);
-
-        Session::flash('language', $language);
 
         return $next($request);
     }

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -6,7 +6,7 @@ use Closure;
 use App;
 use Illuminate\Support\Facades\Request;
 
-class Localization
+class SetLanguageFromHeader
 {
     /**
      * Handle an incoming request.

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -4,7 +4,6 @@ namespace Northstar\Http\Middleware;
 
 use Closure;
 use App;
-use Session;
 use Illuminate\Support\Facades\Request;
 
 class SetLanguageFromHeader

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -18,19 +18,25 @@ class SetLanguageFromHeader
     public function handle($request, Closure $next)
     {
         $countryCode = strtolower($request->header('X-Fastly-Country-Code'));
+
         if ($countryCode) {
             switch ($countryCode) {
                 case 'us':
-                    App::setLocale('en');
+                    $language = 'en';
                     break;
                 case 'mx':
-                    App::setLocale('es-mx');
+                    $language = 'es-mx';
                     break;
                 default:
-                    App::setLocale('en');
+                    $language = 'en';
                     break;
             }
         }
+
+        App::setLocale($language);
+        app('JavaScript')->put([
+            'language' => $language,
+        ]);
 
         return $next($request);
     }

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -4,7 +4,6 @@ namespace Northstar\Http\Middleware;
 
 use Closure;
 use App;
-use Illuminate\Support\Facades\Request;
 
 class SetLanguageFromHeader
 {

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -4,6 +4,7 @@ namespace Northstar\Http\Middleware;
 
 use Closure;
 use App;
+use Session;
 use Illuminate\Support\Facades\Request;
 
 class SetLanguageFromHeader
@@ -35,9 +36,12 @@ class SetLanguageFromHeader
         }
 
         App::setLocale($language);
+
         app('JavaScript')->put([
             'language' => $language,
         ]);
+
+        Session::flash('language', $language);
 
         return $next($request);
     }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ Session::get('language') }}">
 
 <head>
     <meta charset="UTF-8">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ Session::get('language') }}">
+<html lang="{{ App::getLocale() }}">
 
 <head>
     <meta charset="UTF-8">

--- a/tests/Http/LocalizationTest.php
+++ b/tests/Http/LocalizationTest.php
@@ -12,7 +12,8 @@ class LocalizationTest extends TestCase
         $this->assertEquals(App::getLocale(), 'es-mx');
     }
 
-    public function testUnsupportedCountry() {
+    public function testUnsupportedCountry()
+    {
         $this->get('/', ['X-FASTLY-COUNTRY-CODE' => 'FR']);
         $this->assertEquals(App::getLocale(), 'en');
     }

--- a/tests/Http/LocalizationTest.php
+++ b/tests/Http/LocalizationTest.php
@@ -2,7 +2,6 @@
 
 class LocalizationTest extends TestCase
 {
-
     /**
      * Test that the correct Fastly header is applied for the given header.
      */

--- a/tests/Http/LocalizationTest.php
+++ b/tests/Http/LocalizationTest.php
@@ -1,8 +1,5 @@
 <?php
 
-use App as App;
-use Northstar\Models\User;
-
 class LocalizationTest extends TestCase
 {
 
@@ -11,7 +8,7 @@ class LocalizationTest extends TestCase
      */
     public function testAppLocale()
     {
-        $this->call('GET', '/', [], [], [], ['HTTP_X_FASTLY_COUNTRY_CODE' => 'MX']);
+        $this->get('/', ['X-FASTLY-COUNTRY-CODE' => 'MX']);
         $this->assertEquals(App::getLocale(), 'es-mx');
     }
 }

--- a/tests/Http/LocalizationTest.php
+++ b/tests/Http/LocalizationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App as App;
+use Northstar\Models\User;
+
+class LocalizationTest extends TestCase
+{
+
+    /**
+     * Test that the correct Fastly header is applied for the given header.
+     */
+    public function testAppLocale()
+    {
+        $this->call('GET', '/', [], [], [], ['HTTP_X_FASTLY_COUNTRY_CODE' => 'MX']);
+        $this->assertEquals(App::getLocale(), 'es-mx');
+    }
+}

--- a/tests/Http/LocalizationTest.php
+++ b/tests/Http/LocalizationTest.php
@@ -3,7 +3,7 @@
 class LocalizationTest extends TestCase
 {
     /**
-     * Test that the correct Fastly header is applied for the given header.
+     * Test that the correct language is applied for the supported header.
      */
     public function testSupportedCountry()
     {
@@ -11,6 +11,9 @@ class LocalizationTest extends TestCase
         $this->assertEquals(App::getLocale(), 'es-mx');
     }
 
+    /**
+     * Test that the default language is applied for an unsupported header.
+     */
     public function testUnsupportedCountry()
     {
         $this->get('/', ['X-FASTLY-COUNTRY-CODE' => 'FR']);

--- a/tests/Http/LocalizationTest.php
+++ b/tests/Http/LocalizationTest.php
@@ -6,9 +6,14 @@ class LocalizationTest extends TestCase
     /**
      * Test that the correct Fastly header is applied for the given header.
      */
-    public function testAppLocale()
+    public function testSupportedCountry()
     {
         $this->get('/', ['X-FASTLY-COUNTRY-CODE' => 'MX']);
         $this->assertEquals(App::getLocale(), 'es-mx');
+    }
+
+    public function testUnsupportedCountry() {
+        $this->get('/', ['X-FASTLY-COUNTRY-CODE' => 'FR']);
+        $this->assertEquals(App::getLocale(), 'en');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Adds Localization middleware to accept Fastly headers and convert that into a language.

#### How should this be reviewed?
1. To check it works I did a `dd(App::getLocale());` on the index route, which works as expected (Use ModHeader to change your fastly header).
2. Was attempting to write a test for this, but running into a wall here.

```
    public function testAppLocale()
    {
        $this->call('GET', '/', [], [], [], ['HTTP_X_FASTLY_COUNTRY_CODE' => 'MX']);
        $this->assertEquals(App::getLocale(), 'es-mx');
    }
```

The assertion fails here, getLocale returns `en`. Any ideas on how to properly test this?

#### Checklist
- [ ] Tests added for new features/bug fixes.