### PR TITLE
Save country and language from Fastly in Northstar.

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -185,7 +185,15 @@ class AuthController extends BaseController
         ]);
 
         // Register and login the user.
-        $user = $this->registrar->register($request->except(User::$internal));
+        $editableFields = $request->except(User::$internal);
+        $user = $this->registrar->register($editableFields, null, function ($user) {
+            // Set the user's country code by Fastly geo-location header.
+            $user->country = country_code();
+
+            // Set language based on locale (either 'en', 'es-mx')
+            $user->language = app()->getLocale();
+        });
+
         $this->auth->guard('web')->login($user, true);
 
         // Send them a welcome email!

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -16,13 +16,13 @@ class SetLanguageFromHeader
      */
     public function handle($request, Closure $next)
     {
-        $countryCode = strtolower($request->header('X-Fastly-Country-Code'));
+        $countryCode = country_code();
 
         switch ($countryCode) {
-            case 'us':
+            case 'US':
                 App::setLocale('en');
                 break;
-            case 'mx':
+            case 'MX':
                 App::setLocale('es-mx');
                 break;
             default:

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 use Northstar\Auth\Normalizer;
 use Northstar\Models\Client;
 
@@ -104,4 +105,16 @@ function get_countries()
     $iso = (new League\ISO3166\ISO3166)->getAll();
 
     return collect($iso)->pluck('name', 'alpha2');
+}
+
+/**
+ * Get the country code from the `X-Fastly-Country-Code` header.
+ *
+ * @return string|null
+ */
+function country_code()
+{
+    $code = request()->header('X-Fastly-Country-Code');
+
+    return $code ? Str::upper($code) : null;
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -80,7 +80,7 @@
             </div>
 
             <div class="form-actions -padded">
-                <input type="submit" class="button" value="{{ trans('auth.log_in.submit') }}">
+                <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
             </div>
         </form>
     </div>

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -6,11 +6,11 @@ use Northstar\Models\User;
 class PasswordResetTest extends TestCase
 {
     /**
-     * Reset the server variables for the request.
+     * Default headers for this test case.
      *
      * @var array
      */
-    protected $serverVariables = [
+    protected $headers = [
         'Accept' => 'text/html',
     ];
 

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -5,11 +5,11 @@ use Northstar\Models\User;
 class WebAuthenticationTest extends TestCase
 {
     /**
-     * Reset the server variables for the request.
+     * Default headers for this test case.
      *
      * @var array
      */
-    protected $serverVariables = [
+    protected $headers = [
         'Accept' => 'text/html',
     ];
 
@@ -155,9 +155,35 @@ class WebAuthenticationTest extends TestCase
     public function testRegister()
     {
         $this->phoenixMock->shouldReceive('sendTransactional')->once();
-        $this->register();
+        $this->withHeader('X-Fastly-Country-Code', 'US')
+            ->register();
 
         $this->seeIsAuthenticated('web');
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        $this->assertEquals('US', $user->country);
+        $this->assertEquals('en', $user->language);
+    }
+
+    /**
+     * Test that users can register from other countries
+     * and get the correct `country` and `language` fields.
+     */
+    public function testRegisterFromMexico()
+    {
+        $this->phoenixMock->shouldReceive('sendTransactional')->once();
+        $this->withHeader('X-Fastly-Country-Code', 'MX')
+            ->register();
+
+        $this->seeIsAuthenticated('web');
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        $this->assertEquals('MX', $user->country);
+        $this->assertEquals('es-mx', $user->language);
     }
 
     /**

--- a/tests/Http/Web/WebUserTest.php
+++ b/tests/Http/Web/WebUserTest.php
@@ -5,6 +5,15 @@ use Northstar\Models\User;
 class WebUserTest extends TestCase
 {
     /**
+     * Default headers for this test case.
+     *
+     * @var array
+     */
+    protected $headers = [
+        'Accept' => 'text/html',
+    ];
+
+    /**
      * Test that an authenticated, unauthorized user cannot see the
      * /users/:id page and is redirected to view their profile on
      * the homepage.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -304,7 +304,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         auth('web')->logout();
 
         $this->visit('register');
-        $this->submitForm('Create New Account', [
+        $this->submitForm('register-submit', [
             'first_name' => $this->faker->firstName,
             'email' => $this->faker->unique->email,
             'birthdate' => $this->faker->date('m/d/Y', '5 years ago'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,13 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
     protected $baseUrl = 'http://localhost';
 
     /**
+     * Default headers for this test case.
+     *
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
      * The Faker generator, for creating test data.
      *
      * @var \Faker\Generator
@@ -64,6 +71,8 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function setUp()
     {
         parent::setUp();
+
+        $this->serverVariables = $this->transformHeadersToServerVars($this->headers);
 
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
@@ -267,6 +276,21 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $form = $this->fillForm($buttonText, $inputs);
 
         $this->call($form->getMethod(), $form->getUri(), $this->extractParametersFromForm($form));
+
+        return $this;
+    }
+
+    /**
+     * Set a header on the request.
+     *
+     * @param $name
+     * @param $value
+     * @return $this
+     */
+    public function withHeader($name, $value)
+    {
+        $header = $this->transformHeadersToServerVars([$name => $value]);
+        $this->serverVariables = array_merge($this->serverVariables, $header);
 
         return $this;
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the web registration flow to save a user's country code & language to their account. This was originally only saving in Phoenix as part of the OpenID Connect flow, but that meant the "created" hook would not include the full profile for Customer.io.

#### How should this be reviewed?
I made some updates to the base `TestCase` so we can add headers per request, and extracted a `country_code` helper from the original middleware. Currently `country` will be set to the upper-cased code provided by Fastly (or `null`), and `language` will be set to the app locale (either `en` or `es-mx`).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  