### PR TITLE
Fixing the element loop to work cross browser

### DIFF
--- a/resources/assets/js/utilities/PasswordVisibility.js
+++ b/resources/assets/js/utilities/PasswordVisibility.js
@@ -22,12 +22,9 @@ function clickHandler(event) {
 
 function init() {
   $(document).ready(() => {
-    const passwordToggles = document.getElementsByClassName('password-visibility__toggle');
-    if (! passwordToggles) return;
-
-    for (const toggle of passwordToggles) {
+    document.querySelectorAll('.password-visibility__toggle').forEach(toggle => {
       toggle.addEventListener('click', clickHandler);
-    }
+    });
   });
 }
 


### PR DESCRIPTION
#### What's this PR do?
@DFurnes noticed password show/hide wasn't working on Safari. Seems to be a weird browser quirk between Chrome & Safari in how it treats that "array" of HTML elements from the selector. 

I replaced the old query with a new one that seems to work fine across browsers without any issue.

#### How should this be reviewed?
Test the password show/hide on Safari and Chrome!