### PR TITLE
Fix index creation & add script to remove dupes from E.164 conversion.

### DIFF
--- a/app/Console/Commands/FixE164DuplicatesCommand.php
+++ b/app/Console/Commands/FixE164DuplicatesCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+
+class FixE164DuplicatesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:e164-dupes {column=mobile}
+                            {--pretend : List the duplicates that would be deleted.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix duplicates created during E.164 conversion.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $pretending = $this->option('pretend');
+
+        // Since new environments have proper uniqueness constraint
+        // on 'mobile', we need to be able to override this.
+        $mobileColumn = $this->argument('column');
+        $originalColumn = '_old_mobile';
+
+        /** @var \MongoDB\Database $mongo */
+        $mongo = app('db')->getMongoDB();
+
+        // Find the documents where the 'mobile' column has a duplicate.
+        // credit: https://stackoverflow.com/a/35624773/811624
+        $collection = $mongo->selectCollection('users');
+        $duplicates = $collection->aggregate([
+            [
+                '$group' => [
+                    '_id' => [$mobileColumn => '$'.$mobileColumn],
+                    'uniqueIds' => ['$addToSet' => '$_id'],
+                    'count' => ['$sum' => 1],
+                ],
+            ],
+            [
+                '$match' => [
+                    'count' => ['$gt' => 1],
+                ],
+            ],
+        ], ['allowDiskUse' => true]);
+
+        /** @var \MongoDB\Model\BSONDocument $duplicate */
+        foreach ($duplicates as $duplicate) {
+            // Recursively convert BSONDocument into an array.
+            $duplicate = json_decode(json_encode($duplicate), true);
+
+            $mobile = $duplicate['_id'][$mobileColumn];
+            $ids = array_pluck($duplicate['uniqueIds'], '$oid');
+
+            $this->comment('Found duplicates for '.$mobile);
+
+            // When we find multiple IDs with the same E.164 'mobile' value,
+            // destroy the ones that weren't normalized as we intended.
+            $trash = User::find($ids)->filter(function ($user) use ($originalColumn) {
+                return ! preg_match('#^[0-9]{10}$#', $user->{$originalColumn});
+            });
+
+            /** @var User $user */
+            foreach ($trash as $user) {
+                $verb = $pretending ? 'Will remove' : 'Removing';
+                $this->line($verb.' duplicate user '.$user->id);
+
+                if (! $pretending) {
+                    $user->delete();
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
         \Northstar\Console\Commands\ConvertMobilesCommand::class,
+        \Northstar\Console\Commands\FixE164DuplicatesCommand::class,
         \Northstar\Console\Commands\FixMongoDatesCommand::class,
         \Northstar\Console\Commands\FixSourcesCommand::class,
         \Northstar\Console\Commands\BackfillPhoenixAccounts::class,

--- a/database/migrations/2015_10_26_193708_AddDrupalIDIndex.php
+++ b/database/migrations/2015_10_26_193708_AddDrupalIDIndex.php
@@ -12,7 +12,7 @@ class AddDrupalIDIndex extends Migration
     public function up()
     {
         Schema::table('users', function ($collection) {
-            $collection->index('drupal_id', ['sparse' => true]);
+            $collection->index('drupal_id', null, null, ['sparse' => true]);
         });
     }
 

--- a/database/migrations/2016_03_16_181119_AddUniqueIndexes.php
+++ b/database/migrations/2016_03_16_181119_AddUniqueIndexes.php
@@ -14,10 +14,10 @@ class AddUniqueIndexes extends Migration
     {
         Schema::table('users', function (Blueprint $collection) {
             $collection->dropIndex('email');
-            $collection->index('email', ['sparse' => true, 'unique' => true]);
+            $collection->index('email', null, null, ['sparse' => true, 'unique' => true]);
 
             $collection->dropIndex('mobile');
-            $collection->index('mobile', ['sparse' => true, 'unique' => true]);
+            $collection->index('mobile', null, null, ['sparse' => true, 'unique' => true]);
         });
 
         Schema::table('tokens', function (Blueprint $collection) {

--- a/database/migrations/2016_07_05_155130_AddIndexToSource.php
+++ b/database/migrations/2016_07_05_155130_AddIndexToSource.php
@@ -13,7 +13,7 @@ class AddIndexToSource extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $collection) {
-            $collection->index('source', ['sparse' => true]);
+            $collection->index('source', null, null, ['sparse' => true]);
         });
     }
 

--- a/database/migrations/2016_07_14_182348_AddIndexToRole.php
+++ b/database/migrations/2016_07_14_182348_AddIndexToRole.php
@@ -13,7 +13,7 @@ class AddIndexToRole extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $collection) {
-            $collection->index('role', ['sparse' => true]);
+            $collection->index('role', null, null, ['sparse' => true]);
         });
     }
 

--- a/database/migrations/2016_08_31_181524_AddIndexToFacebookId.php
+++ b/database/migrations/2016_08_31_181524_AddIndexToFacebookId.php
@@ -13,7 +13,7 @@ class AddIndexToFacebookId extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $collection) {
-            $collection->index('facebook_id', ['sparse' => true]);
+            $collection->index('facebook_id', null, null, ['sparse' => true]);
         });
     }
 

--- a/database/migrations/2017_09_19_204233_SwapE164ForMobileField.php
+++ b/database/migrations/2017_09_19_204233_SwapE164ForMobileField.php
@@ -21,7 +21,7 @@ class SwapE164ForMobileField extends Migration
         $this->renameField('users', 'e164', 'mobile');
 
         Schema::table('users', function (Blueprint $collection) {
-            $collection->index('mobile', ['sparse' => true, 'unique' => true]);
+            $collection->index('mobile', null, null, ['sparse' => true, 'unique' => true]);
         });
     }
 
@@ -40,7 +40,7 @@ class SwapE164ForMobileField extends Migration
         $this->renameField('users', '_old_mobile', 'mobile');
 
         Schema::table('users', function (Blueprint $collection) {
-            $collection->index('mobile', ['sparse' => true, 'unique' => true]);
+            $collection->index('mobile', null, null, ['sparse' => true, 'unique' => true]);
         });
     }
 

--- a/tests/Console/FixE164DuplicatesTest.php
+++ b/tests/Console/FixE164DuplicatesTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class FixE164DuplicatesTest extends TestCase
+{
+    /** @test */
+    public function it_should_remove_duplicates()
+    {
+        // For the test, we'll put our "duplicates" in `new_mobile`.
+        $this->createMongoDocument('users', ['_old_mobile' => '7455559417', 'new_mobile' => '+17455559417']);
+        $this->createMongoDocument('users', ['_old_mobile' => '6965552100', 'new_mobile' => '+16965552100']);
+        $this->createMongoDocument('users', ['_old_mobile' => '16965552100', 'new_mobile' => '+16965552100']);
+
+        // Run the command to convert to E.164 format.
+        $this->artisan('northstar:e164-dupes', ['column' => 'new_mobile']);
+
+        $this->seeInDatabase('users', ['_old_mobile' => '7455559417', 'new_mobile' => '+17455559417']);
+        $this->seeInDatabase('users', ['_old_mobile' => '6965552100', 'new_mobile' => '+16965552100']);
+        $this->notSeeInDatabase('users', ['_old_mobile' => '16965552100']);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes two issues:

🍂 The method signature for `index` [changed](https://git.io/vdt4y) in the [v3.1 release](https://github.com/jenssegers/laravel-mongodb/releases/tag/v3.1.0) of the Laravel MongoDB adapter that we use. As far as I can tell this was undocumented, which is frustrating. I've updated the calls to this function in our migrations so tests & new instances get the proper settings on indexes.

📴 Adds a `northstar:e164-dupes` command to remove any duplicate accounts that were [created by the E.164 conversion](https://github.com/DoSomething/northstar/issues/637). Since we would always resolve accounts without the leading `1`, these accounts have been effectively deleted for a long time.

#### How should this be reviewed?
If you haven't, give a read to #637 for full context. I wrote a test case for the new script added in this pull request. Because the database uniqueness constraint on the `mobile` column is working again, it uses a `new_mobile` column for simulating instances where the constraint doesn't exist.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  