### PR TITLE
Add rate limiting to authentication & registration endpoints.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,9 @@ DS_ENABLE_PASSWORD_RESET=true
 # DB_AUTH_NAME=admin
 # DB_SSL=false
 
-# If running behind a load balancer, specify which
-# addresses to trust `X-Forwarded-For` headers from.
-# TRUSTED_PROXY_IP_ADDRESS=
+# If running behind a load balancer, specify which IP addresses (for
+# example, HAProxy or Fastly) to trust `X-Forwarded-For` headers from.
+# TRUSTED_PROXY_IP_ADDRESSES=
 
 DRUPAL_API_URL=http://dev.dosomething.org:8888
 DRUPAL_API_USERNAME=username

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=SomeRandomString
 
+# Feature Flags
 DS_ENABLE_PASSWORD_RESET=true
+DS_ENABLE_RATE_LIMITING=true
 
 # DB_HOST=localhost
 # DB_PORT=27017

--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ DS_ENABLE_RATE_LIMITING=true
 # DB_AUTH_NAME=admin
 # DB_SSL=false
 
-# If running behind a load balancer, specify which IP addresses (for
-# example, HAProxy or Fastly) to trust `X-Forwarded-For` headers from.
+# If we're running behind a load balancer (for example, HAProxy or Fastly), a
+# comma-separated list of IP addresses to trust `X-Forwarded-For` headers from.
 # TRUSTED_PROXY_IP_ADDRESSES=
 
 DRUPAL_API_URL=http://dev.dosomething.org:8888

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -66,6 +66,7 @@ class AuthController extends Controller
 
         $this->middleware('scope:user');
         $this->middleware('auth', ['only' => ['invalidateToken', 'phoenix']]);
+        $this->middleware('throttle', ['only' => ['createToken', 'verify', 'register']]);
         $this->middleware('guest', ['except' => ['invalidateToken', 'phoenix']]);
     }
 

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -92,7 +92,7 @@ class OAuthController extends Controller
 
         // If this IP has given incorrect client credentials too many times, take a break.
         // @see: EventServiceProvider `client.authentication.failed` listener.
-        if ($shouldRateLimit && $this->limiter->tooManyAttempts(request()->fingerprint(), 10)) {
+        if ($shouldRateLimit && $this->limiter->tooManyAttempts(request()->fingerprint(), 10, 15)) {
             event(RateLimitedRequest::class);
 
             $seconds = $this->limiter->availableIn(request()->ip());

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -4,7 +4,6 @@ namespace Northstar\Http\Controllers;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Factory as Auth;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -54,6 +54,7 @@ class AuthController extends BaseController
         $this->oauth = $oauth;
 
         $this->middleware('guest:web', ['only' => ['getLogin', 'postLogin', 'getRegister', 'postRegister']]);
+        $this->middleware('throttle', ['only' => ['postLogin', 'postRegister']]);
         $this->middleware('session_vars');
     }
 
@@ -129,7 +130,9 @@ class AuthController extends BaseController
         if (! $this->auth->guard('web')->attempt($credentials, true)) {
             return redirect()->back()
                 ->withInput($request->only('username'))
-                ->withErrors(['username' => 'These credentials do not match our records.']);
+                ->withErrors([
+                    $this->loginUsername() => 'These credentials do not match our records.'
+                ]);
         }
 
         // If we had stored a destination name, reset it.
@@ -190,5 +193,15 @@ class AuthController extends BaseController
         $this->registrar->sendWelcomeEmail($user);
 
         return redirect()->intended('/');
+    }
+
+    /**
+     * Get the login username to be used by the controller.
+     *
+     * @return string
+     */
+    public function loginUsername()
+    {
+        return 'username';
     }
 }

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -131,7 +131,7 @@ class AuthController extends BaseController
             return redirect()->back()
                 ->withInput($request->only('username'))
                 ->withErrors([
-                    $this->loginUsername() => 'These credentials do not match our records.'
+                    $this->loginUsername() => 'These credentials do not match our records.',
                 ]);
         }
 

--- a/app/Http/Controllers/Web/PasswordController.php
+++ b/app/Http/Controllers/Web/PasswordController.php
@@ -18,6 +18,15 @@ class PasswordController extends BaseController
     protected $guard = 'web';
 
     /**
+     * Make a new PasswordController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
+    public function __construct()
+    {
+        $this->middleware('throttle', ['only' => ['postEmail']]);
+    }
+
+    /**
      * Reset the given user's password.
      *
      * @param  \Northstar\Models\User  $user

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -46,5 +46,6 @@ class Kernel extends HttpKernel
         'scope' => \Northstar\Http\Middleware\RequireScope::class,
         'role' => \Northstar\Http\Middleware\RequireRole::class,
         'session_vars' => \Northstar\Http\Middleware\SessionVariablesToJavaScript::class,
+        'throttle' => \Northstar\Http\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Northstar\Http\Middleware;
+
+use Closure;
+use Northstar\Listeners\RateLimitedRequest;
+use Illuminate\Routing\Middleware\ThrottleRequests as BaseThrottler;
+use Illuminate\Http\JsonResponse;
+
+class ThrottleRequests extends BaseThrottler
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @param  int $maxAttempts
+     * @param  int $decayMinutes
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $maxAttempts = 15, $decayMinutes = 1)
+    {
+        return parent::handle($request, $next, $maxAttempts, $decayMinutes);
+    }
+
+    /**
+     * Create a 'too many attempts' response.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @return \Illuminate\Http\Response|JsonResponse
+     */
+    protected function buildResponse($key, $maxAttempts)
+    {
+        // Report the rate-limited request to StatHat.
+        event(RateLimitedRequest::class);
+
+        $seconds = $this->limiter->availableIn($key);
+        $message = 'Too many attempts. Please try again in '.$seconds.' seconds.';
+
+        if (request()->wantsJson() || request()->ajax()) {
+            return new JsonResponse($message, 429);
+        }
+
+        return redirect()->back()->with('status', $message);
+    }
+}

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -39,7 +39,9 @@ class ThrottleRequests extends BaseThrottler
         // Report the rate-limited request to StatHat.
         event(RateLimitedRequest::class);
 
-        $message = 'Too many attempts. Please try again in a few minutes.';
+        $minutes = ceil($this->limiter->availableIn($key) / 60);
+        $pluralizedNoun = $minutes === 1 ? 'minute' : 'minutes';
+        $message = 'Too many attempts. Please try again in '.$minutes.' '.$pluralizedNoun.'.';
 
         if (request()->wantsJson() || request()->ajax()) {
             return new JsonResponse($message, 429);

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -18,8 +18,12 @@ class ThrottleRequests extends BaseThrottler
      * @param  int $decayMinutes
      * @return mixed
      */
-    public function handle($request, Closure $next, $maxAttempts = 15, $decayMinutes = 1)
+    public function handle($request, Closure $next, $maxAttempts = 10, $decayMinutes = 1)
     {
+        if (! config('features.rate-limiting')) {
+            return $next($request);
+        }
+
         return parent::handle($request, $next, $maxAttempts, $decayMinutes);
     }
 

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -18,7 +18,7 @@ class ThrottleRequests extends BaseThrottler
      * @param  int $decayMinutes
      * @return mixed
      */
-    public function handle($request, Closure $next, $maxAttempts = 10, $decayMinutes = 1)
+    public function handle($request, Closure $next, $maxAttempts = 10, $decayMinutes = 15)
     {
         if (! config('features.rate-limiting')) {
             return $next($request);
@@ -39,8 +39,7 @@ class ThrottleRequests extends BaseThrottler
         // Report the rate-limited request to StatHat.
         event(RateLimitedRequest::class);
 
-        $seconds = $this->limiter->availableIn($key);
-        $message = 'Too many attempts. Please try again in '.$seconds.' seconds.';
+        $message = 'Too many attempts. Please try again in a few minutes.';
 
         if (request()->wantsJson() || request()->ajax()) {
             return new JsonResponse($message, 429);

--- a/app/Listeners/RateLimitedRequest.php
+++ b/app/Listeners/RateLimitedRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Northstar\Listeners;
+
+use DoSomething\StatHat\Client as StatHat;
+
+class RateLimitedRequest
+{
+    /**
+     * The StatHat client.
+     *
+     * @var StatHat
+     */
+    protected $stathat;
+
+    /**
+     * Create the event listener.
+     *
+     * @param StatHat $stathat
+     */
+    public function __construct(StatHat $stathat)
+    {
+        $this->stathat = $stathat;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->stathat->ezCount('rate-limited user authentication attempt');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,7 +16,6 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\AuthorizationServer;
-use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\ResourceServer;
 use Northstar\Auth\NorthstarTokenGuard;
 use Northstar\Auth\NorthstarUserProvider;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\ResourceServer;
 use Northstar\Auth\NorthstarTokenGuard;
 use Northstar\Auth\NorthstarUserProvider;

--- a/config/features.php
+++ b/config/features.php
@@ -14,4 +14,6 @@ return [
 
     'password-reset' => env('DS_ENABLE_PASSWORD_RESET'),
 
+    'rate-limiting' => env('DS_ENABLE_RATE_LIMITING'),
+
 ];

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -17,9 +17,7 @@ return [
      * It will mean that $request->getClientIp() always gets the originating client IP,
      * no matter how many proxies that client's request has subsequently passed through.
      */
-    'proxies' => [
-        env('TRUSTED_PROXY_IP_ADDRESS'),
-    ],
+    'proxies' => explode(',', env('TRUSTED_PROXY_IP_ADDRESSES')),
 
     /*
      * Default Header Names

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -166,7 +166,7 @@ OAuth authentication errors are formatted slightly differently (to conform to [t
 
 ## Rate Limiting
 Authentication and registration attempts are rate limited to prevent abuse. Users are limited by IP
-address to 10 logins or registrations per minute, and 10 failed client authentication attempts.
+address to 10 logins or registrations per 15 minutes, and 10 failed client authentication attempts.
 
 The currently applied rate limit and remaining requests are returned as headers on each response:
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -122,6 +122,7 @@ Code | Meaning
 404  | __Not Found__ – The specified resource could not be found.
 418  | __I'm a teapot__ – The user [needs more caffeine](https://www.ietf.org/rfc/rfc2324.txt).
 422  | __Unprocessable Entity__ – The request couldn't be completed due to validation errors. See the `error.fields` property on the response.
+429  | __Too Many Requests__ – The user/client has sent too many requests in the past minute. See [Rate Limiting](#rate-limiting).
 500  | __Internal Server Error__ – Northstar has encountered an internal error. Please [make a bug report](https://github.com/DoSomething/northstar/issues/new) with as much detail as possible about what led to the error!
 503  | __Service Unavailable__ – Northstar is temporarily unavailable.
 
@@ -162,6 +163,19 @@ OAuth authentication errors are formatted slightly differently (to conform to [t
   "hint": "..."
 }
 ```
+
+## Rate Limiting
+Authentication and registration attempts are rate limited to prevent abuse. Users are limited by IP
+address to 10 logins or registrations per minute, and 10 failed client authentication attempts.
+
+The currently applied rate limit and remaining requests are returned as headers on each response:
+
+Header                  | Description
+----------------------- | -------------------------------------------------------------------------
+`X-RateLimit-Limit`     |	The maximum number of requests that this client may make per hour.
+`X-RateLimit-Remaining` |	The number of requests remaining of your provided limit.
+`Retry-After`           | If rate limit is exceeded, this is the amount of time until you may make another request.
+
 
 ## Libraries
 We have a [PHP API client](https://github.com/DoSomething/northstar-php) for simplified usage of the API in PHP clients.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -257,4 +257,22 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 
         return $this;
     }
+
+    /**
+     * Register a new user account.
+     */
+    public function register()
+    {
+        // Make sure we're logged out before trying to register.
+        auth('web')->logout();
+
+        $this->visit('register');
+        $this->submitForm('Create New Account', [
+            'first_name' => $this->faker->firstName,
+            'email' => $this->faker->unique->email,
+            'birthdate' => $this->faker->date('m/d/Y', '5 years ago'),
+            'password' => 'secret',
+            'password_confirmation' => 'secret',
+        ]);
+    }
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -10,12 +10,12 @@ build:
         name: start mongodb
         code: |-
           sudo /usr/bin/mongod --quiet --config /etc/mongod.conf --fork --logpath /var/log/mongod.log
-    - leipert/composer-install@0.9.1
     - script:
         name: create test keys
         code: |-
           openssl genrsa -out storage/keys/private.key 1024
           openssl rsa -in storage/keys/private.key -pubout -out storage/keys/public.key
+    - leipert/composer-install@0.9.1
     - script:
         name: npm install
         code: |-


### PR DESCRIPTION
#### What's this PR do?
This pull request adds rate limiting to the authentication & registration endpoints: you can make 10 login attempts or registrations before hitting the cap, and 10 "invalid credentials" errors (so you can request as many tokens as you want, but are stopped if you keep making bad requests).

The limit resets after 15 minutes.

![screen shot 2017-05-08 at 12 26 21 pm](https://cloud.githubusercontent.com/assets/583202/25814123/4cb62d0a-33ea-11e7-9ab2-7692c2e52513.png)

#### How should this be reviewed?
This uses a slightly spruced up version of Laravel's rate limiting middleware (which changes the default cap & decay, and adds support for rate limiting browser requests). OAuth requests are rate-limited separately because we do not want to prevent internal clients from requesting a ton of tokens, so we specifically increment the limiter only on failed credentials.

Definitely let me know if there are other things we should be rate limiting that I missed. My goal here was to knock out the most "dangerous" things while not introducing any unexpected bugs for internal clients that rely on Northstar and don't expect to be slowed down. 🐌

This PR is a bit hefty, but should be okay if you go commit-by-commit. Tests in d446766.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!