### PR TITLE
Switch to chunking/offsetting by ID.

### DIFF
--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -15,7 +15,7 @@ class ConvertMobilesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:e164 {skip=0}';
+    protected $signature = 'northstar:e164 {start?}';
 
     /**
      * The console command description.
@@ -31,18 +31,27 @@ class ConvertMobilesCommand extends Command
      */
     public function handle()
     {
-        $skip = $this->argument('skip');
-        $counter = $skip + 1;
+        $start = $this->argument('start');
+        if (! $start) {
+            $firstMatch = User::whereNull('e164')->whereNotNull('mobile')->orderBy('_id')->first();
+            if (! $firstMatch) {
+                $this->error('No users need to be converted.');
+                return;
+            }
+
+            $start = $firstMatch->id;
+        }
+
+        $counter = 1;
 
         // Iterate over users where the `mobile` field is not null.
-        $query = User::whereNotNull('mobile')->orderBy('created_at');
-        $query->chunkWithOffset(200, (int) $skip, function (Collection $users) use (&$counter) {
+        User::whereNull('e164')->whereNotNull('mobile')->chunkFromId(200, $start, function (Collection $records) use (&$counter, $start) {
             $parser = PhoneNumberUtil::getInstance();
-            $users = User::hydrate($users->toArray());
+            $users = User::hydrate($records->toArray());
 
             /** @var User $user */
             foreach ($users as $user) {
-                $this->line('['.$counter++.'] '.$user->id.' - '.$user->mobile);
+                $this->line('['.$counter.'] '.$user->id.' - '.$user->mobile);
 
                 try {
                     // Parse & format as E.164.
@@ -63,7 +72,9 @@ class ConvertMobilesCommand extends Command
                         $user->save();
                     }
                 }
+
+                $counter++;
             }
-        });
+        }, '_id');
     }
 }

--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -36,6 +36,7 @@ class ConvertMobilesCommand extends Command
             $firstMatch = User::whereNull('e164')->whereNotNull('mobile')->orderBy('_id')->first();
             if (! $firstMatch) {
                 $this->error('No users need to be converted.');
+
                 return;
             }
 

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -13,6 +13,7 @@ use MongoDB\BSON\UTCDateTime;
  * Base model class
  *
  * @mixin \Jenssegers\Mongodb\Query\Builder
+ * @method chunkFromId($count, $startId, \Closure $callback, $column)
  */
 class Model extends BaseModel
 {

--- a/tests/Console/ConvertMobilesCommandTest.php
+++ b/tests/Console/ConvertMobilesCommandTest.php
@@ -46,11 +46,12 @@ class ConvertMobilesCommandTest extends TestCase
     {
         $this->createMongoDocument('users', ['mobile' => '7455559417']);
         $this->createMongoDocument('users', ['mobile' => '6965552100']);
-        $this->createMongoDocument('users', ['mobile' => '2225559999']);
+        $this->createMongoDocument('users', ['mobile' => '2225559999']); // start!
         $this->createMongoDocument('users', ['mobile' => '8145551234']);
 
         // Run the command to convert to E.164 format.
-        $this->artisan('northstar:e164', ['skip' => '2']);
+        $id = User::where('mobile', '2225559999')->first()->id;
+        $this->artisan('northstar:e164', ['start' => $id]);
 
         $this->seeInDatabase('users', ['mobile' => '7455559417', 'e164' => null]); // skipped!
         $this->seeInDatabase('users', ['mobile' => '6965552100', 'e164' => null]); // skipped!


### PR DESCRIPTION
#### What's this PR do?
Alright, hopefully this should alleviate our performance issues – instead of offsetting by a number of records, the script now chunks by Object ID (and if we need to restart it, you specify the ID to start from).

#### How should this be reviewed?
Unfortunately Laravel's built-in `chunkById` method assumes integer IDs, and needed to be overridden to work with Mongo's string ObjectIds (and to also provide a "start" offset). It's not super elegant, but it gets the job done. 😅

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  