### PR TITLE
Fix issue where we could add `null` values to Mongo documents on updates.

### DIFF
--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Northstar\Models\User;
+
+class ModelTest extends TestCase
+{
+    /** @test */
+    public function it_should_unset_null_fields()
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create([
+            'mobile' => $this->faker->phoneNumber,
+            'last_name' => null,
+        ]);
+
+        // Now, unset some fields.
+        $user->mobile = null;
+        $user->last_name = null;
+        $user->save();
+
+        // Make sure the field is unset on the actual document.
+        $document = $this->getMongoDocument('users', $user->id);
+        $this->assertArrayNotHasKey('mobile', $document);
+        $this->assertArrayNotHasKey('last_name', $document);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue where editing a users profile on Aurora would insert `null` values for any fields that were already empty on that database record.

Unfortunately, this meant as soon as you edited an account without a mobile you'd insert `null` on that field and the Mongo uniqueness constraint would explode (since Mongo bizarrely treats `null` as a distinct value when checking uniqueness). 💥

#### How should this be reviewed?
I added a test case demonstrating the problem & the fix. Originally, the `last_name` field in that example would have been left in the database & now it gets properly cleaned up.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  