### PR TITLE
Fix issue with incorrect search results.

### DIFF
--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -35,7 +35,7 @@ class Normalizer
         }
 
         if (! empty($credentials['mobile'])) {
-            $credentials ['mobile'] = $this->mobile($credentials['mobile']);
+            $credentials['mobile'] = $this->mobile($credentials['mobile']);
         }
 
         return $credentials;

--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -35,7 +35,8 @@ class Normalizer
         }
 
         if (! empty($credentials['mobile'])) {
-            $credentials['mobile'] = $this->mobile($credentials['mobile']);
+            $mobile = $this->mobile($credentials['mobile']);
+            $credentials['mobile'] = $mobile ?: '';
         }
 
         return $credentials;
@@ -65,7 +66,7 @@ class Normalizer
     public function mobile($mobile)
     {
         if (empty($mobile)) {
-            return null;
+            return '';
         }
 
         // Normalize "1 (555) 555-5555" format without leading "+".
@@ -80,7 +81,7 @@ class Normalizer
 
             return $parser->format($number, PhoneNumberFormat::E164);
         } catch (\libphonenumber\NumberParseException $e) {
-            return null;
+            return '';
         }
     }
 

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -296,18 +296,18 @@ class LegacyUserTest extends TestCase
      */
     public function testSearchUsers()
     {
-        // Make a test user to search for.
-        User::create([
-            'email' => 'search-result@dosomething.org',
-        ]);
+        // Make a target user to search for & some others.
+        factory(User::class)->create(['email' => 'search-result@dosomething.org']);
+        factory(User::class, 2)->create(['mobile' => null]);
 
         // Search should be limited to `admin` scoped keys.
         $this->get('v1/users?search[email]=search-result@dosomething.org');
         $this->assertResponseStatus(403);
 
-        // Query by a "known" search term
+        // Query by a "known" search term.
+        $query = 'search-result@dosomething.org';
         $this->withLegacyApiKeyScopes(['admin'])
-            ->get('v1/users?search[_id]=search-result@dosomething.org&search[email]=search-result@dosomething.org');
+            ->get('v1/users?search[id]='.$query.'&search[email]='.$query.'&search[mobile]='.$query);
         $this->assertResponseStatus(200);
 
         // There should be one match (a user with the provided email)


### PR DESCRIPTION
#### What's this PR do?
With the [changes to how phone numbers are normalized](https://github.com/DoSomething/northstar/pull/634/commits/3ed9661c858ca4eced907482b7e0218d600de4a9), we started returning `null` if a number is invalid. Awkwardly, this means we now query for users where `mobile == null` if an admin searches by anything other than phone number in Aurora or Rogue.

This pull request adds a quick fix to ensure the normalized mobile isn't `null`, and therefore gets our search results back under control. (And our base Eloquent model automatically strips empty-strings when saving this to the database.)

#### How should this be reviewed?
Updated the `testSearchUsers` test case to demonstrate this bug & fix.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  