### PR TITLE
Get lockout based on the appropriate key & format in minutes.

### DIFF
--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -95,8 +95,9 @@ class OAuthController extends Controller
         if ($shouldRateLimit && $this->limiter->tooManyAttempts(request()->fingerprint(), 10, 15)) {
             event(RateLimitedRequest::class);
 
-            $seconds = $this->limiter->availableIn(request()->ip());
-            $message = 'Too many failed attempts. Please try again in '.$seconds.' seconds.';
+            $minutes = ceil($this->limiter->availableIn(request()->fingerprint()) / 60);
+            $pluralizedNoun = $minutes === 1 ? 'minute' : 'minutes';
+            $message = 'Too many attempts. Please try again in '.$minutes.' '.$pluralizedNoun.'.';
 
             throw new OAuthServerException($message, 429, 'rate_limit', 429);
         }


### PR DESCRIPTION
#### What's this PR do?
I noticed this message checks the wrong key for the lockout timer (`request()->ip()` instead of `request()->fingerprint()`) and does not format in minutes like the middleware. This pull request updates both rate limiters to be consistently reported.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  