### PR TITLE
Fix Mexico login/registration

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -21,7 +21,12 @@ import Analytics from './utilities/Analytics';
 import DeLorean from './utilities/DeLorean';
 
 // Register validation rules for en lang only.
-if (document.documentElement.lang === 'en') require('./validators/auth');
+if (document.documentElement.lang !== 'en') {
+  const $ = require('jquery');
+  $('[data-validate]').each(input => $(input).removeAttr('data-validate'));
+}
+
+import Validation from './validators/auth';
 
 
 // Initialize analytics.

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -19,15 +19,13 @@ window.Drupal = {
 // Utilities
 import Analytics from './utilities/Analytics';
 import DeLorean from './utilities/DeLorean';
+import Validation from './validators/auth';
 
 // Register validation rules for en lang only.
 if (document.documentElement.lang !== 'en') {
   const $ = require('jquery');
   $('[data-validate]').each(input => $(input).removeAttr('data-validate'));
 }
-
-import Validation from './validators/auth';
-
 
 // Initialize analytics.
 Analytics.init();

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -24,7 +24,7 @@ import Validation from './validators/auth';
 // Register validation rules for en lang only.
 if (document.documentElement.lang !== 'en') {
   const $ = require('jquery');
-  $('[data-validate]').each(input => $(input).removeAttr('data-validate'));
+  $('input').attr('data-validate', null);
 }
 
 // Initialize analytics.


### PR DESCRIPTION
#### What's this PR do?
Previously I was only importing the validation functions if the users lang was English. However the data attributes still existed which broke our ds-validation module

![screen shot 2017-02-15 at 2 38 44 pm](https://cloud.githubusercontent.com/assets/897368/22992782/c435e6be-f38e-11e6-9410-73a4e353d56b.png)

This PR instead,
 - checks user lang
 - if not equal to en
   - remove all `data-validate` attributes

#### How should this be reviewed?
Can you register in both ES-MX and EN?

🇲🇽 