### PR TITLE
Remove ability to backfill 'source' or 'created_at'.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Http\Controllers;
 
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
 use Northstar\Auth\Role;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -111,17 +111,8 @@ class UserController extends Controller
             }
         }
 
-        $user = $this->registrar->register($request->except('role'), $existingUser, function ($user) use ($request, $existingUser) {
-            // Optionally, allow setting a custom "created_at" (useful for back-filling from other services).
-            // We'll only update this value on existing records if it's earlier than the existing timestamp.
-            $created_at = $request->input('created_at');
-            $existingUserHasEarlierCreatedTimestamp = $existingUser && $existingUser->created_at->lte(Carbon::createFromTimestamp($created_at));
-            if ($created_at && ! $existingUserHasEarlierCreatedTimestamp) {
-                $user->created_at = $created_at;
-                $user->setSource($request->input('source', client_id()), $request->input('source_detail'));
-            }
-
-            // Only save a source if not upserting a user (unless back-filling, see above).
+        $user = $this->registrar->register($request->except('role'), $existingUser, function (User $user) use ($request, $existingUser) {
+            // Only save a source if not upserting a user.
             if ($request->has('source') && ! $existingUser) {
                 $user->setSource($request->input('source'), $request->input('source_detail'));
             }

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -108,8 +108,8 @@ class FacebookController extends Controller
             $fields['country'] = country_code();
             $fields['language'] = app()->getLocale();
 
-            $northstarUser = $this->registrar->register($fields, null, function ($user) {
-                $user->setSource(client_id(), 'facebook');
+            $northstarUser = $this->registrar->register($fields, null, function (User $user) {
+                $user->setSource(null, 'facebook');
             });
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -397,7 +397,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setSource($source, $detail = null)
     {
-        $this->source = $source;
+        if ($this->source) {
+            return;
+        }
+
+        $this->source = $source ?: client_id();
         $this->source_detail = $detail;
     }
 }

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -151,7 +151,7 @@ Either a mobile number or email is required.
   slack_id: String
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
-  source: String // Will only be set on new records, or if being provided an earlier `created_at`.
+  source: String // Immutable. Will only be set on new records.
   source_detail: String // Only accepted alongside a valid 'source'.
   created_at: Number // timestamp
 

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -100,6 +100,7 @@ class FacebookTest extends TestCase
 
         $user = auth()->user();
         $this->assertEquals($user->email, 'test@dosomething.org');
+        $this->assertEquals($user->source, 'northstar');
         $this->assertEquals($user->source_detail, 'facebook');
     }
 


### PR DESCRIPTION
#### What's this PR do?
__This pull request removes the ability to backfill `source` or `created_at` via Northstar's general-purpose user endpoint.__ This prevents an issue where clock drift between servers was causing it to appear that MobileCommons users were always "older" (by 6 seconds! ⏱) than the one's we'd just created in Northstar, and therefore unexpectedly overwrite sources as `sms`. 

Since we're no longer backfilling old user data into Northstar (and likely won't ever need to again), I think this is safe to remove so we can reduce some complexity.

Closes [#149379309](https://www.pivotaltracker.com/story/show/149379309).

#### How should this be reviewed?
I updated the test suite for the new expected behavior.

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  