### PR TITLE
Ensure user has a Northstar ID before sending to Phoenix.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -202,12 +202,13 @@ class Registrar
             $customizer($user);
         }
 
+        $user->save();
+
         // If this user doesn't have a `drupal_id`, try to make one.
         if (! $user->drupal_id) {
             $user = $this->createDrupalUser($user);
+            $user->save();
         }
-
-        $user->save();
 
         return $user;
     }


### PR DESCRIPTION
#### What's this PR do?
We need the user to have an `_id` before we can send it to Phoenix. This pull request adds an additional `save()` call (once the profile is completed, but not forwarded to Phoenix) so that is filled in on the Eloquent model.

This fixes an error where accounts could not be created [because `_id` was missing](https://github.com/DoSomething/phoenix/blob/df6364925f9dcfd4f11c493315820a8ecd028438/lib/modules/dosomething/dosomething_api/resources/member_resource.inc#L172):

```
[2017-05-11 21:09:50] production.DEBUG: Encountered error when creating Drupal user {"user":"[object] (Northstar\\Models\\User: {\"first_name\":\"Test\",\"birthdate\":\"1990-10-25 00:00:00\",\"email\":\"test-mexican-user-123456@example.com\",\"country\":\"MX\",\"language\":\"es-mx\"})","error":"[object] (GuzzleHttp\\Exception\\ServerException(code: 500): Server error: `POST https://thor.dosomething.org/api/v1/users?forward=0` resulted in a `500 Internal Server Error : An error occurred (0): New Drupal accounts must be registered via Northstar.` response:


[\"New Drupal accounts must be registered via Northstar.\"]
```

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  