### PR TITLE
Wait for full user document before creating.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -197,7 +197,6 @@ class Registrar
         }
 
         $user->fill($input);
-        $user->save();
 
         if (! is_null($customizer)) {
             $customizer($user);
@@ -206,8 +205,9 @@ class Registrar
         // If this user doesn't have a `drupal_id`, try to make one.
         if (! $user->drupal_id) {
             $user = $this->createDrupalUser($user);
-            $user->save();
         }
+
+        $user->save();
 
         return $user;
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the Registrar's `register` method to only save the Eloquent model once the whole thing is ready. This will allow the "created" hook for Customer.io profiles to send all fields on a user's account (rather than just the ones persisted by that first save).

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  