### PR TITLE
Verify Facebook token before auth

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -59,7 +59,7 @@ class FacebookController extends Controller
 
         try {
             // Confirm the details are real by asking for them again with the given Facebook token.
-            // This token only works if the user is asking for their own profile information.
+            // This token only works if the user is asking for their profile information.
             $facebookUser = Socialite::driver('facebook')->userFromToken($requestUser->token);
         } catch (RequestException $e) {
             return redirect('/login')->with('status', 'Unable to verify Facebook account.');

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -4,6 +4,7 @@ namespace Northstar\Http\Controllers\Web;
 
 use Socialite;
 use Illuminate\Contracts\Auth\Factory as Auth;
+use GuzzleHttp\Exception\RequestException;
 use Northstar\Auth\Registrar;
 use Northstar\Models\User;
 
@@ -54,15 +55,16 @@ class FacebookController extends Controller
      */
     public function handleProviderCallback()
     {
-        // TODO: I think we should verify the Facebook token here to make sure
-        // someone can't send a fake FB response & take over an account.
-        // This will require re-introducing the Facebook service I just removed
-        // in a prior commit. :facepalm:
-        //
-        // https://stackoverflow.com/a/16822904/2129670
-        // https://github.com/DoSomething/northstar/pull/605/files#diff-84b65dc95c66e295b3b94d21c873ea18L46
+        $requestUser = Socialite::driver('facebook')->user();
 
-        $facebookUser = Socialite::driver('facebook')->user();
+        try {
+            // Confirm the details are real by asking for them again with the given Facebook token.
+            // This token only works if the user is asking for their own profile information.
+            $facebookUser = Socialite::driver('facebook')->userFromToken($requestUser->token);
+        } catch (RequestException $e) {
+            return redirect('/login')->with('status', 'Unable to verify Facebook account.');
+        }
+
         $northstarUser = User::where('email', '=', $facebookUser->email)->first();
 
         if (! $northstarUser) {

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -9,7 +9,8 @@ class FacebookTest extends TestCase
      * @param  array  $fields
      * @param  string $method
      */
-    private function mockSocialiteFacade($fields, $method) {
+    private function mockSocialiteFacade($fields, $method)
+    {
         $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
 
         $user = new Laravel\Socialite\Two\User();

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -3,6 +3,22 @@
 class FacebookTest extends TestCase
 {
     /**
+     * Mock a Socialite user for the given
+     * method and user fields.
+     *
+     * @param  array  $fields
+     * @param  string $method
+     */
+    private function mockSocialiteFacade($fields, $method) {
+        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
+
+        $user = new Laravel\Socialite\Two\User();
+        $user->map($fields);
+
+        Socialite::shouldReceive($method)->andReturn($user);
+    }
+
+    /**
      * Mock a Socialite user.
      *
      * @param  string  $email email
@@ -12,12 +28,7 @@ class FacebookTest extends TestCase
      */
     private function mockSocialiteFromUser($email, $name, $id, $token)
     {
-        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
-
-        $user = new Laravel\Socialite\Two\User();
-        $user->map(compact('id', 'name', 'email', 'token'));
-
-        Socialite::shouldReceive('driver->user')->andReturn($user);
+        $this->mockSocialiteFacade(compact('id', 'name', 'email', 'token'), 'driver->user');
     }
 
     /**
@@ -30,12 +41,7 @@ class FacebookTest extends TestCase
      */
     private function mockSocialiteFromUserToken($email, $name, $id, $token)
     {
-        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
-
-        $user = new Laravel\Socialite\Two\User();
-        $user->map(compact('id', 'name', 'email', 'token'));
-
-        Socialite::shouldReceive('driver->userFromToken')->andReturn($user);
+        $this->mockSocialiteFacade(compact('id', 'name', 'email', 'token'), 'driver->userFromToken');
     }
 
     /**

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -88,7 +88,7 @@ class FacebookTest extends TestCase
     public function testFacebookTokenValidation()
     {
         $this->mockSocialiteFromUser('test@dosomething.org', 'Puppet Sloth', '12345', 'token');
-        Socialite::shouldReceive('driver->userFromToken')->andReturnUsing(function() {
+        Socialite::shouldReceive('driver->userFromToken')->andReturnUsing(function () {
             $request = new GuzzleHttp\Psr7\Request('GET', 'http://graph.facebook.com');
             throw new GuzzleHttp\Exception\RequestException('Token validation failed', $request);
         });


### PR DESCRIPTION
#### What's this PR do?
- This PR uses the socialite `getUserFromToken` function in combination with the token supplied by the callback response. Thus, if a user faked a random string, Facebook graph will not be able to use that token & return the proper user profile.
- Adds some more testing around the token response

#### How should this be reviewed?
- Run the test suite to check for bad token handling, or manually add this change`$requestUser->token = 'blahblah'`
- If you hit the `facebook/continue` endpoint as a regular non-hacker human being nothing should change for you

#### Checklist
- [x] Tests added for new features/bug fixes.