### PR TITLE
Log user profile changes.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,6 +31,12 @@ class AppServiceProvider extends ServiceProvider
             app('stathat')->ezCount('user created');
             app('stathat')->ezCount('user created - '.$user->source);
         });
+
+        User::updating(function (User $user) {
+            // Write profile changes to the log, with redacted values for hidden fields.
+            $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
+            logger('updated user', ['id' => $user->id, 'client_id' => client_id(), 'changed' => $changed]);
+        });
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -118,3 +118,21 @@ function country_code()
 
     return $code ? Str::upper($code) : null;
 }
+
+/**
+ * Replace the given keys with a value.
+ *
+ * @param $array
+ * @param $keys
+ * @return mixed
+ */
+function array_replace_keys($array, $keys, $value)
+{
+    foreach ($keys as $key) {
+        if (isset($array[$key])) {
+            $array[$key] = $value;
+        }
+    }
+
+    return $array;
+}

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -7,6 +7,8 @@ class UserModelTest extends TestCase
     /** @test */
     public function it_should_send_new_users_to_blink()
     {
+        config(['features.blink' => true]);
+
         /** @var User $user */
         $user = factory(User::class)->create([
             'birthdate' => '1/2/1990',

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -35,4 +35,24 @@ class UserModelTest extends TestCase
             'created_at' => $user->created_at->toIso8601String(),
         ]);
     }
+
+    /** @test */
+    public function it_should_log_changes()
+    {
+        $logger = $this->spy('log');
+        $user = User::create();
+
+        $user->first_name = 'Caroline';
+        $user->password = 'secret';
+        $user->save();
+
+        $logger->shouldHaveReceived('debug')->once()->with('updated user', [
+            'id' => $user->id,
+            'client_id' => 'northstar',
+            'changed' => [
+                'first_name' => 'Caroline',
+                'password' => '*****',
+            ],
+        ]);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -265,6 +265,21 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
     }
 
     /**
+     * Spy on a class.
+     *
+     * @param $class String - Class name to mock
+     * @return \Mockery\MockInterface
+     */
+    public function spy($class)
+    {
+        $spy = Mockery::spy($class);
+
+        $this->app->instance($class, $spy);
+
+        return $spy;
+    }
+
+    /**
      * "Freeze" time so we can make assertions based on it.
      *
      * @param string $time


### PR DESCRIPTION
#### What's this PR do?
This pull request writes any changes to user profiles to the log file, which will help us debug unexpected changes in the future. Any "hidden" values (like password hashes) will be automatically replaced with asterisks in the log. Closes #335.

#### How should this be reviewed?
I'd recommend going commit-by-commit.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  