### PR TITLE
Allow passing a "skip" value to restart E.164 script.

### DIFF
--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -14,7 +14,7 @@ class ConvertMobilesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:e164';
+    protected $signature = 'northstar:e164 {skip=0}';
 
     /**
      * The console command description.
@@ -30,10 +30,11 @@ class ConvertMobilesCommand extends Command
      */
     public function handle()
     {
-        $counter = 1;
+        $skip = $this->argument('skip');
+        $counter = $skip + 1;
 
         // Iterate over users where the `mobile` field is not null.
-        User::whereNotNull('mobile')->chunk(200, function ($users) use (&$counter) {
+        User::whereNotNull('mobile')->skip($skip)->chunk(200, function ($users) use (&$counter) {
             $parser = PhoneNumberUtil::getInstance();
 
             /** @var User $user */


### PR DESCRIPTION
#### What's this PR do?
This pull request adds an optional "skip" parameter to restart the script from a given point:

```sh
php artisan northstar:e164 2923801
```

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!