### PR TITLE
Swap temporary 'e164' to 'mobile'.

### DIFF
--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -68,6 +68,12 @@ class Normalizer
             return null;
         }
 
+        // Normalize "1 (555) 555-5555" format without leading "+".
+        $digits = preg_replace('/[^0-9]/', '', $mobile);
+        if (strlen($digits) === 11 && $digits[0] === '1') {
+            $mobile = '+'.$mobile;
+        }
+
         try {
             $parser = PhoneNumberUtil::getInstance();
             $number = $parser->parse($mobile, 'US');

--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -3,6 +3,8 @@
 namespace Northstar\Auth;
 
 use Carbon\Carbon;
+use libphonenumber\PhoneNumberUtil;
+use libphonenumber\PhoneNumberFormat;
 
 class Normalizer
 {
@@ -62,15 +64,18 @@ class Normalizer
      */
     public function mobile($mobile)
     {
-        // Remove all non-numeric characters.
-        $sanitizedValue = preg_replace('/[^0-9]/', '', $mobile);
-
-        // If it's 11-digits and the leading digit is a 1, then remove country code.
-        if (strlen($sanitizedValue) === 11 && $sanitizedValue[0] === '1') {
-            $sanitizedValue = substr($sanitizedValue, 1);
+        if (empty($mobile)) {
+            return null;
         }
 
-        return $sanitizedValue;
+        try {
+            $parser = PhoneNumberUtil::getInstance();
+            $number = $parser->parse($mobile, 'US');
+
+            return $parser->format($number, PhoneNumberFormat::E164);
+        } catch (\libphonenumber\NumberParseException $e) {
+            return null;
+        }
     }
 
     /**

--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -20,7 +20,7 @@ class UserInfoTransformer extends TransformerAbstract
             'given_name' => $user->first_name,
             'family_name' => $user->last_name,
             'email' => $user->email,
-            'phone_number' => $user->mobile,
+            'phone_number' => format_legacy_mobile($user->mobile),
             'birthdate' => format_date($user->birthdate, 'Y-m-d'),
 
             'address' => [

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -31,7 +31,7 @@ class UserTransformer extends TransformerAbstract
 
         if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['email'] = $user->email;
-            $response['mobile'] = $user->mobile;
+            $response['mobile'] = format_legacy_mobile($user->mobile);
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = $user->interests;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Auth\CanResetPassword as ResetPasswordContract;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
-use libphonenumber\PhoneNumberFormat;
 use Northstar\Auth\Role;
 
 /**
@@ -201,26 +200,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setMobileAttribute($value)
     {
-        $parser = \libphonenumber\PhoneNumberUtil::getInstance();
-
-        // If empty, null out both fields.
-        if (empty($value)) {
-            $this->attributes['mobile'] = null;
-            $this->attributes['e164'] = null;
-
-            return;
-        }
-
-        try {
-            $number = $parser->parse($value, 'US');
-            $formattedNumber = $parser->format($number, PhoneNumberFormat::E164);
-
-            // Parse & save as both non-standard normalized format & E.164.
-            $this->attributes['mobile'] = normalize('mobile', $value);
-            $this->attributes['e164'] = $formattedNumber;
-        } catch (\libphonenumber\NumberParseException $e) {
-            // ...
-        }
+        $this->attributes['mobile'] = normalize('mobile', $value);
     }
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,6 +2,8 @@
 
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
 use Northstar\Auth\Normalizer;
 use Northstar\Models\Client;
 
@@ -156,4 +158,17 @@ function format_birthdate($birthdate)
     }
 
     return format_date($birthdate, 'Y-m-d');
+}
+
+function format_legacy_mobile($mobile)
+{
+    try {
+        $parser = PhoneNumberUtil::getInstance();
+        $number = $parser->parse($mobile, 'US');
+        $formatted = $parser->format($number, PhoneNumberFormat::NATIONAL);
+
+        return preg_replace('#[^0-9]+#', '', $formatted);
+    } catch (\libphonenumber\NumberParseException $e) {
+        return null;
+    }
 }

--- a/database/migrations/2017_09_19_204233_SwapE164ForMobileField.php
+++ b/database/migrations/2017_09_19_204233_SwapE164ForMobileField.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class SwapE164ForMobileField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('mobile');
+        });
+
+        $this->renameField('users', 'mobile', '_old_mobile');
+        $this->renameField('users', 'e164', 'mobile');
+
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('mobile', ['sparse' => true, 'unique' => true]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('mobile');
+        });
+
+        $this->renameField('users', 'mobile', 'e164');
+        $this->renameField('users', '_old_mobile', 'mobile');
+
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('mobile', ['sparse' => true, 'unique' => true]);
+        });
+    }
+
+    /**
+     * Rename the given field on any documents in the collection.
+     *
+     * @param string $collection
+     * @param string $old
+     * @param string $new
+     */
+    public function renameField($collection, $old, $new)
+    {
+        /** @var \Jenssegers\Mongodb\Connection $connection */
+        $connection = app('db')->connection('mongodb');
+
+        // Rename 'mobile_status' to 'mobilecommons_status'.
+        $connection->collection($collection)
+            ->whereRaw([$old => ['$exists' => true]])
+            ->update(['$rename' => [$old => $new]]);
+    }
+}

--- a/tests/Auth/NormalizerTest.php
+++ b/tests/Auth/NormalizerTest.php
@@ -35,7 +35,7 @@ class NormalizerTest extends TestCase
     {
         $normalized = normalize('mobile', '1 (555) 123-4567');
 
-        $this->assertSame('5551234567', $normalized);
+        $this->assertSame('+15551234567', $normalized);
     }
 
     /**
@@ -65,7 +65,7 @@ class NormalizerTest extends TestCase
         $this->assertArrayNotHasKey('username', $normalized);
         $this->assertArrayNotHasKey('email', $normalized);
 
-        $this->assertSame('5551234567', $normalized['mobile']);
+        $this->assertSame('+15551234567', $normalized['mobile']);
     }
 
     /**

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -261,7 +261,7 @@ class UserTest extends TestCase
         $this->seeInDatabase('users', [
             'first_name' => 'Batman',
             'email' => 'batman@example.com',
-            'mobile' => '2223335555',
+            'mobile' => '+12223335555',
         ]);
     }
 
@@ -280,7 +280,7 @@ class UserTest extends TestCase
 
         $this->assertResponseStatus(201);
         $this->seeInDatabase('users', [
-            'mobile' => '2223335555',
+            'mobile' => '+12223335555',
             'sms_status' => 'active',
         ]);
     }

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -657,7 +657,7 @@ class LegacyUserTest extends TestCase
         $this->seeInDatabase('users', [
             '_id' => $user->id,
             'email' => 'upsert-me@dosomething.org',
-            'mobile' => '5556667777',
+            'mobile' => '+15556667777',
         ]);
 
         // The response should indicate a validation conflict!
@@ -681,7 +681,7 @@ class LegacyUserTest extends TestCase
      */
     public function testUpdateUser()
     {
-        $user = User::create(['mobile' => $this->faker->unique()->phoneNumber]);
+        $user = User::create(['mobile' => '+15543694724']);
 
         // Update an existing user
         $this->withLegacyApiKeyScopes(['admin'])->json('PUT', 'v1/users/_id/'.$user->id, [
@@ -692,7 +692,7 @@ class LegacyUserTest extends TestCase
         $this->seeJsonSubset([
             'data' => [
                 'email' => 'newemail@dosomething.org',
-                'mobile' => $user->mobile, // unchanged user values should remain unchanged
+                'mobile' => '5543694724', // unchanged user values should remain unchanged
             ],
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
This pull request finishes up work for storing mobiles in E.164 format.

🚚 Adds a migration which swaps the [pre-generated](https://github.com/DoSomething/northstar/pull/632) `e164` field with the existing `mobile`. The old field is kept in `_old_mobile` in case we need to quickly reverse this.*

📱 Always normalize the `mobile` field in E.164 format (instead of a separate `e164` field).

🍂 For backwards compatibility, we'll continue to return the "old" format from the existing API endpoints. I'm adding a ticket to remember to make a `v2/users` endpoint sometime soon that will return E.164 formatted numbers & removes old fields (like `_id`, `mobilecommons_status`, etc.)

#### How should this be reviewed?
I updated the test suite where it made specific assertions against the database contents, otherwise everything should continue to function exactly the same as it did before!

*__*Important:__* This cannot be deployed until the `artisan northstar:e164` script is run!! 🚨

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  