### PR TITLE
Adds default session values

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -81,9 +81,9 @@ class AuthController extends BaseController
 
             session([
                 'destination' => request()->query('destination', $client->getName()),
-                'title' => request()->query('title'),
-                'callToAction' => request()->query('callToAction'),
-                'coverPhoto' => request()->query('coverPhoto'),
+                'title' => request()->query('title', trans('auth.get_started.create_account')),
+                'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
+                'coverPhoto' => request()->query('coverPhoto', asset('members.jpg')),
             ]);
 
             return redirect()->guest($authorizationRoute);

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -208,6 +208,10 @@ class WebAuthenticationTest extends TestCase
         $this->see('Too many attempts.');
     }
 
+    /**
+     * Test that the various optional variables for customizing the experience
+     * display on the page.
+     */
     public function testAuthorizeSessionVariablesExist()
     {
         $client = Client::create(['client_id' => 'phpunit', 'scope' => ['user'], 'redirect_uri' => 'http://example.com/']);


### PR DESCRIPTION
#### What's this PR do?
If an app does not pass along `title`, `callToAction`, etc, there will be a default value to take its place. Unfortunately, I didn't experience this bug until I tried logging in from a separate application and was presented with lots of white space!