### PR TITLE
Adds EN Localization & translation functions to all auth templates

### DIFF
--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -54,5 +54,5 @@ return [
         'terms_of_service' => 'Terms of Service',
         'privacy_policy' => 'Privacy Policy',
         'messaging' => 'and to receive our weekly update. Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.',
-    ]
+    ],
 ];

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+    'greeting' => [
+        'lets_do_this' => 'Let\'s do this!',
+    ],
+    'log_in' => [
+        'default' => 'Log In',
+        'existing' => 'Log in to an existing account',
+        'create' => 'Create a DoSomething.org account',
+    ],
+    'get_started' => [
+        'log_in' => 'Log in to get started!',
+        'create_account' => 'Create a DoSomething.org account to get started!',
+    ],
+    'validation' => [
+        'issues' => 'Hmm, there were some issues with that submission:',
+        'optional' => '(optional)',
+        'auth' => [
+            'email' => 'Email address is required.',
+        ],
+        'signup' => [
+            'birthday' => 'We need your birthday',
+            'first_name' => 'We need your name',
+            'email' => 'We need a valid email',
+            'password_length' => 'Must be 6+ characters',
+        ]
+    ],
+    'fields' => [
+        'email' => 'Email address',
+        'mobile' => 'Cell Number',
+        'email_or_mobile' => 'Email address or cell number',
+        'first_name' => 'First Name',
+        'birthday' => 'Birthday',
+        'password' => 'Password',
+        'confirm_password' => 'Confirm Password',
+        'new_password' => 'New Password',
+        'confirm_new_password' => 'Confirm New Password',
+    ],
+    'forgot_password' => [
+        'header' => 'Forgot your password?',
+        'instructions' => 'We\'ve all been there. Reset by entering your email',
+    ],
+    'footnote' => [
+        'create' => 'Creating an account means you agree to our',
+        'terms_of_service' => 'Terms of Service',
+        'privacy_policy' => 'Privacy Policy',
+        'messaging' => 'and to receive our weekly update. Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.',
+    ]
+];

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -8,6 +8,7 @@ return [
         'default' => 'Log In',
         'existing' => 'Log in to an existing account',
         'create' => 'Create a DoSomething.org account',
+        'submit' => 'Create New Account',
     ],
     'get_started' => [
         'log_in' => 'Log in to get started!',
@@ -24,7 +25,13 @@ return [
             'first_name' => 'We need your name',
             'email' => 'We need a valid email',
             'password_length' => 'Must be 6+ characters',
-        ]
+        ],
+        'placeholder' => [
+            'call_you' => 'What do we call you?',
+            'birthday' => 'MM/DD/YYYY',
+            'password' => '6+ characters... make it tricky!',
+            'double_checking' => 'Just double checking!',
+        ],
     ],
     'fields' => [
         'email' => 'Email address',

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -46,7 +46,8 @@ return [
     ],
     'forgot_password' => [
         'header' => 'Forgot your password?',
-        'instructions' => 'We\'ve all been there. Reset by entering your email',
+        'instructions' => 'We\'ve all been there. Reset by entering your email.',
+        'request' => 'Request New Password',
     ],
     'footnote' => [
         'create' => 'Creating an account means you agree to our',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,14 +8,14 @@
     @endif
 
     <div class="container__block -centered">
-        <h2 class="heading -alpha">Let's do this!</h2>
+        <h2 class="heading -alpha">{{ trans('auth.greeting.lets_do_this') }}</h2>
         <h3>Log in to continue to {{ session('destination', 'DoSomething.org') }}.</h3>
     </div>
 
     <div class="container__block">
         @if (count($errors) > 0)
             <div class="validation-error fade-in-up">
-                <h4>Hmm, there were some issues with that submission:</h4>
+                <h4>{{ trans('auth.validation.issues') }}</h4>
                 <ul class="list -compacted">
                     @foreach ($errors->all() as $error)
                         <li>{{ $error }}</li>
@@ -30,7 +30,7 @@
             <div class="form-item">
                 <label for="username" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">Email address or cell number <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.email_or_mobile') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
@@ -40,7 +40,7 @@
             <div class="form-item">
                 <label for="password" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">Password <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.password') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
@@ -48,15 +48,15 @@
             </div>
 
             <div class="form-actions -padded">
-                <input type="submit" class="button" value="Log In">
+                <input type="submit" class="button" value="{{ trans('auth.log_in.default') }}">
             </div>
         </form>
     </div>
 
     <div class="container__block -centered">
         <ul>
-            <li><a href="{{ url('register') }}">Create a DoSomething.org account</a></li>
-            <li><a href="{{ url('password/reset') }}">Forgot your password?</a></li>
+            <li><a href="{{ url('register') }}">{{ trans('auth.log_in.create') }}</a></li>
+            <li><a href="{{ url('password/reset') }}">{{ trans('auth.forgot_password.header') }}</a></li>
         </ul>
     </div>
 @stop

--- a/resources/views/auth/password.blade.php
+++ b/resources/views/auth/password.blade.php
@@ -6,13 +6,13 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -centered">
-                <h1>Forgot your password?</h1>
-                <h3>We’ve all been there. Reset by entering your email.</h3>
+                <h1>{{ trans('auth.forgot_password.header') }}</h1>
+                <h3>{{ trans('auth.forgot_password.instructions') }}</h3>
             </div>
             <div class="container__block -centered">
                 @if (count($errors) > 0)
                     <div class="validation-error fade-in-up">
-                        <h4>Hmm, there were some issues with that submission:</h4>
+                        <h4>{{ trans('auth.validation.issues') }}</h4>
                         <ul class="list -compacted">
                             @foreach ($errors->all() as $error)
                                 <li>{{ $error }}</li>
@@ -25,19 +25,19 @@
                     {{ csrf_field() }}
 
                     <div class="form-item">
-                        <label for="email" class="field-label">Email address</label>
+                        <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
                         <input name="email" type="text" class="text-field" placeholder="puppet-sloth@example.org" value="{{ $email or old('email') }}">
                     </div>
 
                     <div class="form-actions -padded">
-                        <input type="submit" class="button" value="Request New Password">
+                        <input type="submit" class="button" value="{{ trans('auth.forgot_password.request') }}">
                     </div>
                 </form>
             </div>
             <div class="container__block -centered">
                 <ul>
-                    <li><a href="{{ url('login') }}">Log in to an existing account</a></li>
-                    <li><a href="{{ url('register') }}">Create a DoSomething.org account</a></li>
+                    <li><a href="{{ url('login') }}">{{ trans('auth.log_in.existing') }}</a></li>
+                    <li><a href="{{ url('register') }}">{{ trans('auth.log_in.create') }}</a></li>
                 </ul>
             </div>
         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -4,13 +4,13 @@
 
 @section('content')
     <div class="container__block -centered">
-        <h1>Create a DoSomething.org account to get started!</h1>
+        <h1>{{ trans('auth.get_started.create_account') }}</h1>
     </div>
 
     <div class="container__block -centered">
         @if (count($errors) > 0)
             <div class="validation-error fade-in-up">
-                <h4>Hmm, there were some issues with that submission:</h4>
+                <h4>{{ trans('auth.validation.issues') }}</h4>
                 <ul class="list -compacted">
                     @foreach ($errors->all() as $error)
                         <li>{{ $error }}</li>
@@ -25,27 +25,27 @@
             <div class="form-item">
                 <label for="first_name" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">First Name <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.first_name') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
-                <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="What do we call you?" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
+                <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
             </div>
 
             <div class="form-item">
                 <label for="birthdate" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">Birthday <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.birthday') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
-                <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="MM/DD/YYYY" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
             </div>
 
             <div class="form-item">
                 <label for="email" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">Email address <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.email') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
@@ -53,46 +53,45 @@
             </div>
 
             <div class="form-item">
-                <label for="mobile" class="field-label">Cell Number <em>(optional)</em></label>
+                <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
                 <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
             </div>
 
             <div class="form-item">
                 <label for="password" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">Password <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.password') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
-                <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="6+ characters... make it tricky!" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
+                <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
             </div>
 
             <div class="form-item">
                 <label for="password_confirmation" class="field-label">
                     <div class="validation">
-                        <div class="validation__label">Confirm Password <span class="form-required" title="This field is required.">*</span></div>
+                        <div class="validation__label">{{ trans('auth.fields.confirm_password') }} <span class="form-required" title="This field is required.">*</span></div>
                         <div class="validation__message"></div>
                     </div>
                 </label>
-                <input name="password_confirmation" type="password" id="password_confirmation" class="text-field required js-validate" placeholder="Just double checking!" data-validate="match" data-validate-required data-validate-match="#password" />
+                <input name="password_confirmation" type="password" id="password_confirmation" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.double_checking') }}" data-validate="match" data-validate-required data-validate-match="#password" />
             </div>
 
             <div class="form-actions -padded">
-                <input type="submit" class="button" value="Create New Account">
+                <input type="submit" class="button" value="{{ trans('auth.log_in.submit') }}">
             </div>
         </form>
     </div>
 
     <div class="container__block -centered">
         <ul>
-            <li><a href="{{ url('login') }}">Log in to an existing account</a></li>
+            <li><a href="{{ url('login') }}">{{ trans('auth.log_in.existing') }}</a></li>
         </ul>
     </div>
 
     <div class="container__block -centered">
-        <p class="footnote">Creating an account means you agree to our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service</a>
-            &amp; <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> and to receive our weekly update.
-            Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.</p>
+        <p class="footnote">{{ trans('auth.footnote.create') }} <a href="https://www.dosomething.org/us/about/terms-service">{{ trans('auth.footnote.terms_of_service') }}</a>
+            &amp; <a href="https://www.dosomething.org/us/about/privacy-policy">{{ trans('auth.footnote.privacy_policy') }}</a> {{ trans('auth.footnote.messaging') }}</p>
     </div>
 
 @stop

--- a/resources/views/auth/reset.blade.php
+++ b/resources/views/auth/reset.blade.php
@@ -6,13 +6,13 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -centered">
-                <h1>Forgot your password?</h1>
-                <h3>We’ve all been there. Reset by entering your email.</h3>
+                <h1>{{ trans('auth.forgot_password.header') }}</h1>
+                <h3>{{ trans('auth.forgot_password.instructions') }}</h3>
             </div>
             <div class="container__block -centered">
                 @if (count($errors) > 0)
                     <div class="validation-error fade-in-up">
-                        <h4>Hmm, there were some issues with that submission:</h4>
+                        <h4>{{ trans('auth.validation.issues') }}</h4>
                         <ul class="list -compacted">
                             @foreach ($errors->all() as $error)
                                 <li>{{ $error }}</li>
@@ -27,17 +27,17 @@
                     <input type="hidden" name="token" value="{{ $token }}">
 
                     <div class="form-item">
-                        <label for="email" class="field-label">Email address</label>
+                        <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
                         <input name="email" type="text" class="text-field" placeholder="puppet-sloth@example.org" value="{{ $email or old('email') }}">
                     </div>
 
                     <div class="form-item">
-                        <label for="password" class="field-label">New Password</label>
+                        <label for="password" class="field-label">{{ trans('auth.fields.new_password') }}</label>
                         <input name="password" type="password" class="text-field" placeholder="••••••">
                     </div>
 
                     <div class="form-item">
-                        <label for="password_confirmation" class="field-label">Confirm New Password</label>
+                        <label for="password_confirmation" class="field-label">{{ trans('auth.fields.confirm_new_password') }}</label>
                         <input name="password_confirmation" type="password" class="text-field" placeholder="••••••">
                     </div>
 
@@ -48,8 +48,8 @@
             </div>
             <div class="container__block -centered">
                 <ul>
-                    <li><a href="{{ url('login') }}">Log in to an existing account</a></li>
-                    <li><a href="{{ url('register') }}">Create a DoSomething.org account</a></li>
+                    <li><a href="{{ url('login') }}">{{ trans('auth.log_in.existing') }}</a></li>
+                    <li><a href="{{ url('register') }}">{{ trans('auth.log_in.create') }}</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
#### What's this PR do?
This PR adds `{{ trans('...') }}` literally everywhere, and my take for the translation file structure (In EN only).

Once this PR is merged I'll add the `es-mx` translations

Questions
- I assume the `validation.php` is what's being used for server errors, looking at most of these I don't think we have 1:1 translations. How should we proceed?
- Off the top of your head, are there strings anywhere in the code I should be searching for, or is everything we need to worry about in the templates?

#### How should this be reviewed?
I've checked all of the templates to make sure the strings are still rendering correctly, (if the translation name is wrong then it displays that instead)

![screen shot 2017-02-07 at 3 48 45 pm](https://cloud.githubusercontent.com/assets/897368/22711063/c94926b2-ed4d-11e6-8b21-b9b4474391ed.png)
![screen shot 2017-02-07 at 3 48 53 pm](https://cloud.githubusercontent.com/assets/897368/22711060/c9410680-ed4d-11e6-8d2e-51bc95175c6f.png)
![screen shot 2017-02-07 at 3 49 01 pm](https://cloud.githubusercontent.com/assets/897368/22711061/c946cb38-ed4d-11e6-8290-7cfb95abf611.png)
![screen shot 2017-02-07 at 3 49 06 pm](https://cloud.githubusercontent.com/assets/897368/22711062/c947936a-ed4d-11e6-8e16-2d18d2afafd7.png)
