### PR TITLE
Create a user when logging in via Facebook

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -54,6 +54,14 @@ class FacebookController extends Controller
      */
     public function handleProviderCallback()
     {
+        // TODO: I think we should verify the Facebook token here to make sure
+        // someone can't send a fake FB response & take over an account.
+        // This will require re-introducing the Facebook service I just removed
+        // in a prior commit. :facepalm:
+        //
+        // https://stackoverflow.com/a/16822904/2129670
+        // https://github.com/DoSomething/northstar/pull/605/files#diff-84b65dc95c66e295b3b94d21c873ea18L46
+
         $facebookUser = Socialite::driver('facebook')->user();
         $northstarUser = User::where('email', '=', $facebookUser->email)->first();
 
@@ -70,7 +78,6 @@ class FacebookController extends Controller
         } else {
             // TODO: Sync the existing user with Facebook fields.
         }
-
 
         $this->auth->guard('web')->login($northstarUser, true);
 

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -79,7 +79,6 @@ class FacebookController extends Controller
             // TODO: Sync the existing user with Facebook fields.
         }
 
-
         $this->auth->guard('web')->login($northstarUser, true);
 
         // TODO: Implement a feature flag for Phoenix requests, then uncomment this email request.

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -69,7 +69,7 @@ class FacebookController extends Controller
             $fields = [
                 'email' => $facebookUser->email,
                 'facebook_id' => $facebookUser->id,
-                'first_name' => $facebookUser->name, // QUESTION: Should we attempt to split the string here or leave it?
+                'first_name' => explode(" ", $facebookUser->name)[0],
                 'country' => country_code(),
                 'language' => app()->getLocale(),
             ];

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -3,9 +3,40 @@
 namespace Northstar\Http\Controllers\Web;
 
 use Socialite;
+use Illuminate\Contracts\Auth\Factory as Auth;
+use Northstar\Auth\Registrar;
+use Northstar\Models\User;
 
 class FacebookController extends Controller
 {
+    /**
+     * The authentication factory.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $auth;
+
+    /**
+     * The registrar.
+     *
+     * @var Registrar
+     */
+    protected $registrar;
+
+    /**
+     * Make a new FacebookController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param Auth $auth
+     * @param Registrar $registrar
+     * @param AuthorizationServer $oauth
+     */
+    public function __construct(Auth $auth, Registrar $registrar)
+    {
+        $this->auth = $auth;
+        $this->registrar = $registrar;
+    }
+
     /**
      * Redirect the user to the Facebook authentication page.
      *
@@ -23,7 +54,28 @@ class FacebookController extends Controller
      */
     public function handleProviderCallback()
     {
-        $user = Socialite::driver('facebook')->user();
-        dd($user);
+        $facebookUser = Socialite::driver('facebook')->user();
+        $northstarUser = User::where('email', '=', $facebookUser->email)->first();
+
+        if (! isset($northstarUser)) {
+            $fields = [
+                'email' => $facebookUser->email,
+                'facebook_id' => $facebookUser->id,
+                'first_name' => $facebookUser->name, // QUESTION: Should we attempt to split the string here or leave it?
+                'country' => country_code(),
+                'language' => app()->getLocale(),
+            ];
+
+            $northstarUser = $this->registrar->register($fields, null);
+        } else {
+            // TODO: Sync the existing user with Facebook fields.
+        }
+
+
+        $this->auth->guard('web')->login($northstarUser, true);
+
+        $this->registrar->sendWelcomeEmail($northstarUser);
+
+        return redirect()->intended('/');
     }
 }

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -66,10 +66,12 @@ class FacebookController extends Controller
         $northstarUser = User::where('email', '=', $facebookUser->email)->first();
 
         if (! $northstarUser) {
+            $name = get_first_and_last($facebookUser->name);
             $fields = [
                 'email' => $facebookUser->email,
                 'facebook_id' => $facebookUser->id,
-                'first_name' => explode(' ', $facebookUser->name)[0],
+                'first_name' => $name['first_name'],
+                'last_name' => $name['last_name'],
                 'country' => country_code(),
                 'language' => app()->getLocale(),
             ];

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -69,7 +69,7 @@ class FacebookController extends Controller
             $fields = [
                 'email' => $facebookUser->email,
                 'facebook_id' => $facebookUser->id,
-                'first_name' => explode(" ", $facebookUser->name)[0],
+                'first_name' => explode(' ', $facebookUser->name)[0],
                 'country' => country_code(),
                 'language' => app()->getLocale(),
             ];

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -65,7 +65,7 @@ class FacebookController extends Controller
         $facebookUser = Socialite::driver('facebook')->user();
         $northstarUser = User::where('email', '=', $facebookUser->email)->first();
 
-        if (! isset($northstarUser)) {
+        if (! $northstarUser) {
             $fields = [
                 'email' => $facebookUser->email,
                 'facebook_id' => $facebookUser->id,
@@ -79,9 +79,11 @@ class FacebookController extends Controller
             // TODO: Sync the existing user with Facebook fields.
         }
 
+
         $this->auth->guard('web')->login($northstarUser, true);
 
-        $this->registrar->sendWelcomeEmail($northstarUser);
+        // TODO: Implement a feature flag for Phoenix requests, then uncomment this email request.
+        // $this->registrar->sendWelcomeEmail($northstarUser);
 
         return redirect()->intended('/');
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -140,14 +140,15 @@ function array_replace_keys($array, $keys, $value)
 /**
  * Get the first & last name for the given full name.
  *
- * @param  String $full_name
- * @return Array
+ * @param  string $full_name
+ * @return array
  */
-function get_first_and_last($full_name) {
+function get_first_and_last($full_name)
+{
     $parts = explode(' ', $full_name);
 
     return [
         'first_name' => $parts[0],
-        'last_name' => sizeof($parts) >= 2 ? $parts[1] : '',
+        'last_name' => count($parts) >= 2 ? $parts[1] : '',
     ];
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -145,5 +145,9 @@ function array_replace_keys($array, $keys, $value)
  */
 function get_first_and_last($full_name) {
     $parts = explode(' ', $full_name);
-    return ['first_name' => $parts[0], 'last_name' => $parts[1]];
+
+    return [
+        'first_name' => $parts[0],
+        'last_name' => sizeof($parts) >= 2 ? $parts[1] : '',
+    ];
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -136,3 +136,14 @@ function array_replace_keys($array, $keys, $value)
 
     return $array;
 }
+
+/**
+ * Get the first & last name for the given full name.
+ *
+ * @param  String $full_name
+ * @return Array
+ */
+function get_first_and_last($full_name) {
+    $parts = explode(' ', $full_name);
+    return ['first_name' => $parts[0], 'last_name' => $parts[1]];
+}

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -45,7 +45,6 @@ class FacebookTest extends TestCase
         $this->assertEquals($user->email, 'test@dosomething.org');
     }
 
-
     /**
      * Test that a full name is split into just a first name.
      */

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -44,4 +44,19 @@ class FacebookTest extends TestCase
         $user = auth()->user();
         $this->assertEquals($user->email, 'test@dosomething.org');
     }
+
+
+    /**
+     * Test that a full name is split into just a first name.
+     */
+    public function testFacebookNameSplit()
+    {
+        $this->mockSocialiteFacade('test@dosomething.org', 'Puppet Sloth', 12345);
+
+        $this->visit('/facebook/verify')->seePageIs('/');
+        $this->seeIsAuthenticated('web');
+
+        $user = auth()->user();
+        $this->assertEquals($user->first_name, 'Puppet');
+    }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -4,6 +4,23 @@ class FacebookTest extends TestCase
 {
 
     /**
+     * Mock a Socialite user.
+     *
+     * @param  string  $email email
+     * @param  string  $token token
+     * @param  integer $id    id
+     */
+    private function mockSocialiteFacade($email, $name, $id)
+    {
+        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
+
+        $user = new Laravel\Socialite\Two\User();
+        $user->map(compact('id', 'name', 'email'));
+
+        Socialite::shouldReceive('driver->user')->andReturn($user);
+    }
+
+    /**
      * Test that a user is redirected to Facebook
      * @expectedException \Illuminate\Foundation\Testing\HttpException
      * @expectedExceptionMessageRegExp /www\.facebook\.com/
@@ -14,4 +31,18 @@ class FacebookTest extends TestCase
         $this->assertRedirectedTo('https://www.facebook.com/');
     }
 
+    /**
+     * Test a brand new user connecting through Facebook will
+     * successfully get logged in with an account.
+     */
+    public function testFacebookVerify()
+    {
+        $this->mockSocialiteFacade('test@dosomething.org', 'Joe', 12345);
+
+        $this->visit('/facebook/verify')->seePageIs('/');
+        $this->seeIsAuthenticated('web');
+
+        $user = auth()->user();
+        $this->assertEquals($user->email, 'test@dosomething.org');
+    }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -8,7 +8,7 @@ class FacebookTest extends TestCase
      *
      * @param  string  $email email
      * @param  string  $token token
-     * @param  integer $id    id
+     * @param  int     $id    id
      */
     private function mockSocialiteFacade($email, $name, $id)
     {

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -8,7 +8,8 @@ class FacebookTest extends TestCase
      * @expectedException \Illuminate\Foundation\Testing\HttpException
      * @expectedExceptionMessageRegExp /www\.facebook\.com/
      */
-    public function testFacebookRedirect() {
+    public function testFacebookRedirect()
+    {
         $this->visit('/facebook/continue');
         $this->assertRedirectedTo('https://www.facebook.com/');
     }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -57,5 +57,6 @@ class FacebookTest extends TestCase
 
         $user = auth()->user();
         $this->assertEquals($user->first_name, 'Puppet');
+        $this->assertEquals($user->last_name, 'Sloth');
     }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -2,7 +2,6 @@
 
 class FacebookTest extends TestCase
 {
-
     /**
      * Mock a Socialite user.
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use Socialite;
 use DoSomething\Gateway\Blink;
 use League\OAuth2\Server\CryptKey;
 use Northstar\Auth\Entities\AccessTokenEntity;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,6 @@
 <?php
 
 use Carbon\Carbon;
-use Socialite;
 use DoSomething\Gateway\Blink;
 use League\OAuth2\Server\CryptKey;
 use Northstar\Auth\Entities\AccessTokenEntity;


### PR DESCRIPTION
#### What's this PR do?
- Takes some of the public profile fields and converts them into a Northstar user
- Leaves several TODO's for finishing this feature out (at least enough to call it an MVP, still need to think about Facebook scopes for more profile fields)
- Adds some testing

**SECURITY NOTE**: This has a security hole I pointed out in the comments, but it only applies to account merging, which is not handled (yet), so it's safe to merge this PR.

#### How should this be reviewed?
When you hit the facebook continue endpoint you should be logged into a new account

#### Checklist
- [x] Tests added for new features/bug fixes.
