### PR TITLE
Merge a Facebook account and a Northstar account on login

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -66,9 +66,9 @@ class FacebookController extends Controller
         }
 
         $northstarUser = User::where('email', '=', $facebookUser->email)->first();
+        $name = get_first_and_last($facebookUser->name);
 
         if (! $northstarUser) {
-            $name = get_first_and_last($facebookUser->name);
             $fields = [
                 'email' => $facebookUser->email,
                 'facebook_id' => $facebookUser->id,
@@ -80,7 +80,11 @@ class FacebookController extends Controller
 
             $northstarUser = $this->registrar->register($fields, null);
         } else {
-            // TODO: Sync the existing user with Facebook fields.
+            // Fill in any blank fields with Facebook values.
+            $northstarUser->facebook_id ? null : $northstarUser->facebook_id = $facebookUser->id;
+            $northstarUser->first_name ? null : $northstarUser->fist_name = $name['first_name'];
+            $northstarUser->last_name ? null : $northstarUser->last_name = $name['last_name'];
+            $northstarUser->save();
         }
 
         $this->auth->guard('web')->login($northstarUser, true);

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -80,11 +80,11 @@ class FacebookController extends Controller
 
             $northstarUser = $this->registrar->register($fields, null);
         } else {
-            // Fill in any blank fields with Facebook values.
-            $northstarUser->facebook_id ? null : $northstarUser->facebook_id = $facebookUser->id;
-            $northstarUser->first_name ? null : $northstarUser->fist_name = $name['first_name'];
-            $northstarUser->last_name ? null : $northstarUser->last_name = $name['last_name'];
-            $northstarUser->save();
+            $northstarUser->fillUnlessNull([
+               'facebook_id' => $facebookUser->id,
+               'first_name' => $name['first_name'],
+               'last_name' => $name['last_name'],
+            ]);
         }
 
         $this->auth->guard('web')->login($northstarUser, true);

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -85,6 +85,7 @@ class FacebookController extends Controller
                'first_name' => $name['first_name'],
                'last_name' => $name['last_name'],
             ]);
+            $northstarUser->save();
         }
 
         $this->auth->guard('web')->login($northstarUser, true);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -377,9 +377,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Fill & save the user with the given array
-     * of fields. Filter out any fields that
-     * have a null value.
+     * Fill & save the user with the given array of fields.
+     * Filter out any fields that have a null value.
      *
      * @param  array $fields
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -385,6 +385,5 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function fillUnlessNull($fields)
     {
         $this->fill(array_filter($fields));
-        $this->save();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -375,4 +375,17 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         return $query->where('campaigns', 'elemMatch', ['signup_id' => $id])
             ->orWhere('campaigns', 'elemMatch', ['signup_group' => $id])->get();
     }
+
+    /**
+     * Fill & save the user with the given array
+     * of fields. Filter out any fields that
+     * have a null value.
+     *
+     * @param  array $fields
+     */
+    public function fillUnlessNull($fields)
+    {
+        $this->fill(array_filter($fields));
+        $this->save();
+    }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -13,8 +13,6 @@ class FacebookTest extends TestCase
      */
     private function mockSocialiteFacade($fields, $method)
     {
-        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
-
         $user = new Laravel\Socialite\Two\User();
         $user->map($fields);
 
@@ -116,7 +114,7 @@ class FacebookTest extends TestCase
     {
         $factoryUser = factory(User::class)->create([
             'email' => 'test@dosomething.org',
-            'first_name' => 'Joe'
+            'first_name' => 'Joe',
         ]);
 
         $this->mockSocialiteFromUser('test@dosomething.org', 'Puppet Sloth', '12345', 'token');

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Northstar\Models\User;
+
 class FacebookTest extends TestCase
 {
     /**
@@ -104,5 +106,26 @@ class FacebookTest extends TestCase
             ->seePageIs('/login')
             ->see('Unable to verify Facebook account.');
         $this->dontSeeIsAuthenticated('web');
+    }
+
+    /**
+     * Test that an existing Northstar account can successfully login and merge
+     * with a Facebook user profile.
+     */
+    public function testFacebookAccountMerge()
+    {
+        $factoryUser = factory(User::class)->create([
+            'email' => 'test@dosomething.org',
+            'first_name' => 'Joe'
+        ]);
+
+        $this->mockSocialiteFromUser('test@dosomething.org', 'Puppet Sloth', '12345', 'token');
+        $this->mockSocialiteFromUserToken('test@dosomething.org', 'Puppet Sloth', '12345', 'token');
+
+        $this->visit('/facebook/verify');
+
+        $user = auth()->user();
+        $this->assertEquals($user->first_name, 'Joe');
+        $this->assertEquals($user->last_name, 'Sloth');
     }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -123,7 +123,7 @@ class FacebookTest extends TestCase
         $this->visit('/facebook/verify');
 
         $user = auth()->user();
-        $this->assertEquals($user->first_name, 'Joe');
+        $this->assertEquals($user->first_name, 'Puppet');
         $this->assertEquals($user->last_name, 'Sloth');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- This PR handles cases where a user logs in & the email on Facebook matches a Northstar email.
- In this scenario, we make sure the Facebook Id is set, along with the first+last name. If any of these are not set, we fill them in & save the user. Eventually, this will expand to include birthday, mobile, address, etc

#### How should this be reviewed?
Try logging in via Facebook, then delete either your Facebook ID or a last+first name value. I've been doing this in Mongo with,

```
db.users.update({email: "thedeadlybutter@gmail.com"}, {$set: {"last_name": ""}})
```

Then, log out of Northstar and log back in via Facebook. The missing value should be filled in.

_You can also just run the test!_

#### Checklist
- [x] Tests added for new features/bug fixes.