### PR TITLE
Fix incorrect label on log.

### DIFF
--- a/app/Auth/Repositories/AuthCodeRepository.php
+++ b/app/Auth/Repositories/AuthCodeRepository.php
@@ -62,10 +62,10 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
      */
     public function isAuthCodeRevoked($codeId)
     {
-        $exists = ! AuthCode::where('code', $codeId)->exists();
+        $exists = AuthCode::where('code', $codeId)->exists();
 
         logger('checked auth code', ['code' => $codeId, 'exists' => $exists]);
 
-        return $exists;
+        return ! $exists;
     }
 }


### PR DESCRIPTION
#### What's this PR do?
I'm a real dummy and accidentally logged the opposite of `exists` on this line (see the location of the `!` before and after for details). This made the logs real confusing. 💩

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  