### PR TITLE
Facebook launch

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -79,7 +79,7 @@ class FacebookController extends Controller
         }
 
         // If we were denied access to read email, do not log them in.
-        if (! isset($facebookUser->email) || empty($facebookUser->email)) {
+        if (empty($facebookUser->email)) {
             $this->stathat->ezCount('facebook email hidden');
             return redirect('/register')->with('status', 'Unable to verify Facebook account.');
         }

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -83,7 +83,7 @@ class FacebookController extends Controller
         if (empty($facebookUser->email)) {
             $this->stathat->ezCount('facebook email hidden');
 
-            return redirect('/register')->with('status', 'Unable to verify Facebook account.');
+            return redirect('/register')->with('status', 'We need your email to contact you if you win a scholarship.');
         }
 
         // Aggregate public profile fields

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -5,6 +5,7 @@ namespace Northstar\Http\Controllers\Web;
 use Socialite;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use GuzzleHttp\Exception\RequestException;
+use DoSomething\StatHat\Client as StatHat;
 use Northstar\Auth\Registrar;
 use Northstar\Models\User;
 
@@ -25,17 +26,25 @@ class FacebookController extends Controller
     protected $registrar;
 
     /**
+     * The StatHat client.
+     *
+     * @var StatHat
+     */
+    protected $stathat;
+
+    /**
      * Make a new FacebookController, inject dependencies,
      * and set middleware for this controller's methods.
      *
      * @param Auth $auth
      * @param Registrar $registrar
-     * @param AuthorizationServer $oauth
+     * @param StatHat $stathat
      */
-    public function __construct(Auth $auth, Registrar $registrar)
+    public function __construct(Auth $auth, Registrar $registrar, StatHat $stathat)
     {
         $this->auth = $auth;
         $this->registrar = $registrar;
+        $this->stathat = $stathat;
     }
 
     /**
@@ -65,7 +74,14 @@ class FacebookController extends Controller
                 ->fields(['email', 'first_name', 'last_name', 'birthday'])
                 ->userFromToken($requestUser->token);
         } catch (RequestException $e) {
-            return redirect('/login')->with('status', 'Unable to verify Facebook account.');
+            $this->stathat->ezCount('facebook token mismatch');
+            return redirect('/register')->with('status', 'Unable to verify Facebook account.');
+        }
+
+        // If we were denied access to read email, do not log them in.
+        if (! isset($facebookUser->email) || empty($facebookUser->email)) {
+            $this->stathat->ezCount('facebook email hidden');
+            return redirect('/register')->with('status', 'Unable to verify Facebook account.');
         }
 
         // Aggregate public profile fields
@@ -94,6 +110,7 @@ class FacebookController extends Controller
         }
 
         $this->auth->guard('web')->login($northstarUser, true);
+        $this->stathat->ezCount('facebook authentication');
 
         return redirect()->intended('/');
     }

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -75,12 +75,14 @@ class FacebookController extends Controller
                 ->userFromToken($requestUser->token);
         } catch (RequestException $e) {
             $this->stathat->ezCount('facebook token mismatch');
+
             return redirect('/register')->with('status', 'Unable to verify Facebook account.');
         }
 
         // If we were denied access to read email, do not log them in.
         if (empty($facebookUser->email)) {
             $this->stathat->ezCount('facebook email hidden');
+
             return redirect('/register')->with('status', 'Unable to verify Facebook account.');
         }
 

--- a/resources/assets/scss/_components/_divider.scss
+++ b/resources/assets/scss/_components/_divider.scss
@@ -1,0 +1,21 @@
+$divider-height: 2px;
+$content-width: 40px;
+
+.divider {
+  display: block;
+  width: 100%;
+  height: $divider-height;
+  background: $black;
+  position: relative;
+  text-align: center;
+  margin: $base-spacing 0;
+
+  &:before {
+    content: 'or';
+    position: absolute;
+    top: -(($base-spacing / 2) + $divider-height);
+    background: white;
+    width: $content-width;
+    margin-left: -($content-width / 2);
+  }
+}

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -19,6 +19,7 @@
 @import "_components/_messages";
 @import "_components/_facebook-login";
 @import "_components/_cover-photo";
+@import "_components/_divider";
 
 // Regions - complete sections of an interface
 @import "_regions/_chrome";

--- a/resources/views/auth/facebook.blade.php
+++ b/resources/views/auth/facebook.blade.php
@@ -1,3 +1,0 @@
-@if (request()->query('fb') === 'true')
-    <a href="{{ url('facebook/continue') }}" class="button facebook-login">{{ trans('auth.log_in.facebook') }}</a>
-@endif

--- a/resources/views/auth/facebook.blade.php
+++ b/resources/views/auth/facebook.blade.php
@@ -1,0 +1,1 @@
+<a href="{{ url('facebook/continue') }}" class="button facebook-login">{{ trans('auth.log_in.facebook') }}</a>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -54,7 +54,7 @@
     </div>
 
     <div class="container__block -centered">
-        <a href="{{ url('facebook/continue') }}" class="button facebook-login">{{ trans('auth.log_in.facebook') }}</a>
+        @include('auth.facebook')
 
         <ul>
             <li><a href="{{ url('register') }}">{{ trans('auth.log_in.create') }}</a></li>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -54,7 +54,7 @@
     </div>
 
     <div class="container__block -centered">
-        @include('auth.facebook')
+        <a href="{{ url('facebook/continue') }}" class="button facebook-login">{{ trans('auth.log_in.facebook') }}</a>
 
         <ul>
             <li><a href="{{ url('register') }}">{{ trans('auth.log_in.create') }}</a></li>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -8,6 +8,11 @@
         <p>{{ session('callToAction', trans('auth.get_started.call_to_action')) }}
     </div>
 
+    <div class="container__block">
+        <a href="{{ url('facebook/continue') }}" class="button facebook-login">{{ trans('auth.log_in.facebook') }}</a>
+        <span class="divider"></span>
+    </div>
+
     <div class="container__block -centered">
         @if (count($errors) > 0)
             <div class="validation-error fade-in-up">
@@ -59,8 +64,6 @@
     </div>
 
     <div class="container__block -centered">
-        @include('auth.facebook')
-
         <ul>
             <li><a href="{{ url('login') }}">{{ trans('auth.log_in.existing') }}</a></li>
         </ul>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -9,7 +9,7 @@
     </div>
 
     <div class="container__block">
-        <a href="{{ url('facebook/continue') }}" class="button facebook-login">{{ trans('auth.log_in.facebook') }}</a>
+        @include('auth.facebook')
         <span class="divider"></span>
     </div>
 

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -201,7 +201,7 @@ class FacebookTest extends TestCase
 
         $this->visit('/facebook/verify')
             ->seePageIs('/register')
-            ->see('Unable to verify Facebook account.');
+            ->see('We need your email');
         $this->dontSeeIsAuthenticated('web');
     }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -134,7 +134,7 @@ class FacebookTest extends TestCase
         });
 
         $this->visit('/facebook/verify')
-            ->seePageIs('/login')
+            ->seePageIs('/register')
             ->see('Unable to verify Facebook account.');
         $this->dontSeeIsAuthenticated('web');
     }
@@ -188,5 +188,20 @@ class FacebookTest extends TestCase
 
         $user = auth()->user();
         $this->assertEquals($user->birthdate, new Carbon\Carbon('2000-01-01'));
+    }
+
+    /**
+     * If the user does not share email, it should not authenticate them.
+     */
+    public function testMissingEmail()
+    {
+        $abstractUser = $this->mockSocialiteAbstractUser('', 'Puppet', 'Sloth', '12345', 'token', '01/01/2000');
+        $this->mockSocialiteFromUser($abstractUser);
+        $this->mockSocialiteFromUserToken($abstractUser);
+
+        $this->visit('/facebook/verify')
+            ->seePageIs('/register')
+            ->see('Unable to verify Facebook account.');
+        $this->dontSeeIsAuthenticated('web');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds some more error handling for email not being present. Noticed this yesterday when an intern was testing.
- Adds StatHat tracking for a few things
- Adds the "divider" component to separate the normal registration from the facebook auth
- Removes the fb= query param....  ❗️ ⚠️ ❗️ 

#### How should this be reviewed?
1. bite your nails 
2. say a prayer
3. visually inspect everything looks right, test suite passes

<img width="509" alt="screen shot 2017-08-01 at 11 01 01 am" src="https://user-images.githubusercontent.com/897368/28832605-f4398a60-76aa-11e7-8981-b93e8984f4ea.png">
<img width="437" alt="screen shot 2017-08-01 at 11 00 53 am" src="https://user-images.githubusercontent.com/897368/28832606-f43a16b0-76aa-11e7-85d0-5efc719b5f93.png">

#### Checklist
- [x] Tests added for new features/bug fixes.
