### PR TITLE
Don't report authentication exceptions to the log.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -27,6 +27,7 @@ class Handler extends ExceptionHandler
      * @var array
      */
     protected $dontReport = [
+        AuthenticationException::class,
         AuthorizationException::class,
         HttpException::class,
         OAuthServerException::class,


### PR DESCRIPTION
#### What's this PR do?
This pull request silences `AuthenticationException`s from being output to the log file since this was adding a ton of unnecessary noise (as users who go through the auth flow will always trigger one on their first time logging in during a session).

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  