### PR TITLE
(Discussion) Adding redirect uri to Facebook

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -54,6 +54,9 @@ class FacebookController extends Controller
      */
     public function redirectToProvider()
     {
+        // Store the referrer URI so we can redirect back to it if necessary.
+        session()->put('referrer_uri', request()->headers->get('referer'));
+
         return Socialite::driver('facebook')
             ->scopes(['user_birthday'])
             ->redirect();
@@ -116,6 +119,6 @@ class FacebookController extends Controller
         $this->auth->guard('web')->login($northstarUser, true);
         $this->stathat->ezCount('facebook authentication');
 
-        return redirect()->intended('/');
+        return redirect(session('referrer_uri', '/'));
     }
 }


### PR DESCRIPTION
#### What's this PR do?
In order to allow for one click auth, we're adding redirect uri support to the Facebook login flow.

At the moment, I did this by placing the `session()->referer` code in the `redirectToProvider()` function. However, I'm now thinking this would break the normal client based redirect, because the `referer_uri` is going to override the intended redirect for the client (Basically, if i click signup, and click login with facebook, the referer uri will be northstar/register, not phoenix/campaign)

So I'm now thinking, maybe we need one more Facebook route specifically for 1 click login that puts the referrer in the session and then sends you to `redirectToProvider`

#### How should this be reviewed?
…

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …
