### PR TITLE
Exclude null values when running aggregation query.

### DIFF
--- a/app/Console/Commands/FixE164DuplicatesCommand.php
+++ b/app/Console/Commands/FixE164DuplicatesCommand.php
@@ -44,6 +44,11 @@ class FixE164DuplicatesCommand extends Command
         $collection = $mongo->selectCollection('users');
         $duplicates = $collection->aggregate([
             [
+                '$match' => [
+                    'mobile' => ['$ne' => null],
+                ],
+            ],
+            [
                 '$group' => [
                     '_id' => [$mobileColumn => '$'.$mobileColumn],
                     'uniqueIds' => ['$addToSet' => '$_id'],

--- a/app/Console/Commands/FixE164DuplicatesCommand.php
+++ b/app/Console/Commands/FixE164DuplicatesCommand.php
@@ -45,7 +45,7 @@ class FixE164DuplicatesCommand extends Command
         $duplicates = $collection->aggregate([
             [
                 '$match' => [
-                    'mobile' => ['$ne' => null],
+                    $mobileColumn => ['$ne' => null],
                 ],
             ],
             [


### PR DESCRIPTION
#### What's this PR do?
A ha! The `northstar:e164-dedupe` script was failing on Thor because it was trying to list out all the "duplicates" of records with a `null` value for the `mobile` field. Adding a step to exclude those records from the aggregation pipeline should clear things up.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  