### PR TITLE
Remove validation on `drupal_id` field.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -66,7 +66,6 @@ class Registrar
         $rules = [
             'email' => 'email|unique:users,email,'.$existingId.',_id|required_without:mobile',
             'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id|required_without:email',
-            'drupal_id' => 'unique:users,drupal_id,'.$existingId.',_id',
             'birthdate' => 'date',
             'country' => 'country',
             'password' => 'min:6|max:512',

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -755,14 +755,17 @@ class LegacyUserTest extends TestCase
      */
     public function testUpdateWithDrupalIDConflict()
     {
-        factory(User::class)->create(['drupal_id' => '123456']);
-        $user = factory(User::class)->create(['email' => 'admiral.ackbar@example.com']);
+        $user1 = factory(User::class)->create(['drupal_id' => '123456']);
+        $user2 = factory(User::class)->create(['drupal_id' => '555123']);
 
-        $this->withLegacyApiKeyScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
+        $this->withLegacyApiKeyScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user2->id, [
             'drupal_id' => '123456', // the existing user account
         ]);
 
-        $this->assertResponseStatus(422);
+        // The `drupal_id` field is ignored as un-fillable.
+        $this->assertResponseStatus(200);
+        $this->assertEquals('123456', $user1->fresh()->drupal_id);
+        $this->assertEquals('555123', $user2->fresh()->drupal_id);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
An addendum to #588: this pull request removes validation on the `drupal_id` index since it can only be set programmatically now (so there's no reason to care what other clients attempt to post).

Fixes #559.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  