### PR TITLE
Fix issue where script would stop at first skipped user.

### DIFF
--- a/app/Console/Commands/FixSourcesCommand.php
+++ b/app/Console/Commands/FixSourcesCommand.php
@@ -44,7 +44,7 @@ class FixSourcesCommand extends Command
             if ($user->created_at->lt($threshold)) {
                 $this->warn('Not updating source for '.$user->id.', created'.$user->created_at->toFormattedDateString());
 
-                return;
+                continue;
             }
 
             // Otherwise, reset their source to expected 'niche'.

--- a/tests/Console/example-sources.csv
+++ b/tests/Console/example-sources.csv
@@ -1,5 +1,5 @@
 "field_user_registration_source_value","field_northstar_id_value","created"
 "niche-import-service","57c9b53e42a0646a1b8b4670",1407367849
+"niche-import-service","57c9be8842a064c81b8b462d",1408490367
 "niche-import-service","57c9bbdc42a064b91b8b472d",1407786136
 "niche-import-service","57c9bbdb42a064b91b8b472b",1407787157
-"niche-import-service","57c9be8842a064c81b8b462d",1408490367


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes a lil' bug in the script added in #622, where the first "skipped" user would cause the script to stop entirely because I used `return` instead of `continue`.

#### How should this be reviewed?
Updated test case to demonstrate problem/fix.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  