### PR TITLE
Sending facebook id in the blink payload

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -348,6 +348,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'email' => $this->email,
             'mobile' => $this->mobile,
             'mobile_status' => $this->mobilecommons_status,
+            'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
             'birthdate' => format_date($this->birthdate, 'Y-m-d'),

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -23,6 +23,7 @@ class UserModelTest extends TestCase
             'email' => $user->email,
             'mobile' => $user->mobile,
             'mobile_status' => $user->mobilecommons_status,
+            'facebook_id' => $user->facebook_id,
             'addr_city' => $user->addr_city,
             'addr_state' => $user->addr_state,
             'addr_zip' => $user->addr_zip,


### PR DESCRIPTION
#### What's this PR do?
After some debugging with Sergii we realized Blink was never getting the Facebook ID from Northstar! Whoops.

Just added it to the user function and updated the blink test. (Facebook ID was already in the model generator, just had to ensure it was in the blink payload)