### PR TITLE
Merge endpoint fixes and model setter fixes.

### DIFF
--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -79,8 +79,8 @@ class MergeController extends Controller
         }
 
         // Save the changes to the two accounts.
-        $target->save();
         $duplicate->save();
+        $target->save();
 
         return $this->item($target, 200, [
             'updated' => array_keys($duplicateFields),

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -55,7 +55,9 @@ class MergeController extends Controller
 
         // Copy the "duplicate" account's fields to the target & unset on the dupe account.
         $target->fill($duplicateFields);
-        $duplicate->unset($duplicateFieldNames);
+        foreach ($duplicateFieldNames as $field) {
+            $duplicate->$field = null;
+        }
 
         if (empty($duplicate->email) && empty($duplicate->mobile)) {
             $duplicate->email = 'merged-account-'.$target->id.'@dosomething.invalid';

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -71,7 +71,11 @@ class MergeController extends Controller
 
         // Are we "pretending" for this request? If so, short-circuit and display the (unsaved) result.
         if ($request->query('pretend', false)) {
-            return $this->item($target, 200, ['updated' => array_keys($duplicateFields)]);
+            return $this->item($target, 200, [
+                'pretending' => true,
+                'updated' => array_keys($duplicateFields),
+                'duplicate' => $duplicate->toArray(),
+            ]);
         }
 
         // Save the changes to the two accounts.
@@ -80,7 +84,7 @@ class MergeController extends Controller
 
         return $this->item($target, 200, [
             'updated' => array_keys($duplicateFields),
-            'duplicate' => $duplicate,
+            'duplicate' => $duplicate->toArray(),
         ]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -235,14 +235,15 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setPasswordAttribute($value)
     {
         if (isset($this->drupal_password)) {
-            $this->drop('drupal_password');
+            $this->drupal_password = null;
         }
 
         if (! empty($this->attributes['password'])) {
             logger('Saving a new password for '.$this->id.' via '.client_id());
         }
 
-        $this->attributes['password'] = bcrypt($value);
+        // Only hash and set password if not empty.
+        $this->attributes['password'] = $value ? bcrypt($value) : null;
     }
 
     /**

--- a/tests/Http/MergeTest.php
+++ b/tests/Http/MergeTest.php
@@ -33,7 +33,6 @@ class MergeTest extends TestCase
             'email' => 'target-account@example.com',
             'first_name' => 'Phil',
             'last_name' => 'Dunfy',
-            'birthdate' => '1994-02-26',
             'addr_street1' => '19 W 21st St',
             'city' => 'New York',
             'addr_state' => 'NY',


### PR DESCRIPTION
#### What's this PR do?
This pull request includes a few tiny fixes for the `v1/users/:id/merge` endpoint, and a pretty important update to how Northstar handles unsetting fields on the MongoDB document.

🍃 Hooks into `performInsert` and `performUpdate` for unsetting fields from Mongo document.

⏫ Fixes an order-of-operations mix-up where we were trying to set the "merged" fields on the target user before removing them from the "dupe", which was causing a database constraint error.

🏷 Update the "pretend" response to show the same things as the real thing.

#### How should this be reviewed?
Looks like Wercker still hasn't figured out how to talk to this repository after the Docker switch, so here's a link to the [latest build](https://app.wercker.com/dosomething/northstar/runs/build/58f9273b8820930001529ec3?step=58f9276e8380e70001ae6534). 🚥 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: @weerd