### PR TITLE
Fix reporting rate limited requests to StatHat.

### DIFF
--- a/app/Events/Throttled.php
+++ b/app/Events/Throttled.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Northstar\Events;
+
+class Throttled extends Event
+{
+    // ...
+}

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -9,7 +9,7 @@ use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Northstar\Auth\Encrypter;
 use Northstar\Http\Transformers\UserInfoTransformer;
-use Northstar\Listeners\RateLimitedRequest;
+use Northstar\Events\Throttled;
 use Northstar\Models\RefreshToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -93,7 +93,7 @@ class OAuthController extends Controller
         // If this IP has given incorrect client credentials too many times, take a break.
         // @see: EventServiceProvider `client.authentication.failed` listener.
         if ($shouldRateLimit && $this->limiter->tooManyAttempts(request()->fingerprint(), 10, 15)) {
-            event(RateLimitedRequest::class);
+            event(Throttled::class);
 
             $minutes = ceil($this->limiter->availableIn(request()->fingerprint()) / 60);
             $pluralizedNoun = $minutes === 1 ? 'minute' : 'minutes';

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -3,7 +3,7 @@
 namespace Northstar\Http\Middleware;
 
 use Closure;
-use Northstar\Listeners\RateLimitedRequest;
+use Northstar\Events\Throttled;
 use Illuminate\Routing\Middleware\ThrottleRequests as BaseThrottler;
 use Illuminate\Http\JsonResponse;
 
@@ -37,7 +37,7 @@ class ThrottleRequests extends BaseThrottler
     protected function buildResponse($key, $maxAttempts)
     {
         // Report the rate-limited request to StatHat.
-        event(RateLimitedRequest::class);
+        event(Throttled::class);
 
         $minutes = ceil($this->limiter->availableIn($key) / 60);
         $pluralizedNoun = $minutes === 1 ? 'minute' : 'minutes';

--- a/app/Listeners/ReportFailedAuthenticationAttempt.php
+++ b/app/Listeners/ReportFailedAuthenticationAttempt.php
@@ -4,7 +4,7 @@ namespace Northstar\Listeners;
 
 use DoSomething\StatHat\Client as StatHat;
 
-class FailedAuthenticationAttempt
+class ReportFailedAuthenticationAttempt
 {
     /**
      * The StatHat client.

--- a/app/Listeners/ReportSuccessfulAuthentication.php
+++ b/app/Listeners/ReportSuccessfulAuthentication.php
@@ -7,7 +7,7 @@ use DoSomething\StatHat\Client as StatHat;
 use Illuminate\Auth\Events\Login;
 use Northstar\Models\User;
 
-class SuccessfulAuthentication
+class ReportSuccessfulAuthentication
 {
     /**
      * The StatHat client.

--- a/app/Listeners/ReportThrottledRequest.php
+++ b/app/Listeners/ReportThrottledRequest.php
@@ -4,7 +4,7 @@ namespace Northstar\Listeners;
 
 use DoSomething\StatHat\Client as StatHat;
 
-class RateLimitedRequest
+class ReportThrottledRequest
 {
     /**
      * The StatHat client.
@@ -30,6 +30,6 @@ class RateLimitedRequest
      */
     public function handle()
     {
-        $this->stathat->ezCount('rate-limited user authentication attempt');
+        $this->stathat->ezCount('rate limited request');
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,7 +9,9 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Routing\Events\RouteMatched;
 use League\OAuth2\Server\AuthorizationServer;
+use Northstar\Events\Throttled;
 use Northstar\Listeners\ReportFailedAuthenticationAttempt;
+use Northstar\Listeners\ReportThrottledRequest;
 use Northstar\Listeners\ReportSuccessfulAuthentication;
 
 class EventServiceProvider extends ServiceProvider
@@ -22,6 +24,7 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Login::class => [ReportSuccessfulAuthentication::class],
         Failed::class => [ReportFailedAuthenticationAttempt::class],
+        Throttled::class => [ReportThrottledRequest::class],
     ];
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,8 +9,8 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Routing\Events\RouteMatched;
 use League\OAuth2\Server\AuthorizationServer;
-use Northstar\Listeners\FailedAuthenticationAttempt;
-use Northstar\Listeners\SuccessfulAuthentication;
+use Northstar\Listeners\ReportFailedAuthenticationAttempt;
+use Northstar\Listeners\ReportSuccessfulAuthentication;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -20,8 +20,8 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        Login::class => [SuccessfulAuthentication::class],
-        Failed::class => [FailedAuthenticationAttempt::class],
+        Login::class => [ReportSuccessfulAuthentication::class],
+        Failed::class => [ReportFailedAuthenticationAttempt::class],
     ];
 
     /**

--- a/tests/Http/OAuthTest.php
+++ b/tests/Http/OAuthTest.php
@@ -221,9 +221,13 @@ class OAuthTest extends TestCase
         ];
 
         for ($i = 0; $i < 10; $i++) {
+            $this->doesntExpectEvents(\Northstar\Events\Throttled::class);
             $this->post('v2/auth/token', $invalidCredentials);
             $this->assertResponseStatus(401);
         }
+
+        // This next request should trigger a StatHat counter.
+        $this->expectsEvents(\Northstar\Events\Throttled::class);
 
         $this->post('v2/auth/token', $invalidCredentials);
         $this->assertResponseStatus(429);

--- a/tests/Http/OAuthTest.php
+++ b/tests/Http/OAuthTest.php
@@ -221,7 +221,6 @@ class OAuthTest extends TestCase
         ];
 
         for ($i = 0; $i < 10; $i++) {
-            $this->doesntExpectEvents(\Northstar\Events\Throttled::class);
             $this->post('v2/auth/token', $invalidCredentials);
             $this->assertResponseStatus(401);
         }

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -83,8 +83,6 @@ class WebAuthenticationTest extends TestCase
     {
         for ($i = 0; $i < 10; $i++) {
             $this->visit('login');
-
-            $this->doesntExpectEvents(\Northstar\Events\Throttled::class);
             $this->submitForm('Log In', [
                 'username' => 'target@example.com',
                 'password' => 'password'.$i,

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -83,6 +83,8 @@ class WebAuthenticationTest extends TestCase
     {
         for ($i = 0; $i < 10; $i++) {
             $this->visit('login');
+
+            $this->doesntExpectEvents(\Northstar\Events\Throttled::class);
             $this->submitForm('Log In', [
                 'username' => 'target@example.com',
                 'password' => 'password'.$i,
@@ -90,6 +92,9 @@ class WebAuthenticationTest extends TestCase
 
             $this->see('These credentials do not match our records.');
         }
+
+        // This next request should trigger a StatHat counter.
+        $this->expectsEvents(\Northstar\Events\Throttled::class);
 
         $this->visit('login');
         $this->submitForm('Log In', [

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,9 +4,6 @@ build:
   # The steps that will be executed on build
   steps:
     - script:
-        name: install npm 4.x
-        code: npm install -g npm@4
-    - script:
         name: start mongodb
         code: |-
           sudo /usr/bin/mongod --quiet --config /etc/mongod.conf --fork --logpath /var/log/mongod.log
@@ -16,12 +13,7 @@ build:
           openssl genrsa -out storage/keys/private.key 1024
           openssl rsa -in storage/keys/private.key -pubout -out storage/keys/public.key
     - leipert/composer-install@0.9.1
-    - script:
-        name: npm install
-        code: |-
-          mkdir -p $WERCKER_CACHE_DIR/wercker/npm
-          npm config set cache $WERCKER_CACHE_DIR/wercker/npm
-          npm install
+    - npm-install
     - script:
         name: build front-end assets
         code: npm run build


### PR DESCRIPTION
#### What's this PR do?
I had set up the event listener for rate limited requests incorrectly before, so it wasn't properly reporting to StatHat. This fixes that so we get reliable metrics here.

#### How should this be reviewed?
I also renamed the other two listeners for consistency, but otherwise it's pretty straightforward! I just added a `Throttled` event and registered it to the `ReportThrottledRequest` listener in the event service provider.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  