### PR TITLE
Send user updates to Blink.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_KEY=
 
 # Feature Flags
 DS_ENABLE_BLINK=true
+DS_ENABLE_BLINK_UPDATES=true
 DS_ENABLE_RATE_LIMITING=true
 
 # DB_HOST=localhost

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -66,13 +66,13 @@ class UserTransformer extends TransformerAbstract
         $response['role'] = $user->role;
 
         if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
-            $response['last_accessed_at'] = $user->last_accessed_at ? $user->last_accessed_at->toIso8601String() : null;
-            $response['last_authenticated_at'] = $user->last_authenticated_at ? $user->last_authenticated_at->toIso8601String() : null;
-            $response['last_messaged_at'] = $user->last_messaged_at ? $user->last_messaged_at->toIso8601String() : null;
+            $response['last_accessed_at'] = iso8601($user->last_accessed_at);
+            $response['last_authenticated_at'] = iso8601($user->last_authenticated_at);
+            $response['last_messaged_at'] = iso8601($user->last_messaged_at);
         }
 
-        $response['updated_at'] = $user->updated_at->toIso8601String();
-        $response['created_at'] = $user->created_at->toIso8601String();
+        $response['updated_at'] = iso8601($user->updated_at);
+        $response['created_at'] = iso8601($user->created_at);
 
         return $response;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -380,10 +380,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'country' => $this->country,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
-            'last_messaged_at' => $this->last_messaged_at ? $this->last_messaged_at->toIso8601String() : null,
-            'last_authenticated_at' => $this->last_authenticated_at ? $this->last_authenticated_at->toIso8601String() : null,
-            'updated_at' => $this->updated_at->toIso8601String(),
-            'created_at' => $this->created_at->toIso8601String(),
+            'last_messaged_at' => iso8601($this->last_messaged_at),
+            'last_authenticated_at' => iso8601($this->last_authenticated_at),
+            'updated_at' => iso8601($this->updated_at),
+            'created_at' => iso8601($this->created_at),
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,7 +39,7 @@ class AppServiceProvider extends ServiceProvider
 
         User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            if (config('features.blink')) {
+            if (config('features.blink') && config('features.blink-updates')) {
                 app(Blink::class)->userCreate($user->toBlinkPayload());
             }
         });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,6 +32,11 @@ class AppServiceProvider extends ServiceProvider
         });
 
         User::updating(function (User $user) {
+            // Send payload to Blink for Customer.io profile.
+            if (config('features.blink')) {
+                app(Blink::class)->userCreate($user->toBlinkPayload());
+            }
+
             // Write profile changes to the log, with redacted values for hidden fields.
             $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
             logger('updated user', ['id' => $user->id, 'client_id' => client_id(), 'changed' => $changed]);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,14 +32,16 @@ class AppServiceProvider extends ServiceProvider
         });
 
         User::updating(function (User $user) {
+            // Write profile changes to the log, with redacted values for hidden fields.
+            $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
+            logger('updated user', ['id' => $user->id, 'client_id' => client_id(), 'changed' => $changed]);
+        });
+
+        User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
             if (config('features.blink')) {
                 app(Blink::class)->userCreate($user->toBlinkPayload());
             }
-
-            // Write profile changes to the log, with redacted values for hidden fields.
-            $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
-            logger('updated user', ['id' => $user->id, 'client_id' => client_id(), 'changed' => $changed]);
         });
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -34,7 +34,7 @@ function normalize($type = null, $value = null)
 /**
  * Format a Carbon date if available to a specified format.
  *
- * @param  string $date
+ * @param Carbon|string $date
  * @param string $format
  * @return null|string
  */
@@ -51,6 +51,19 @@ function format_date($date, $format = 'M j, Y')
     }
 
     return $date->format($format);
+}
+
+/**
+ * Format a date as an ISO-8601 timestamp.
+ *
+ * @param Carbon|string $date
+ * @return null|string
+ */
+function iso8601($date)
+{
+    // Fun fact: PHP's built-in DateTime::ISO8601 constant is wrong,
+    // so that's why we use Carbon::ATOM here. (https://goo.gl/MzIaqP)
+    return format_date($date, Carbon::ATOM);
 }
 
 /**

--- a/config/features.php
+++ b/config/features.php
@@ -14,6 +14,8 @@ return [
 
     'blink' => env('DS_ENABLE_BLINK'),
 
+    'blink-updates' => env('DS_ENABLE_BLINK_UPDATES'),
+
     'password-grant' => env('DS_ENABLE_PASSWORD_GRANT', true),
 
     'rate-limiting' => env('DS_ENABLE_RATE_LIMITING'),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,5 +20,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="DS_ENABLE_PASSWORD_GRANT" value="true"/>
     </php>
 </phpunit>

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -21,6 +21,14 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
+    public function testIso8601()
+    {
+        $this->assertEquals('2017-12-15T22:00:00+00:00', iso8601('December 15 2017 10:00pm'));
+        $this->assertEquals('2017-12-15T22:00:00+00:00', iso8601(new Carbon('December 15 2017 10:00pm')));
+        $this->assertEquals(null, iso8601(null), 'handles null values safely');
+    }
+
+    /** @test */
     public function testRouteHasAttachedMiddleware()
     {
         $this->get('/login');

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -42,7 +42,7 @@ class UserModelTest extends TestCase
     /** @test */
     public function it_should_send_updated_users_to_blink()
     {
-        config(['features.blink' => true]);
+        config(['features.blink' => true, 'features.blink-updates' => true]);
 
         /** @var User $user */
         $user = factory(User::class)->create();

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -40,6 +40,20 @@ class UserModelTest extends TestCase
     }
 
     /** @test */
+    public function it_should_send_updated_users_to_blink()
+    {
+        config(['features.blink' => true]);
+
+        /** @var User $user */
+        $user = factory(User::class)->create();
+        $user->update(['birthdate' => '1/15/1990']);
+
+        // We should have made one "create" request to Blink,
+        // and a second "update" request afterwards.
+        $this->blinkMock->shouldHaveReceived('userCreate')->twice();
+    }
+
+    /** @test */
     public function it_should_log_changes()
     {
         $logger = $this->spy('log');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,16 +78,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
 
-        // Configure a mock for Phoenix & default `createDrupalUser` response.
-        $this->phoenixMock = $this->mock(Phoenix::class);
-        $this->phoenixMock->shouldReceive('createDrupalUser')->andReturnUsing(function () {
-            return $this->faker->unique()->numberBetween(1, 30000000);
-        });
-
-        // Configure a mock for Blink model events.
-        $this->blinkMock = $this->mock(Blink::class);
-        $this->blinkMock->shouldReceive('userCreate')->andReturn(true);
-
         // Reset the testing database & run migrations.
         $this->app->make('db')->getMongoDB()->drop();
         $this->artisan('migrate');
@@ -270,11 +260,21 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      */
     public function createApplication()
     {
-        $app = require __DIR__.'/../bootstrap/app.php';
+        $this->app = require __DIR__.'/../bootstrap/app.php';
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $this->app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
 
-        return $app;
+        // Configure a mock for Phoenix & default `createDrupalUser` response.
+        $this->phoenixMock = $this->mock(Phoenix::class);
+        $this->phoenixMock->shouldReceive('createDrupalUser')->andReturnUsing(function () {
+            return $this->faker->unique()->numberBetween(1, 30000000);
+        });
+
+        // Configure a mock for Blink model events.
+        $this->blinkMock = $this->mock(Blink::class);
+        $this->blinkMock->shouldReceive('userCreate')->andReturn(true);
+
+        return $this->app;
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request adds an event listener which sends updated users to Blink. It also adds an `iso8601` helper to simplify the kinda frustrating ternaries we were doing before.

#### How should this be reviewed?
References DoSomething/blink#134 for supporting "updated" user events.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  