### PR TITLE
Add "chunk with offset" macro & use for E.164 script.

### DIFF
--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Console\Commands;
 
+use Illuminate\Support\Collection;
 use Northstar\Models\User;
 use Illuminate\Console\Command;
 use libphonenumber\PhoneNumberUtil;
@@ -34,8 +35,10 @@ class ConvertMobilesCommand extends Command
         $counter = $skip + 1;
 
         // Iterate over users where the `mobile` field is not null.
-        User::whereNotNull('mobile')->skip($skip)->chunk(200, function ($users) use (&$counter) {
+        $query = User::whereNotNull('mobile')->orderBy('created_at');
+        $query->chunkWithOffset(200, (int) $skip, function (Collection $users) use (&$counter) {
             $parser = PhoneNumberUtil::getInstance();
+            $users = User::hydrate($users->toArray());
 
             /** @var User $user */
             foreach ($users as $user) {

--- a/tests/Console/ConvertMobilesCommandTest.php
+++ b/tests/Console/ConvertMobilesCommandTest.php
@@ -40,4 +40,21 @@ class ConvertMobilesCommandTest extends TestCase
 
         $this->assertEquals(null, $user->fresh()->e164);
     }
+
+    /** @test */
+    public function it_should_restart_based_on_skip_argument()
+    {
+        $this->createMongoDocument('users', ['mobile' => '7455559417']);
+        $this->createMongoDocument('users', ['mobile' => '6965552100']);
+        $this->createMongoDocument('users', ['mobile' => '2225559999']);
+        $this->createMongoDocument('users', ['mobile' => '8145551234']);
+
+        // Run the command to convert to E.164 format.
+        $this->artisan('northstar:e164', ['skip' => '2']);
+
+        $this->seeInDatabase('users', ['mobile' => '7455559417', 'e164' => null]); // skipped!
+        $this->seeInDatabase('users', ['mobile' => '6965552100', 'e164' => null]); // skipped!
+        $this->seeInDatabase('users', ['mobile' => '8145551234', 'e164' => '+18145551234']);
+        $this->seeInDatabase('users', ['mobile' => '2225559999', 'e164' => '+12225559999']);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes the ability to provide the "skip" parameter for restarting the `northstar:e164` command at a given offset (added in #633). Because Eloquent's [`chunk` method silently resets the offset](https://git.io/vdJU0), we were not _really_ restarting the script at the given point. By adding a custom macro which preserves offset, the script now functions as expected.

#### How should this be reviewed?
I added a test case demonstrating the bug & fix. 🚥

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  