### PR TITLE
Add command to retroactively fix incorrect Niche import sources.

### DIFF
--- a/app/Console/Commands/FixSourcesCommand.php
+++ b/app/Console/Commands/FixSourcesCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use League\Csv\Reader;
+use Northstar\Models\User;
+
+class FixSourcesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:sources {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix incorrect sources using the provided CSV.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //
+        $this->info('Done!');
+    }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
         \Northstar\Console\Commands\FixMongoDatesCommand::class,
+        \Northstar\Console\Commands\FixSourcesCommand::class,
         \Northstar\Console\Commands\BackfillPhoenixAccounts::class,
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "league/iso3166": "^1.0",
     "fideloper/proxy": "^3.3",
     "dosomething/gateway": "^1.2",
-    "laravel/socialite": "~2.0.20"
+    "laravel/socialite": "~2.0.20",
+    "league/csv": "^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb9a41fa4718d5553b63eed672656849",
+    "content-hash": "31a5a975aacefd1aea50267ddd293a8c",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1183,6 +1183,63 @@
                 "jwt"
             ],
             "time": "2016-10-31T20:09:32+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "8.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "fa8bc05f64eb6c66b96edfaf60648f022ecb5f55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/fa8bc05f64eb6c66b96edfaf60648f022ecb5f55",
+                "reference": "fa8bc05f64eb6c66b96edfaf60648f022ecb5f55",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.9",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Csv data manipulation made easy in PHP",
+            "homepage": "http://csv.thephpleague.com",
+            "keywords": [
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "write"
+            ],
+            "time": "2017-07-12T07:18:20+00:00"
         },
         {
             "name": "league/event",

--- a/tests/Console/FixSourcesCommandTest.php
+++ b/tests/Console/FixSourcesCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Northstar\Models\User;
+
+class FixSourcesCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_fix_incorrect_sources()
+    {
+        // Make a ton of test accounts (without Drupal IDs).
+        $one = factory(User::class)->create(['_id' => '57c9b53e42a0646a1b8b4670', 'source' => 'sms']);
+        $two = factory(User::class)->create(['_id' => '57c9bbdc42a064b91b8b472d', 'source' => 'sms']);
+        $three = factory(User::class)->create(['_id' => '57c9bbdb42a064b91b8b472b', 'source' => 'sms']);
+        $sms = factory(User::class)->create([
+            '_id' => '57c9be8842a064c81b8b462d',
+            'source' => 'sms',
+            'created_at' => '2013-05-01',
+        ]);
+
+        // Run the magic command on our messy data.
+        $this->artisan('northstar:sources', ['path' => 'tests/Console/example-sources.csv']);
+
+        // After running the command, the given users should have 'niche' source.
+        $this->assertEquals('niche', $one->fresh()->source);
+        $this->assertEquals('niche', $two->fresh()->source);
+        $this->assertEquals('niche', $three->fresh()->source);
+
+        // ...unless their 'created_at' was way before the Niche import timestamp.
+        $this->assertEquals('sms', $sms->fresh()->source);
+    }
+}

--- a/tests/Console/example-sources.csv
+++ b/tests/Console/example-sources.csv
@@ -1,0 +1,5 @@
+"field_user_registration_source_value","field_northstar_id_value","created"
+"niche-import-service","57c9b53e42a0646a1b8b4670",1407367849
+"niche-import-service","57c9bbdc42a064b91b8b472d",1407786136
+"niche-import-service","57c9bbdb42a064b91b8b472b",1407787157
+"niche-import-service","57c9be8842a064c81b8b462d",1408490367


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `northstar:sources` which takes a [massive CSV](https://drive.google.com/open?id=0Bxn2NczVERKlZlZhbVdaUU12LUE) and retroactively sets their sources to `niche`. This will fix incorrect records due to a [bug in the backfill logic](https://github.com/DoSomething/northstar/pull/621).

Pivotal Ticket: [#178357846](https://www.pivotaltracker.com/n/projects/2076969/stories/149379309/comments/178357846)

#### How should this be reviewed?
I wrote a little test case to demonstrate the expected behavior, and have confirmed on my local machine that the script can safely iterate over the values in the provided 75MB CSV.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  