### PR TITLE
Add logging when auth codes are created/revoked/compared.

### DIFF
--- a/app/Auth/Repositories/AuthCodeRepository.php
+++ b/app/Auth/Repositories/AuthCodeRepository.php
@@ -26,6 +26,12 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
     {
+        logger('created new auth code', [
+            'code' => $authCodeEntity->getIdentifier(),
+            'user_id' => $authCodeEntity->getUserIdentifier(),
+            'client_id' => $authCodeEntity->getClient()->getIdentifier(),
+        ]);
+
         AuthCode::create([
             'code' => $authCodeEntity->getIdentifier(),
             'scopes' => $authCodeEntity->getScopes(),
@@ -43,6 +49,8 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function revokeAuthCode($codeId)
     {
+        logger('revoked auth code', ['code' => $codeId]);
+
         AuthCode::where('code', $codeId)->delete();
     }
 
@@ -54,6 +62,10 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        return ! AuthCode::where('code', $codeId)->exists();
+        $exists = ! AuthCode::where('code', $codeId)->exists();
+
+        logger('checked auth code', ['code' => $codeId, 'exists' => $exists]);
+
+        return $exists;
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request adds logging for the auth code "lifecycle" – when codes are created, compared, and revoked. This will help in debugging DoSomething/phoenix#7304.

#### How should this be reviewed?
![LOG!](https://i.ytimg.com/vi/2C7mNr5WMjA/hqdefault.jpg)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  