### PR TITLE
Discard invalid country code fields in accessor.

### DIFF
--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -28,7 +28,7 @@ class UserInfoTransformer extends TransformerAbstract
                 'locality' => $user->addr_city,
                 'region' => $user->addr_state,
                 'postal_code' => $user->addr_zip,
-                'country' => strlen($user->country) === 2 ? $user->country : null,
+                'country' => $user->country,
             ],
 
             'updated_at' => $user->updated_at->timestamp,

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -55,9 +55,7 @@ class UserTransformer extends TransformerAbstract
         }
 
         $response['language'] = $user->language;
-
-        // Ensure we only return 2-letter country codes.
-        $response['country'] = strlen($user->country) === 2 ? $user->country : null;
+        $response['country'] = $user->country;
 
         // Drupal ID for this user. Used in the mobile app.
         $response['drupal_id'] = $user->drupal_id;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -214,6 +214,23 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Accessor for the `country` field.
+     *
+     * @return string
+     */
+    public function getCountryAttribute()
+    {
+        if (empty($this->attributes['country'])) {
+            return null;
+        }
+
+        $countryCode = Str::upper($this->attributes['country']);
+        $isValid = get_countries()->has($countryCode);
+
+        return $isValid ? $countryCode : null;
+    }
+
+    /**
      * Mutator for the `country` field.
      *
      * @param $value

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -244,6 +244,34 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test that the `country` field is removed if it
+     * does not contain a valid ISO-3166 country code.
+     * GET /users/:term/:id
+     *
+     * @return void
+     */
+    public function testSanitizesInvalidCountryCode()
+    {
+        $user = factory(User::class)->create([
+            'email' => 'antonia.anderson@example.com',
+            'country' => 'United States',
+        ]);
+
+        $this->asAdminUser()->json('POST', 'v1/users', [
+            'email' => 'antonia.anderson@example.com',
+            'first_name' => 'Antonia',
+        ]);
+
+        // We should not see a validation error.
+        $this->assertResponseStatus(200);
+
+        // The user should be updated & their invalid country removed.
+        $user = $user->fresh();
+        $this->assertEquals('Antonia', $user->first_name);
+        $this->assertEquals(null, $user->country);
+    }
+
+    /**
      * Test that the `country` field is validated.
      * GET /users/:term/:id
      *


### PR DESCRIPTION
#### What's this PR do?
Some [northstar-mobilecommonsd](https://github.com/DoSomething/northstar-mobilecommonsd) jobs were failing because the users didn't have valid ISO-3166 country codes. This is happening because we merge changes into the existing account before validating (to ensure, for example, that we can't remove one of the required indexes).

Because of that, users with invalid data in the `country` field are now effectively "locked" until we fix it... whoops. This pull request sanitizes any bad data on-demand when accessing that field.

#### How should this be reviewed?
I added a test case demonstrating this new behavior. We should also give a little thought to the general approach in case there's a better way we could be handling this in the future.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  