### PR TITLE
Rename SMS status field & add "paused" field.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -72,6 +72,7 @@ class Registrar
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
             'sms_status' => 'in:active,less,undeliverable,unknown',
             'sms_paused' => 'boolean',
+            'last_messaged_at' => 'date',
         ];
 
         // If existing user is provided, merge indexes into the request so

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -69,6 +69,8 @@ class Registrar
             'birthdate' => 'date',
             'country' => 'country',
             'password' => 'min:6|max:512',
+            'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
+            'sms_status' => 'in:active,less,undeliverable,unknown',
         ];
 
         // If existing user is provided, merge indexes into the request so

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -71,6 +71,7 @@ class Registrar
             'password' => 'min:6|max:512',
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
             'sms_status' => 'in:active,less,undeliverable,unknown',
+            'sms_paused' => 'boolean',
         ];
 
         // If existing user is provided, merge indexes into the request so

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -55,6 +55,7 @@ class UserTransformer extends TransformerAbstract
 
             // Subscription status
             $response['sms_status'] = $user->sms_status;
+            $response['sms_paused'] = (bool) $user->sms_paused;
         }
 
         $response['language'] = $user->language;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -68,6 +68,7 @@ class UserTransformer extends TransformerAbstract
         if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['last_accessed_at'] = $user->last_accessed_at ? $user->last_accessed_at->toIso8601String() : null;
             $response['last_authenticated_at'] = $user->last_authenticated_at ? $user->last_authenticated_at->toIso8601String() : null;
+            $response['last_messaged_at'] = $user->last_messaged_at ? $user->last_messaged_at->toIso8601String() : null;
         }
 
         $response['updated_at'] = $user->updated_at->toIso8601String();

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -50,8 +50,11 @@ class UserTransformer extends TransformerAbstract
             // Internal & third-party service IDs:
             $response['slack_id'] = $user->slack_id;
             $response['mobilecommons_id'] = $user->mobilecommons_id;
+            $response['mobilecommons_status'] = $user->sms_status; // @DEPRECATED: Will be removed.
             $response['parse_installation_ids'] = $user->parse_installation_ids;
-            $response['mobilecommons_status'] = $user->mobilecommons_status;
+
+            // Subscription status
+            $response['sms_status'] = $user->sms_status;
         }
 
         $response['language'] = $user->language;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -54,13 +54,15 @@ use Northstar\Auth\Role;
  *
  * And we store some external service IDs for hooking things together:
  * @property string $mobilecommons_id
- * @property string $mobilecommons_status
  * @property string $cgg_id
  * @property string $drupal_id
  * @property string $agg_id
  * @property array  $parse_installation_ids
  * @property string $facebook_id
  * @property string $slack_id
+ *
+ * Messaging subscription status:
+ * @property string $sms_status
  *
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
@@ -191,6 +193,16 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setMobileAttribute($value)
     {
         $this->attributes['mobile'] = normalize('mobile', $value);
+    }
+
+    /**
+     * Mutator to support old `mobilecommons_status` field input.
+     *
+     * @param string $value
+     */
+    public function setMobilecommonsStatusAttribute($value)
+    {
+        $this->attributes['sms_status'] = $value;
     }
 
     /**
@@ -347,7 +359,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'id' => $this->id,
             'email' => $this->email,
             'mobile' => $this->mobile,
-            'mobile_status' => $this->mobilecommons_status,
+            'mobile_status' => $this->sms_status,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -63,6 +63,7 @@ use Northstar\Auth\Role;
  *
  * Messaging subscription status:
  * @property string $sms_status
+ * @property bool   $sms_paused
  *
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
@@ -95,6 +96,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'slack_id',
+        'sms_status', 'sms_paused',
     ];
 
     /**
@@ -104,7 +106,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $internal = [
-        'mobilecommons_id', 'mobilecommons_status', 'cgg_id', 'drupal_id', 'agg_id', 'role', 'facebook_id', 'slack_id',
+        'cgg_id', 'drupal_id', 'agg_id', 'role', 'facebook_id', 'slack_id',
+        'mobilecommons_id', 'mobilecommons_status', 'sms_status', 'sms_paused',
     ];
 
     /**
@@ -146,6 +149,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $casts = [
         'cgg_id' => 'integer',
         'birthdate' => 'date',
+        'sms_paused' => 'boolean',
         'last_accessed_at' => 'datetime',
         'last_authenticated_at' => 'datetime',
     ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -67,6 +67,7 @@ use Northstar\Auth\Role;
  *
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
+ * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */
@@ -96,7 +97,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'slack_id',
-        'sms_status', 'sms_paused',
+        'sms_status', 'sms_paused', 'last_messaged_at',
     ];
 
     /**
@@ -108,6 +109,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public static $internal = [
         'cgg_id', 'drupal_id', 'agg_id', 'role', 'facebook_id', 'slack_id',
         'mobilecommons_id', 'mobilecommons_status', 'sms_status', 'sms_paused',
+        'last_messaged_at',
     ];
 
     /**
@@ -152,6 +154,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'sms_paused' => 'boolean',
         'last_accessed_at' => 'datetime',
         'last_authenticated_at' => 'datetime',
+        'last_messaged_at' => 'datetime',
     ];
 
     /**
@@ -375,6 +378,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'country' => $this->country,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
+            'last_messaged_at' => $this->last_messaged_at ? $this->last_messaged_at->toIso8601String() : null,
             'last_authenticated_at' => $this->last_authenticated_at ? $this->last_authenticated_at->toIso8601String() : null,
             'updated_at' => $this->updated_at->toIso8601String(),
             'created_at' => $this->created_at->toIso8601String(),

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -14,7 +14,7 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'email' => $faker->unique()->safeEmail,
         'mobile' => $faker->unique()->phoneNumber,
         'mobilecommons_id' => $faker->randomNumber(5),
-        'mobilecommons_status' => $faker->randomElement(['active', 'undeliverable']),
+        'sms_status' => $faker->randomElement(['active', 'undeliverable']),
         'facebook_id' => $faker->unique()->randomNumber(),
         'password' => $faker->password,
         'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),

--- a/database/migrations/2017_09_15_152015_RenameMobileStatusField.php
+++ b/database/migrations/2017_09_15_152015_RenameMobileStatusField.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class RenameMobileStatusField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->renameField('users', 'mobilecommons_status', 'sms_status');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->renameField('users', 'sms_status', 'mobilecommons_status');
+    }
+
+    /**
+     * Rename the given field on any documents in the collection.
+     *
+     * @param string $collection
+     * @param string $old
+     * @param string $new
+     */
+    public function renameField($collection, $old, $new)
+    {
+        /** @var \Jenssegers\Mongodb\Connection $connection */
+        $connection = app('db')->connection('mongodb');
+
+        // Rename 'mobile_status' to 'mobilecommons_status'.
+        $connection->collection($collection)
+            ->whereRaw([$old => ['$exists' => true]])
+            ->update(['$rename' => [$old => $new]]);
+    }
+}

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -151,6 +151,8 @@ Either a mobile number or email is required.
   slack_id: String
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
+  sms_status: String // Either 'active', 'less', 'undeliverable' or 'unknown'
+  sms_paused: Boolean // Whether a user is in a support conversation.
   source: String // Immutable. Will only be set on new records.
   source_detail: String // Only accepted alongside a valid 'source'.
   created_at: Number // timestamp
@@ -304,6 +306,8 @@ PUT /v1/users/drupal_id/<drupal_id>
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
+  sms_status: String // Either 'active', 'less', 'undeliverable' or 'unknown'
+  sms_paused: Boolean // Whether a user is in a support conversation.
 
   // Hidden fields (optional):
   race: String
@@ -500,7 +504,8 @@ curl -X POST \
     "slack_id": null,
     "mobilecommons_id": null,
     "parse_installation_ids": null,
-    "mobilecommons_status": null,
+    "sms_status": null,
+    "sms_paused": false,
     "language": null,
     "country": null,
     "drupal_id": "187",

--- a/tests/Http/MergeTest.php
+++ b/tests/Http/MergeTest.php
@@ -45,7 +45,7 @@ class MergeTest extends TestCase
         $duplicate = User::forceCreate([
             'mobile' => '5551234567',
             'mobilecommons_id' => '199483623',
-            'mobilecommons_status' => 'active',
+            'sms_status' => 'active',
             'drupal_id' => '7175144',
             'source' => 'sms',
         ]);
@@ -60,7 +60,7 @@ class MergeTest extends TestCase
             'email' => $user->email,
             'mobile' => $duplicate->mobile,
             'mobilecommons_id' => $duplicate->mobilecommons_id,
-            'mobilecommons_status' => $duplicate->mobilecommons_status,
+            'sms_status' => $duplicate->sms_status,
             'drupal_id' => '1234567',
         ]);
 
@@ -70,7 +70,7 @@ class MergeTest extends TestCase
             'email' => 'merged-account-'.$user->id.'@dosomething.invalid',
             'mobile' => null,
             'mobilecommons_id' => null,
-            'mobilecommons_status' => null,
+            'sms_status' => null,
             'drupal_id' => '7175144',
         ]);
     }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -266,6 +266,26 @@ class UserTest extends TestCase
     }
 
     /**
+     * Test that we can still set old `mobilecommons_status` field.
+     * POST /users
+     *
+     * @return void
+     */
+    public function testMobileCommonsStatusFieldTransform()
+    {
+        $this->asAdminUser()->json('POST', 'v1/users', [
+            'mobile' => '1 (222) 333-5555',
+            'mobilecommons_status' => 'active',
+        ]);
+
+        $this->assertResponseStatus(201);
+        $this->seeInDatabase('users', [
+            'mobile' => '2223335555',
+            'sms_status' => 'active',
+        ]);
+    }
+
+    /**
      * Test that the `country` field is removed if it
      * does not contain a valid ISO-3166 country code.
      * GET /users/:term/:id

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -22,7 +22,7 @@ class UserModelTest extends TestCase
             'birthdate' => '1990-01-02',
             'email' => $user->email,
             'mobile' => $user->mobile,
-            'mobile_status' => $user->mobilecommons_status,
+            'mobile_status' => $user->sms_status,
             'facebook_id' => $user->facebook_id,
             'addr_city' => $user->addr_city,
             'addr_state' => $user->addr_state,

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -32,6 +32,7 @@ class UserModelTest extends TestCase
             'source' => $user->source,
             'source_detail' => $user->source_detail,
             'last_authenticated_at' => null,
+            'last_messaged_at' => null,
             'updated_at' => $user->updated_at->toIso8601String(),
             'created_at' => $user->created_at->toIso8601String(),
         ]);


### PR DESCRIPTION
#### What's this PR do?
This pull request includes field updates for the upcoming SMS work:

☎️ It renames the existing `mobilecommons_status` field to `sms_status` so that it's applicable to more messaging platforms in the future. It maintains support for [applications](https://github.com/DoSomething/northstar-mobilecommonsd) that either read or write to the old `mobilecommons_status` field. (#570)

📴 It adds a `sms_paused` field which Gambit can use to track whether a user is in a bot conversation or talking to a support agent (DoSomething/gambit-conversations#65).

📆 It also adds a `last_messaged_at` field for tracking the last time a user messaged us via Gambit (similar to how we track `last_authenticated_at` or `last_accessed_at` for web traffic).


#### How should this be reviewed?
I've added a test for the backwards-compatible `mobilecommons_status` field support, and updated documentation to reference the new field name. It'll be interesting to see how long the migration takes when deploying this to Thor... hopefully not too long!

#### Checklist
- [x] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!