### PR TITLE
Allow setting a specific trusted proxy.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ DS_ENABLE_PASSWORD_RESET=true
 # DB_AUTH_NAME=admin
 # DB_SSL=false
 
+# If running behind a load balancer, specify which
+# addresses to trust `X-Forwarded-For` headers from.
+# TRUSTED_PROXY_IP_ADDRESS=
+
 DRUPAL_API_URL=http://dev.dosomething.org:8888
 DRUPAL_API_USERNAME=username
 DRUPAL_API_PASSWORD=password

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -18,7 +18,7 @@ return [
      * no matter how many proxies that client's request has subsequently passed through.
      */
     'proxies' => [
-        '*',
+        env('TRUSTED_PROXY_IP_ADDRESS'),
     ],
 
     /*


### PR DESCRIPTION
#### What's this PR do?
This pull request allows us to set a specific trusted proxy (in our case, HAProxy) so we don't trust just anyone's `X-Forwarded-For` header and let them do malicious things! 

#### How should this be reviewed?
With yer eyes! 👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  