### PR TITLE
Disable inputs & validation depending on language

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -20,8 +20,9 @@ window.Drupal = {
 import Analytics from './utilities/Analytics';
 import DeLorean from './utilities/DeLorean';
 
-// Register validation rules.
-import './validators/auth';
+// Register validation rules for en lang only.
+if (document.documentElement.lang === 'en') require('./validators/auth');
+
 
 // Initialize analytics.
 Analytics.init();

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -52,10 +52,12 @@
                 <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
             </div>
 
-            <div class="form-item">
-                <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
-                <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
-            </div>
+            @if (App::getLocale() === 'en')
+                <div class="form-item">
+                    <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
+                    <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
+                </div>
+            @endif
 
             <div class="form-item">
                 <label for="password" class="field-label">


### PR DESCRIPTION
#### What's this PR do?
- Disables JS field validation for non-US
- Disables mobile input for non-US

#### How should this be reviewed?

Mobile disable (This branch didn't have the Spanish translations merged in yet, so note the highlighted HTML)

![screen shot 2017-02-08 at 11 15 26 am](https://cloud.githubusercontent.com/assets/897368/22746392/906f0146-edf1-11e6-9581-c2cf7f27dc55.png)

Validation disable

_Spanish_
![screen shot 2017-02-08 at 11 22 55 am](https://cloud.githubusercontent.com/assets/897368/22746442/ad3d915c-edf1-11e6-991a-be1ca4f4da46.png)

_English_
![screen shot 2017-02-08 at 11 23 14 am](https://cloud.githubusercontent.com/assets/897368/22746443/ad3f9182-edf1-11e6-81a8-e576b0648680.png)