### PR TITLE
Convert existing mobile numbers to E.164 format.

### DIFF
--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use libphonenumber\PhoneNumberUtil;
+use libphonenumber\PhoneNumberFormat;
+
+class ConvertMobilesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:e164';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Convert mobile numbers to E.164 format.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $counter = 1;
+
+        // Iterate over users where the `mobile` field is not null.
+        User::whereNotNull('mobile')->chunk(200, function ($users) use (&$counter) {
+            $parser = PhoneNumberUtil::getInstance();
+
+            /** @var User $user */
+            foreach ($users as $user) {
+                $this->line('['.$counter++.'] '.$user->id.' - '.$user->mobile);
+
+                try {
+                    // Parse & format as E.164.
+                    $number = $parser->parse($user->mobile, 'US');
+                    $formattedNumber = $parser->format($number, PhoneNumberFormat::E164);
+
+                    // Save to the `e164` field. We'll swap this with `mobile` later.
+                    $user->e164 = $formattedNumber;
+                    $user->save();
+
+                    $this->info('['.$counter.'] '.$user->id.' - Formatted as '.$formattedNumber);
+                } catch (\libphonenumber\NumberParseException $e) {
+                    $this->error('['.$counter.'] '.$user->id.' - Could not parse.');
+
+                    // If they don't have one, give this user an email so we can safely drop `mobile`.
+                    if (empty($user->email)) {
+                        $user->email = 'invalid-mobile-'.$user->id.'@dosomething.invalid';
+                        $user->save();
+                    }
+                }
+            }
+        });
+    }
+}

--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -47,7 +47,7 @@ class ConvertMobilesCommand extends Command
 
                     // Save to the `e164` field. We'll swap this with `mobile` later.
                     $user->e164 = $formattedNumber;
-                    $user->save();
+                    $user->save(['touch' => false]);
 
                     $this->info('['.$counter.'] '.$user->id.' - Formatted as '.$formattedNumber);
                 } catch (\libphonenumber\NumberParseException $e) {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
+        \Northstar\Console\Commands\ConvertMobilesCommand::class,
         \Northstar\Console\Commands\FixMongoDatesCommand::class,
         \Northstar\Console\Commands\FixSourcesCommand::class,
         \Northstar\Console\Commands\BackfillPhoenixAccounts::class,

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -12,11 +12,7 @@ use MongoDB\BSON\UTCDateTime;
 /**
  * Base model class
  *
- * @method static \Jenssegers\Mongodb\Query\Builder|$this where(string $field, string $comparison = '=', string $value)
- * @method static \Jenssegers\Mongodb\Query\Builder|$this whereNull(string $field)
- * @method static \Jenssegers\Mongodb\Query\Builder|$this find(string $id, array $columns=['*'])
- * @method static \Jenssegers\Mongodb\Query\Builder|$this findMany(array $ids)
- * @method static \Jenssegers\Mongodb\Query\Builder|$this findOrFail(string $id, array $columns=['*'])
+ * @mixin \Jenssegers\Mongodb\Query\Builder
  */
 class Model extends BaseModel
 {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "fideloper/proxy": "^3.3",
     "dosomething/gateway": "^1.2",
     "laravel/socialite": "~2.0.20",
-    "league/csv": "^8.0"
+    "league/csv": "^8.0",
+    "giggsey/libphonenumber-for-php": "^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "31a5a975aacefd1aea50267ddd293a8c",
+    "content-hash": "db0c62b5041a5ea0befc9288fab23398",
     "packages": [
         {
             "name": "aws/aws-sdk-php",

--- a/tests/Console/ConvertMobilesCommandTest.php
+++ b/tests/Console/ConvertMobilesCommandTest.php
@@ -7,27 +7,27 @@ class ConvertMobilesCommandTest extends TestCase
     /** @test */
     public function it_should_convert_numbers()
     {
-        // Create users with some pre-generated numbers.
-        $user1 = factory(User::class)->create(['mobile' => '7455559417']);
-        $user2 = factory(User::class)->create(['mobile' => '6965552100']);
+        $this->createMongoDocument('users', ['mobile' => '7455559417']);
+        $this->createMongoDocument('users', ['mobile' => '6965552100']);
 
         // Run the command to convert to E.164 format.
         $this->artisan('northstar:e164');
 
-        $this->assertEquals('+17455559417', $user1->fresh()->e164);
-        $this->assertEquals('+16965552100', $user2->fresh()->e164);
+        $this->seeInDatabase('users', ['mobile' => '7455559417', 'e164' => '+17455559417']);
+        $this->seeInDatabase('users', ['mobile' => '6965552100', 'e164' => '+16965552100']);
     }
 
     /** @test */
     public function it_should_handle_invalid_mobiles()
     {
-        $user = factory(User::class)->create(['mobile' => '3', 'email' => null]);
+        $this->createMongoDocument('users', ['mobile' => '3']);
 
         // Run the command to convert to E.164 format.
         $this->artisan('northstar:e164');
 
-        $this->assertEquals(null, $user->fresh()->e164);
-        $this->assertNotNull($user->fresh()->email);
+        $user = User::first();
+        $this->assertEquals(null, $user->e164);
+        $this->assertNotNull($user->email);
     }
 
     /** @test */

--- a/tests/Console/ConvertMobilesCommandTest.php
+++ b/tests/Console/ConvertMobilesCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Northstar\Models\User;
+
+class ConvertMobilesCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_convert_numbers()
+    {
+        // Create users with some pre-generated numbers.
+        $user1 = factory(User::class)->create(['mobile' => '7455559417']);
+        $user2 = factory(User::class)->create(['mobile' => '6965552100']);
+
+        // Run the command to convert to E.164 format.
+        $this->artisan('northstar:e164');
+
+        $this->assertEquals('+17455559417', $user1->fresh()->e164);
+        $this->assertEquals('+16965552100', $user2->fresh()->e164);
+    }
+
+    /** @test */
+    public function it_should_handle_invalid_mobiles()
+    {
+        $user = factory(User::class)->create(['mobile' => '3', 'email' => null]);
+
+        // Run the command to convert to E.164 format.
+        $this->artisan('northstar:e164');
+
+        $this->assertEquals(null, $user->fresh()->e164);
+        $this->assertNotNull($user->fresh()->email);
+    }
+
+    /** @test */
+    public function it_should_ignore_users_without_mobiles()
+    {
+        $user = factory(User::class)->create(['mobile' => null]);
+
+        // Run the command to convert to E.164 format.
+        $this->artisan('northstar:e164');
+
+        $this->assertEquals(null, $user->fresh()->e164);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -235,6 +235,20 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      * Get the raw Mongo document for inspection.
      *
      * @param $collection - Mongo Collection name
+     * @param array $contents
+     * @return bool
+     */
+    public function createMongoDocument($collection, array $contents)
+    {
+        $document = $this->app->make('db')->collection($collection)->insert($contents);
+
+        return $document;
+    }
+
+    /**
+     * Get the raw Mongo document for inspection.
+     *
+     * @param $collection - Mongo Collection name
      * @param $id - The _id of the document to fetch
      * @return array
      */


### PR DESCRIPTION
#### What's this PR do?
This pull request gets us ready to convert all numbers to [E.164 format](https://www.twilio.com/docs/glossary/what-e164) (which is needed to be able to send broadcasts via [Customer.io](https://customer.io/) in the future, and also is just a nicer way to format this data).

📝 I've added a `northstar:e164` script which iterates over all existing phone numbers and saves an E.164-formatted version in an `e164` field on the user document. We can later swap this to be the "real" mobile field (kinda like what we did [with `mobilecommons_status` and `sms_status`](https://github.com/DoSomething/northstar/pull/631)).

🔀 Adds a mutator so any new values for `mobile` also set a corresponding `e164` attribute on the document. This means any new or edited users will automatically have a correct E.164 formatted number, so we don't miss any records between running the script and swapping the fields.

#### How should this be reviewed?
I've added a test for the script, and the existing tests still pass with the new mutator. 🚥

One thing I'm worried about is performance when running this script against millions of records in production... I'm hoping that `User::chunk` helps with this, but I have a feeling it'll still be sluggish. I'll give it a test run on Thor and we'll see. 🤷‍♂️

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  