### PR TITLE
Don't upsert source when `created_at` is the same.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -110,7 +110,7 @@ class UserController extends Controller
             // Optionally, allow setting a custom "created_at" (useful for back-filling from other services).
             // We'll only update this value on existing records if it's earlier than the existing timestamp.
             $created_at = $request->input('created_at');
-            $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lt(Carbon::createFromTimestamp($created_at));
+            $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lte(Carbon::createFromTimestamp($created_at));
             if ($created_at && ! $existingUserHasEarlierCreatedTimestamp) {
                 $user->created_at = $created_at;
                 $user->source = $request->input('source') ?: client_id();

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,8 +4,8 @@ build:
   # The steps that will be executed on build
   steps:
     - script:
-        name: install npm 3.x
-        code: npm install -g npm@3.x-latest
+        name: install npm 4.x
+        code: npm install -g npm@4
     - script:
         name: start mongodb
         code: |-


### PR DESCRIPTION
### What's this PR do?
__Background:__ We had added the ability to upsert users' `source` field only if also providing an earlier `created_at` date in the same request (so, for example, we could update a user's "true" source to be from SMS if they'd texted us first, even if we'd first "created" the account via Phoenix afterwards).

__Problem:__ We create a user's MobileCommons account at (effectively) the exact same time as their Northstar account when doing Niche imports. The comparison check allows us to upsert `created_at` if it's the exact same time (rather than "exclusively" earlier), so all those users would end up with `sms` as a source as soon as their MobileCommons ID was processed by [northstar-mobilecommonsd](https://github.com/DoSomething/northstar-mobilecommonsd).

__Solution:__ Only allow clients to update `source` if it's _actually_ an earlier source, not just the same.

References DoSomething/quasar#356.

### How should this be reviewed?
See the included test case for a demo of the change.

### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  