### PR TITLE
Store "last accessed" field on user accounts.

### DIFF
--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -38,7 +38,11 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity)
     {
         // Since access tokens are not checked against the database, but instead
-        // verified by their hash, we won't bother persisting them.
+        // verified by their hash, we'll just make a record in the log.
+        logger('issued access token', [
+            'id' => $accessTokenEntity->getUserIdentifier(),
+            'jti' => $accessTokenEntity->getIdentifier(),
+        ]);
     }
 
     /**

--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Auth\Repositories;
 
+use Carbon\Carbon;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -24,6 +25,12 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
 
         if ($userIdentifier) {
             $user = User::find($userIdentifier);
+
+            // Update the user's "last accessed at" timestamp.
+            $user->last_accessed_at = Carbon::now();
+            $user->save();
+
+            // Embed the user's role in the token.
             $accessToken->setRole($user->role);
         }
 

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -62,6 +62,7 @@ class UserTransformer extends TransformerAbstract
         $response['role'] = $user->role;
 
         if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
+            $response['last_accessed_at'] = $user->last_accessed_at ? $user->last_accessed_at->toIso8601String() : null;
             $response['last_authenticated_at'] = $user->last_authenticated_at ? $user->last_authenticated_at->toIso8601String() : null;
         }
 

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -12,11 +12,11 @@ use MongoDB\BSON\UTCDateTime;
 /**
  * Base model class
  *
- * @method static \Jenssegers\Mongodb\Query\Builder where(string $field, string $comparison = '=', string $value)
- * @method static \Jenssegers\Mongodb\Query\Builder whereNull(string $field)
- * @method static \Jenssegers\Mongodb\Query\Builder find(string $id, array $columns=['*'])
- * @method static \Jenssegers\Mongodb\Query\Builder findMany(array $ids)
- * @method static \Jenssegers\Mongodb\Query\Builder findOrFail(string $id, array $columns=['*'])
+ * @method static \Jenssegers\Mongodb\Query\Builder|$this where(string $field, string $comparison = '=', string $value)
+ * @method static \Jenssegers\Mongodb\Query\Builder|$this whereNull(string $field)
+ * @method static \Jenssegers\Mongodb\Query\Builder|$this find(string $id, array $columns=['*'])
+ * @method static \Jenssegers\Mongodb\Query\Builder|$this findMany(array $ids)
+ * @method static \Jenssegers\Mongodb\Query\Builder|$this findOrFail(string $id, array $columns=['*'])
  */
 class Model extends BaseModel
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,6 +61,7 @@ use Northstar\Auth\Role;
  * @property string $facebook_id
  * @property string $slack_id
  *
+ * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
  * @property Carbon $created_at
  * @property Carbon $updated_at

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -143,6 +143,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $casts = [
         'cgg_id' => 'integer',
         'birthdate' => 'date',
+        'last_accessed_at' => 'datetime',
         'last_authenticated_at' => 'datetime',
     ];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use DoSomething\Gateway\Blink;
 use League\OAuth2\Server\CryptKey;
 use Northstar\Auth\Entities\AccessTokenEntity;
@@ -261,6 +262,19 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $this->app->instance($class, $mock);
 
         return $mock;
+    }
+
+    /**
+     * "Freeze" time so we can make assertions based on it.
+     *
+     * @param string $time
+     * @return Carbon
+     */
+    public function mockTime($time = 'now')
+    {
+        Carbon::setTestNow((string) new Carbon($time));
+
+        return Carbon::getTestNow();
     }
 
     /**

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,8 +4,8 @@ build:
   # The steps that will be executed on build
   steps:
     - script:
-        name: install npm 3.x
-        code: npm install -g npm@3.x-latest
+        name: install npm 4.x
+        code: npm install -g npm@4
     - script:
         name: start mongodb
         code: |-


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `last_accessed_at` field to user documents, which is updated whenever a token is granted or refreshed. This allows the data team to see a single "last accessed" timestamp across any services that authenticate with Northstar.

References DoSomething/quasar#361.

#### How should this be reviewed?
I added tests to demonstrate this behavior when granting & refreshing access tokens.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  