### PR TITLE
Two tiny touch-ups for password resets.

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -11,7 +11,7 @@ return [
     | framework needs to place the application's name in a notification or
     | any other location as required by the application or its packages.
     */
-    'name' => env('APP_NAME', 'Northstar'),
+    'name' => env('APP_NAME', 'DoSomething.org'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/auth/emails/password.blade.php
+++ b/resources/views/auth/emails/password.blade.php
@@ -1,4 +1,0 @@
-No worries! We've got you. Just use the link below to reset your password:<br/><br/>
-
-<a href="{{ $link = config('app.url').'/password/reset/'.$token.'?email='.urlencode($user->getEmailForPasswordReset()) }}"> {{ $link }} </a>
-


### PR DESCRIPTION
#### What's this PR do?
Two tiny fixes after fully testing Laravel 5.3's new password resets in production. I've updated the default `app.name` value to be something user-facing, and removed an used old email template. 🔨

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
