### PR TITLE
Removing user scope from profile endpoint

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -34,7 +34,6 @@ class ProfileController extends Controller
 
         $this->transformer = new UserTransformer();
 
-        $this->middleware('scope:user');
         $this->middleware('auth');
     }
 

--- a/documentation/endpoints/profile.md
+++ b/documentation/endpoints/profile.md
@@ -1,7 +1,7 @@
 # Profile Endpoints
 
 ## Get Authenticated User's Profile
-Get profile data for the [currently authenticated user](../authentication.md). This must be done using an API key with `user` scope.
+Get profile data for the [currently authenticated user](../authentication.md).
 
 ```
 GET /v1/profile
@@ -48,7 +48,7 @@ curl -X GET \
 </details>
 
 ## Update Authenticated User's Profile
-Update the profile data for the [currently authenticated user](../authentication.md). This must be done using an API key with `user` scope.
+Update the profile data for the [currently authenticated user](../authentication.md).
 
 ```
 POST /v1/profile
@@ -76,7 +76,7 @@ POST /v1/profile
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)
-  
+
   // Hidden fields (optional):
   race: String
   religion: String

--- a/documentation/endpoints/profile.md
+++ b/documentation/endpoints/profile.md
@@ -76,7 +76,6 @@ POST /v1/profile
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)
-
   // Hidden fields (optional):
   race: String
   religion: String

--- a/documentation/endpoints/profile.md
+++ b/documentation/endpoints/profile.md
@@ -76,6 +76,7 @@ POST /v1/profile
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   source: String // Immutable (can only be set if existing value is `null`)
+
   // Hidden fields (optional):
   race: String
   religion: String

--- a/tests/LegacyHttp/ProfileTest.php
+++ b/tests/LegacyHttp/ProfileTest.php
@@ -19,7 +19,7 @@ class ProfileTest extends TestCase
         ]);
 
         // Try to register an account that already exists, but with different capitalization
-        $this->asUserUsingLegacyAuth($user)->withLegacyApiKeyScopes(['user'])->get('v1/profile');
+        $this->asUserUsingLegacyAuth($user)->get('v1/profile');
         $this->assertResponseStatus(200);
         $this->seeJsonSubset([
             'data' => [
@@ -47,7 +47,7 @@ class ProfileTest extends TestCase
             'role' => 'user',
         ]);
 
-        $this->asUserUsingLegacyAuth($user)->withLegacyApiKeyScopes(['user'])->json('POST', 'v1/profile', [
+        $this->asUserUsingLegacyAuth($user)->json('POST', 'v1/profile', [
             'mobile' => '(555) 123-4567',
             'language' => 'en',
             'drupal_id' => 666666,


### PR DESCRIPTION
#### What's this PR do?
This PR removes the user scope from the profile endpoint.  This was to solve a problem we were encountering in this [Phoenix PR](https://github.com/DoSomething/phoenix/pull/7415#discussion_r122284393). 

#### How should this be reviewed?
Can you update your profile without a user scope now?

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] ~Post a message in #api if this includes something that causes a rebuild!~ 