### PR TITLE
More styling for the register page, pulling in new variables

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -186,7 +186,7 @@ class AuthController extends BaseController
             'birthdate' => 'required|date',
             'email' => 'required|email|unique:users',
             'mobile' => 'mobile|unique:users',
-            'password' => 'required|confirmed|min:6|max:512',
+            'password' => 'required|min:6|max:512',
         ]);
 
         // Register and login the user.

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -77,7 +77,6 @@ class AuthController extends BaseController
         session(['referrer_uri' => request()->query('referrer_uri')]);
 
         if (! $this->auth->guard('web')->check()) {
-            // TODO: Wat is this
             $authorizationRoute = request()->query('mode') === 'login' ? 'login' : 'register';
 
             session([

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -78,8 +78,7 @@ class AuthController extends BaseController
 
         if (! $this->auth->guard('web')->check()) {
             $authorizationRoute = request()->query('mode') === 'register' ? 'register' : 'login';
-            $destination = request()->query('destination', $client->getName());
-            session(['destination' => $destination]);
+            set_auth_experience_session();
 
             return redirect()->guest($authorizationRoute);
         }

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -77,7 +77,8 @@ class AuthController extends BaseController
         session(['referrer_uri' => request()->query('referrer_uri')]);
 
         if (! $this->auth->guard('web')->check()) {
-            $authorizationRoute = request()->query('mode') === 'register' ? 'register' : 'login';
+            // TODO: Wat is this
+            $authorizationRoute = request()->query('mode') === 'login' ? 'login' : 'register';
 
             session([
                 'destination' => request()->query('destination', $client->getName()),

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -78,7 +78,13 @@ class AuthController extends BaseController
 
         if (! $this->auth->guard('web')->check()) {
             $authorizationRoute = request()->query('mode') === 'register' ? 'register' : 'login';
-            set_auth_experience_session();
+
+            session([
+                'destination' => request()->query('destination', $client->getName()),
+                'title' => request()->query('title'),
+                'callToAction' => request()->query('callToAction'),
+                'coverPhoto' => request()->query('coverPhoto'),
+            ]);
 
             return redirect()->guest($authorizationRoute);
         }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -157,16 +157,3 @@ function format_birthdate($birthdate)
 
     return format_date($birthdate, 'Y-m-d');
 }
-
-/**
- * Set the session variables from the auth request.
- */
-function set_auth_experience_session()
-{
-    session([
-        'destination' => request()->query('destination'),
-        'title' => request()->query('title'),
-        'callToAction' => request()->query('callToAction'),
-        'coverPhoto' => request()->query('coverPhoto'),
-    ]);
-}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -157,3 +157,16 @@ function format_birthdate($birthdate)
 
     return format_date($birthdate, 'Y-m-d');
 }
+
+/**
+ * Set the session variables from the auth request.
+ */
+function set_auth_experience_session()
+{
+    session([
+        'destination' => request()->query('destination'),
+        'title' => request()->query('title'),
+        'callToAction' => request()->query('callToAction'),
+        'coverPhoto' => request()->query('coverPhoto'),
+    ]);
+}

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -11,7 +11,7 @@ tampering, and can be verified using a shared public key.
 
 __Here's the tl;dr:__ If a user is logging in to an application and making requests, use the [Authorization Code grant](#create-token-authorization-code-grant)
  to request an access & refresh token for them. If you're performing requests as a "machine" (not as a direct result of a
- user's action), use the [Client Credentials Grant](#create-token-client-credentials-grant). 
+ user's action), use the [Client Credentials Grant](#create-token-client-credentials-grant).
 
 ## Create Token (Authorization Code Grant)
 The authorization code grant allows you to authorize a user without needing to manually handle their username or password.
@@ -25,6 +25,9 @@ Redirect the user to Northstar's "authorize" page with the following query strin
 * `response_type` with the value `code`
 * `client_id` with your Client ID
 * `destination` with a destination to display on the login page (optional)
+* `title` with a title to display on the registration page (optional)
+* `callToAction` with a call to action to display on the registration page (optional)
+* `coverPhoto` with a link to a cover photo to display on the registration page (optional)
 * `scope` with a space-delimited list of scopes to request
 * `state` with a CSRF token that can be validated below
 
@@ -51,13 +54,13 @@ POST /v2/auth/token
 
 ```js
 // Content-Type: application/json
- 
+
 {
   grant_type: 'authorization_code',
-  
+
   // The client application's Client ID (required)
   client_id: String,
-  
+
   // The client application's Client Secret (required)
   client_secret: String,
 

--- a/resources/assets/scss/_components/_forms.scss
+++ b/resources/assets/scss/_components/_forms.scss
@@ -2,3 +2,18 @@
 .form-required {
   display: none;
 }
+
+.form-item.-reduced {
+  @include media($tablet) {
+    display: table-cell;
+    padding-bottom: $base-spacing / 2;
+
+    &:not(:last-child) {
+      padding-right: $base-spacing / 2;
+    }
+  }
+}
+
+.form-actions.-left {
+  float: left;
+}

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -7,7 +7,7 @@ return [
     ],
     'log_in' => [
         'default' => 'Log In',
-        'existing' => 'Log in to an existing account',
+        'existing' => 'Already have an account? Sign in.',
         'create' => 'Create a DoSomething.org account',
         'submit' => 'Create New Account',
         'facebook' => 'Continue with Facebook',
@@ -15,6 +15,7 @@ return [
     'get_started' => [
         'log_in' => 'Log in to get started!',
         'create_account' => 'Create a DoSomething.org account to get started!',
+        'call_to_action' => 'Join 5.5 million young people taking action.',
     ],
     'validation' => [
         'issues' => 'Hmm, there were some issues with that submission:',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -25,33 +25,18 @@
 
             <div>
                 <div class="form-item -reduced">
-                    <label for="first_name" class="field-label">
-                        <div class="validation">
-                            <div class="validation__label">{{ trans('auth.fields.first_name') }} <span class="form-required" title="This field is required.">*</span></div>
-                            <div class="validation__message"></div>
-                        </div>
-                    </label>
+                    <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
                     <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
                 </div>
 
                 <div class="form-item -reduced">
-                    <label for="birthdate" class="field-label">
-                        <div class="validation">
-                            <div class="validation__label">{{ trans('auth.fields.birthday') }} <span class="form-required" title="This field is required.">*</span></div>
-                            <div class="validation__message"></div>
-                        </div>
-                    </label>
+                    <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
                     <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
                 </div>
             </div>
 
             <div class="form-item">
-                <label for="email" class="field-label">
-                    <div class="validation">
-                        <div class="validation__label">{{ trans('auth.fields.email') }} <span class="form-required" title="This field is required.">*</span></div>
-                        <div class="validation__message"></div>
-                    </div>
-                </label>
+                <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
                 <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
             </div>
 
@@ -63,12 +48,7 @@
             @endif
 
             <div class="form-item">
-                <label for="password" class="field-label">
-                    <div class="validation">
-                        <div class="validation__label">{{ trans('auth.fields.password') }} <span class="form-required" title="This field is required.">*</span></div>
-                        <div class="validation__message"></div>
-                    </div>
-                </label>
+                <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
                 <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
             </div>
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -3,8 +3,9 @@
 @section('title', 'Create Account | DoSomething.org')
 
 @section('content')
-    <div class="container__block -centered">
-        <h1>{{ trans('auth.get_started.create_account') }}</h1>
+    <div class="container__block">
+        <h2>{{ session('title', trans('auth.get_started.create_account')) }}</h2>
+        <p>{{ session('callToAction', trans('auth.get_started.call_to_action')) }}
     </div>
 
     <div class="container__block -centered">
@@ -22,24 +23,26 @@
         <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
             <input name="_token" type="hidden" value="{{ csrf_token() }}">
 
-            <div class="form-item">
-                <label for="first_name" class="field-label">
-                    <div class="validation">
-                        <div class="validation__label">{{ trans('auth.fields.first_name') }} <span class="form-required" title="This field is required.">*</span></div>
-                        <div class="validation__message"></div>
-                    </div>
-                </label>
-                <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
-            </div>
+            <div>
+                <div class="form-item -reduced">
+                    <label for="first_name" class="field-label">
+                        <div class="validation">
+                            <div class="validation__label">{{ trans('auth.fields.first_name') }} <span class="form-required" title="This field is required.">*</span></div>
+                            <div class="validation__message"></div>
+                        </div>
+                    </label>
+                    <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
+                </div>
 
-            <div class="form-item">
-                <label for="birthdate" class="field-label">
-                    <div class="validation">
-                        <div class="validation__label">{{ trans('auth.fields.birthday') }} <span class="form-required" title="This field is required.">*</span></div>
-                        <div class="validation__message"></div>
-                    </div>
-                </label>
-                <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                <div class="form-item -reduced">
+                    <label for="birthdate" class="field-label">
+                        <div class="validation">
+                            <div class="validation__label">{{ trans('auth.fields.birthday') }} <span class="form-required" title="This field is required.">*</span></div>
+                            <div class="validation__message"></div>
+                        </div>
+                    </label>
+                    <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                </div>
             </div>
 
             <div class="form-item">
@@ -69,17 +72,7 @@
                 <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
             </div>
 
-            <div class="form-item">
-                <label for="password_confirmation" class="field-label">
-                    <div class="validation">
-                        <div class="validation__label">{{ trans('auth.fields.confirm_password') }} <span class="form-required" title="This field is required.">*</span></div>
-                        <div class="validation__message"></div>
-                    </div>
-                </label>
-                <input name="password_confirmation" type="password" id="password_confirmation" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.double_checking') }}" data-validate="match" data-validate-required data-validate-match="#password" />
-            </div>
-
-            <div class="form-actions -padded">
+            <div class="form-actions -padded -left">
                 <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
             </div>
         </form>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -26,7 +26,7 @@
             @if (isset($extended) && $extended)
                 @include('layouts.navigation', ['extended' => true])
                 <section class="container -framed -extended">
-                    <div class="cover-photo" style="background-image: url({{ asset('members.jpg') }})"></div>
+                    <div class="cover-photo" style="background-image: url({{ session('coverPhoto', asset('members.jpg')) }})"></div>
 
                     <div class="wrapper -half">
                         @yield('content')

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Northstar\Models\User;
+use Northstar\Models\Client;
 
 class WebAuthenticationTest extends TestCase
 {
@@ -205,5 +206,24 @@ class WebAuthenticationTest extends TestCase
 
         $this->dontSeeIsAuthenticated('web');
         $this->see('Too many attempts.');
+    }
+
+    public function testAuthorizeSessionVariablesExist()
+    {
+        $client = Client::create(['client_id' => 'phpunit', 'scope' => ['user'], 'redirect_uri' => 'http://example.com/']);
+
+        $this->get('authorize?'.http_build_query([
+            'response_type' => 'code',
+            'client_id' => $client->client_id,
+            'client_secret' => $client->client_secret,
+            'scope' => 'user',
+            'state' => csrf_token(),
+            'title' => 'test title',
+            'callToAction' => 'test call to action',
+        ]))->followRedirects();
+
+        $this->seePageIs('register')
+            ->see('test title')
+            ->see('test call to action');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -352,7 +352,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
             'email' => $this->faker->unique->email,
             'birthdate' => $this->faker->date('m/d/Y', '5 years ago'),
             'password' => 'secret',
-            'password_confirmation' => 'secret',
         ]);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- More styling to the registration page so it nearly matches the mock
- Pulling in the new query params 

#### How should this be reviewed?
<img width="464" alt="screen shot 2017-07-28 at 10 42 42 am" src="https://user-images.githubusercontent.com/897368/28722459-d2775c9e-7381-11e7-8cfa-3d080cff6288.png">
<img width="996" alt="screen shot 2017-07-28 at 10 42 31 am" src="https://user-images.githubusercontent.com/897368/28722458-d2757262-7381-11e7-8391-d4915b5495d0.png">


#### Checklist
**- [ ] Documentation added for changed endpoints.** ([ref](https://github.com/DoSomething/northstar/blob/02795b9f2f7a3ad0ca9fff016e457e29a580a410/documentation/endpoints/auth.md#L27))
**- [ ] Tests added for new features/bug fixes.**

@DFurnes What's the best way to test the session stuff locally?
