### PR TITLE
Make sure country userinfo response is valid.

### DIFF
--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -28,7 +28,7 @@ class UserInfoTransformer extends TransformerAbstract
                 'locality' => $user->addr_city,
                 'region' => $user->addr_state,
                 'postal_code' => $user->addr_zip,
-                'country' => $user->country,
+                'country' => strlen($user->country) === 2 ? $user->country : null,
             ],
 
             'updated_at' => $user->updated_at->timestamp,


### PR DESCRIPTION
#### What's this PR do?
This pull request is a quick follow-up to #563: I had forgotten to update the `v2/auth/info` response as well (which is what provides the `country` field to Phoenix during the login process).

#### How should this be reviewed?
Here's the [Wercker build](https://app.wercker.com/dosomething/northstar/runs/build/5900b92ef71af600010d6d11?step=5900b92ef71af600010d6d16).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  