### PR TITLE
Experimental: Fast mode.

### DIFF
--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -90,7 +90,7 @@ trait TransformsResponses
         $pages = (int) $request->query('limit', 20);
 
         // Experimental: Should we go at warp speed?
-        $fastMode = $request->query('speed') === 'fast';
+        $fastMode = $request->query('pagination') === 'cursor';
         if ($fastMode) {
             $paginator = $query->simplePaginate(min($pages, 100));
         } else {

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -9,6 +9,7 @@ GET /v1/users
 
 **Additional Query Parameters:**
 
+- `pagination`: __[Experimental]__ Either "standard" or "cursor". Cursor pagination is _significantly_ faster, but does not provide any information on the total number of results (only whether another page exists).
 - `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v1/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.


### PR DESCRIPTION
#### What's this PR do?
This adds an experimental "fast mode" which _significantly_ speeds up the `v1/users` index __from around 7 seconds to 142ms on Thor__ by using a database cursor rather than "full" pagination. 🚀 

The downside is that we lose some information in the `meta.pagination` portion of the response (the total number of pages & results), but that seems like a fair trade-off for iterating over a huge dataset.

#### Tell me more!
Standard pagination (where it splits the total results into pages) requires an extra query to get the total sum of the query, which is apparently known to be slow with large datasets in MongoDB.

```js
// the (slow) aggregation query (7.09ms on my local)
users.aggregate([{"$group":{"aggregate":{"$sum":1},"_id":null}}],{"typeMap":{"root":"array","document":"array"}});

// the (much faster) result window query (0.68ms on my local)
users.aggregate([{"$limit":20}],{"typeMap":{"root":"array","document":"array"}});
```

The "cursor" pagination _only_ makes that second query for `$limit + 1`.

#### How should this be reviewed?
I deployed this branch on Thor, so feel free to test it out:

```
GET https://northstar-thor.dosomething.org/v1/users?speed=fast
```

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @sheyd @weerd @deadlybutter