### PR TITLE
Allow filtering users by `created_at` or `updated_at` timestamp.

### DIFF
--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -2,6 +2,8 @@
 
 namespace Northstar\Auth;
 
+use Carbon\Carbon;
+
 class Normalizer
 {
     /**
@@ -69,6 +71,21 @@ class Normalizer
         }
 
         return $sanitizedValue;
+    }
+
+    /**
+     * Parse a string into a Carbon date.
+     *
+     * @param string[] $strings
+     * @return string
+     */
+    public function dates($strings)
+    {
+        $dates = collect($strings)->map(function ($string) {
+            return new Carbon($string);
+        });
+
+        return $dates->toArray();
     }
 
     /**

--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -77,7 +77,7 @@ class Normalizer
      * Parse a string into a Carbon date.
      *
      * @param string[] $strings
-     * @return string
+     * @return Carbon[]
      */
     public function dates($strings)
     {

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -14,9 +14,15 @@ class MergeController extends Controller
      */
     protected $transformer;
 
-    public function __construct()
+    /**
+     * Make a new MergeController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param UserTransformer $transformer
+     */
+    public function __construct(UserTransformer $transformer)
     {
-        $this->transformer = new UserTransformer();
+        $this->transformer = $transformer;
         $this->middleware('role:admin,staff');
     }
 

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -17,14 +17,14 @@ trait FiltersRequests
     }
 
     /**
-     * Limit results to users exactly matching a set of filters.
+     * Limit results to records exactly matching a set of filters.
      *
      * @param $query
      * @param $filters
      * @param $indexes - Indexed fields (whitelisted for filtering)
      * @return mixed
      */
-    public function filter($query, $filters, $indexes)
+    public function filter($query, $filters, $indexes, $operator = '=')
     {
         if (! $filters) {
             return $query;
@@ -42,7 +42,7 @@ trait FiltersRequests
             // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)
             $firstWhere = true;
             foreach ($values as $value) {
-                $query->where($filter, '=', $value, ($firstWhere ? 'and' : 'or'));
+                $query->where($filter, $operator, $value, ($firstWhere ? 'and' : 'or'));
                 $firstWhere = false;
             }
         }
@@ -51,7 +51,7 @@ trait FiltersRequests
     }
 
     /**
-     * Limit results to users matching a set of search terms.
+     * Limit results to records matching a set of search terms.
      *
      * @param $query - Query to apply search to
      * @param array $searches - Key/value array of fields and search terms

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -36,7 +36,7 @@ trait FiltersRequests
         // You can filter by multiple values, e.g. `filter[source]=agg,cgg`
         // to get records that have a source value of either `agg` or `cgg`.
         foreach ($filters as $filter => $values) {
-            $values = explode(',', $values);
+            $values = is_string($values) ? explode(',', $values) : [$values];
 
             // For the first `where` query, we want to limit results... from then on,
             // we want to append (e.g. `SELECT * WHERE _ OR WHERE _ OR WHERE _`)

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -54,9 +54,19 @@ class UserController extends Controller
         // or paginate to retrieve all user records.
         $query = $this->newQuery(User::class);
 
-        $filters = $request->query('filter');
-        $query = $this->filter($query, normalize('credentials', $filters), User::$indexes);
+        // Use `?filter[column]=value` for exact matches.
+        $filters = normalize('credentials', $request->query('filter'));
+        $query = $this->filter($query, $filters, User::$indexes);
 
+        // Use `?before[column]=time` to get records before given value.
+        $befores = normalize('dates', $request->query('before'));
+        $query = $this->filter($query, $befores, [User::CREATED_AT, User::UPDATED_AT], '<');
+
+        // Use `?after[column]=time` to get records after given value.
+        $afters = normalize('dates', $request->query('after'));
+        $query = $this->filter($query, $afters, [User::CREATED_AT, User::UPDATED_AT], '>');
+
+        // Use `?search[column]=value` to find users matching one or more criteria.
         $searches = $request->query('search');
         $query = $this->search($query, normalize('credentials', $searches), User::$indexes);
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -8,20 +8,15 @@ use Northstar\Auth\Registrar;
 use Northstar\Auth\Role;
 use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Services\Phoenix;
 use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UserController extends Controller
 {
     /**
-     * Phoenix Drupal API wrapper.
-     * @var Phoenix
-     */
-    protected $phoenix;
-
-    /**
-     * The registrar.
+     * The registrar handles creating, updating, and
+     * validating user accounts.
+     *
      * @var Registrar
      */
     protected $registrar;
@@ -32,16 +27,16 @@ class UserController extends Controller
     protected $transformer;
 
     /**
-     * UserController constructor.
-     * @param Phoenix $phoenix
+     * Make a new UserController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
      * @param Registrar $registrar
+     * @param UserTransformer $transformer
      */
-    public function __construct(Phoenix $phoenix, Registrar $registrar)
+    public function __construct(Registrar $registrar, UserTransformer $transformer)
     {
-        $this->phoenix = $phoenix;
         $this->registrar = $registrar;
-
-        $this->transformer = new UserTransformer();
+        $this->transformer = $transformer;
 
         $this->middleware('role:admin,staff', ['except' => ['show']]);
     }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -23,7 +23,7 @@ $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']]
     $router->post('login', 'AuthController@postLogin');
     $router->get('logout', 'AuthController@getLogout');
 
-    //Unsubscribe
+    // Unsubscribes
     $router->get('unsubscribe', 'UnsubscribeController@getSubscriptions');
     $router->post('unsubscribe', 'UnsubscribeController@postSubscriptions');
 

--- a/database/migrations/2017_06_29_185542_AddIndexToTimestamps.php
+++ b/database/migrations/2017_06_29_185542_AddIndexToTimestamps.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToTimestamps extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('created_at');
+            $collection->index('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('created_at');
+            $collection->dropIndex('updated_at');
+        });
+    }
+}

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -12,6 +12,8 @@ GET /v1/users
 - `pagination`: __[Experimental]__ Either "standard" or "cursor". Cursor pagination is _significantly_ faster, but does not provide any information on the total number of results (only whether another page exists).
 - `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
+- `before`: Filter the collection to include _only_ users with timestamps before the given date or datetime. For example, `/v1/users?before[created_at]=1/1/2015`. 
+- `after`: Filter the collection to include _only_ users with timestamps after the given date or datetime. For example, `/v1/users?after[created_at]=1/1/2015`. 
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v1/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.
 - `search`: Search the collection for users with fields whose value match the query. For example, `/v1/users?search[id]=test@example.com&search[email]=test@example.org` would return all users with either an ID or email address matching `test@example.org`. You can search by one or more indexed fields.
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -169,15 +169,17 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      * @param array $scopes
      * @return $this
      */
-    public function asUser($user, $scopes = [])
+    public function withAccessToken($scopes = [], $user = null)
     {
         $accessToken = new AccessTokenEntity();
         $accessToken->setClient(new ClientEntity('phpunit', 'PHPUnit', $scopes));
         $accessToken->setIdentifier(bin2hex(random_bytes(40)));
         $accessToken->setExpiryDateTime((new \DateTime())->add(new DateInterval('PT1H')));
 
-        $accessToken->setUserIdentifier($user->id);
-        $accessToken->setRole($user->role);
+        if ($user) {
+            $accessToken->setUserIdentifier($user->id);
+            $accessToken->setRole($user->role);
+        }
 
         foreach ($scopes as $identifier) {
             if (! array_key_exists($identifier, Scope::all())) {
@@ -195,6 +197,18 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         ]);
 
         return $this;
+    }
+
+    /**
+     * Create a signed JWT to authorize resource requests.
+     *
+     * @param User $user
+     * @param array $scopes
+     * @return $this
+     */
+    public function asUser($user, $scopes = [])
+    {
+        return $this->withAccessToken($scopes, $user);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for querying users by timeframes. For example:

```sh
# users updated before 1/1/2010
GET v1/users?before[updated_at]=1/1/2010

# users updated after 1/1/2010
GET v1/users?after[updated_at]=1/1/2010

# users created between 1/1/2010 and 10/25/2011
GET v1/users?after[created_at]=1/1/2010&before[created_at]=10/25/2011
```

It also includes various little touch-ups, like improved docblocks & test helpers.

#### How should this be reviewed?
I'd recommend going commit-by-commit.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  