### PR TITLE
Add Customer.io backfill command.

### DIFF
--- a/app/Console/Commands/BackfillCustomerIoProfiles.php
+++ b/app/Console/Commands/BackfillCustomerIoProfiles.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Carbon\Carbon;
+use DoSomething\Gateway\Blink;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Northstar\Models\User;
+
+class BackfillCustomerIoProfiles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:cio {start}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send profiles updated after the given date to Customer.io';
+
+    /**
+     * Execute the console command.
+     *
+     * @param Blink $blink
+     * @return mixed
+     */
+    public function handle(Blink $blink)
+    {
+        $start = new Carbon($this->argument('start'));
+
+        // Iterate over users where the `mobile` field is not null.
+        $query = User::whereNotNull('mobile')
+            ->orWhere('updated_at', '>', $start);
+
+        $query->chunkById(200, function (Collection $records) use ($blink) {
+            $users = User::hydrate($records->toArray());
+
+            // Send each of the loaded users to Blink's user queue.
+            $users->each(function ($user) {
+                gateway('blink')->userCreate($user->toBlinkPayload());
+            });
+        });
+    }
+}

--- a/app/Console/Commands/BackfillCustomerIoProfiles.php
+++ b/app/Console/Commands/BackfillCustomerIoProfiles.php
@@ -34,7 +34,8 @@ class BackfillCustomerIoProfiles extends Command
     {
         $start = new Carbon($this->argument('start'));
 
-        // Iterate over users where the `mobile` field is not null.
+        // Iterate over users where the `mobile` field is not null
+        // or their profile was updated after the given date.
         $query = User::whereNotNull('mobile')
             ->orWhere('updated_at', '>', $start);
 

--- a/app/Console/Commands/ConvertMobilesCommand.php
+++ b/app/Console/Commands/ConvertMobilesCommand.php
@@ -15,7 +15,7 @@ class ConvertMobilesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:e164 {start?}';
+    protected $signature = 'northstar:e164';
 
     /**
      * The console command description.
@@ -31,22 +31,11 @@ class ConvertMobilesCommand extends Command
      */
     public function handle()
     {
-        $start = $this->argument('start');
-        if (! $start) {
-            $firstMatch = User::whereNull('e164')->whereNotNull('mobile')->orderBy('_id')->first();
-            if (! $firstMatch) {
-                $this->error('No users need to be converted.');
-
-                return;
-            }
-
-            $start = $firstMatch->id;
-        }
-
         $counter = 1;
 
         // Iterate over users where the `mobile` field is not null.
-        User::whereNull('e164')->whereNotNull('mobile')->chunkFromId(200, $start, function (Collection $records) use (&$counter, $start) {
+        $query = User::whereNull('e164')->whereNotNull('mobile');
+        $query->chunkById(200, function (Collection $records) use (&$counter) {
             $parser = PhoneNumberUtil::getInstance();
             $users = User::hydrate($records->toArray());
 
@@ -76,6 +65,6 @@ class ConvertMobilesCommand extends Command
 
                 $counter++;
             }
-        }, '_id');
+        });
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,12 +13,13 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
+        \Northstar\Console\Commands\BackfillCustomerIoProfiles::class,
+        \Northstar\Console\Commands\BackfillPhoenixAccounts::class,
         \Northstar\Console\Commands\CleanDrupalIdsCommand::class,
         \Northstar\Console\Commands\ConvertMobilesCommand::class,
         \Northstar\Console\Commands\FixE164DuplicatesCommand::class,
         \Northstar\Console\Commands\FixMongoDatesCommand::class,
         \Northstar\Console\Commands\FixSourcesCommand::class,
-        \Northstar\Console\Commands\BackfillPhoenixAccounts::class,
     ];
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -80,13 +80,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // @TODO: This should be registered in Gateway's service provider!
-        $this->app->singleton(Blink::class, function () {
-            return new Blink(config('services.blink'));
-        });
-
-        $this->app->singleton(Gladiator::class, function () {
-            return new Gladiator(config('services.gladiator'));
-        });
+        //
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,8 @@
 
 namespace Northstar\Providers;
 
-use Illuminate\Database\Query\Builder;
 use Northstar\Models\User;
 use DoSomething\Gateway\Blink;
-use DoSomething\Gateway\Gladiator;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,39 +38,6 @@ class AppServiceProvider extends ServiceProvider
             $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
             logger('updated user', ['id' => $user->id, 'client_id' => client_id(), 'changed' => $changed]);
         });
-
-        // Add 'chunkWithLimit' method to the query builder.
-        // @see: https://github.com/laravel/internals/issues/103
-        Builder::macro('chunkFromId', function ($count, $startId, callable $callback, $column) {
-            /** @var Builder $this */
-
-            // Literally copy-pasting `chunkById` so we can override this value... :'(
-            $lastId = $startId;
-
-            do {
-                $clone = clone $this;
-
-                // ... and switch this `>` to a `>=`. Oy.
-                $results = $clone->where($column, '>=', $lastId)
-                    ->orderBy($column, 'asc')
-                    ->take($count)
-                    ->get();
-
-                $countResults = $results->count();
-
-                if ($countResults == 0) {
-                    break;
-                }
-
-                if (call_user_func($callback, $results) === false) {
-                    return false;
-                }
-
-                $lastId = $results->last()[$column];
-            } while ($countResults == $count);
-
-            return true;
-        });
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,16 @@
   "description": "The DoSomething.org user & activity API.",
   "license": "MIT",
   "type": "project",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/dosomething/laravel-mongodb"
+    }
+  ],
   "require": {
     "laravel/framework": "5.3.*",
     "guzzlehttp/guzzle": "~6.2.1",
-    "jenssegers/mongodb": "3.2.*",
+    "jenssegers/mongodb": "dev-chunkById",
     "league/flysystem-aws-s3-v3": "~1.0",
     "parse/php-sdk" : "1.1.*",
     "league/fractal": "0.13.*",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "laravel/framework": "5.3.*",
     "guzzlehttp/guzzle": "~6.2.1",
-    "jenssegers/mongodb": "3.1.*",
+    "jenssegers/mongodb": "3.2.*",
     "league/flysystem-aws-s3-v3": "~1.0",
     "parse/php-sdk" : "1.1.*",
     "league/fractal": "0.13.*",
@@ -16,7 +16,7 @@
     "zendframework/zend-diactoros": "^1.3",
     "league/iso3166": "^1.0",
     "fideloper/proxy": "^3.3",
-    "dosomething/gateway": "^1.2",
+    "dosomething/gateway": "^1.7.0",
     "laravel/socialite": "~2.0.20",
     "league/csv": "^8.0",
     "giggsey/libphonenumber-for-php": "^7.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d80b2c16c7b9cd278e59a3d75caaaa52",
+    "content-hash": "46a7e6a3fe51bf3b8d4db46d9b1f4231",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -828,16 +828,16 @@
         },
         {
             "name": "jenssegers/mongodb",
-            "version": "v3.2.3",
+            "version": "dev-chunkById",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jenssegers/laravel-mongodb.git",
-                "reference": "c0cae3e187999ea80f92cc5ab169de4baa784f2e"
+                "url": "https://github.com/DoSomething/laravel-mongodb.git",
+                "reference": "82fad701bb254fde9aba949fb26c8e4905eca954"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jenssegers/laravel-mongodb/zipball/c0cae3e187999ea80f92cc5ab169de4baa784f2e",
-                "reference": "c0cae3e187999ea80f92cc5ab169de4baa784f2e",
+                "url": "https://api.github.com/repos/DoSomething/laravel-mongodb/zipball/82fad701bb254fde9aba949fb26c8e4905eca954",
+                "reference": "82fad701bb254fde9aba949fb26c8e4905eca954",
                 "shasum": ""
             },
             "require": {
@@ -871,7 +871,13 @@
                     "Jenssegers\\Mongodb": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "classmap": [
+                    "tests/TestCase.php",
+                    "tests/models",
+                    "tests/seeds"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -892,7 +898,10 @@
                 "mongo",
                 "mongodb"
             ],
-            "time": "2017-09-05T11:17:05+00:00"
+            "support": {
+                "source": "https://github.com/DoSomething/laravel-mongodb/tree/chunkById"
+            },
+            "time": "2017-09-29T21:14:12+00:00"
         },
         {
             "name": "jeremeamia/SuperClosure",
@@ -4936,7 +4945,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "jenssegers/mongodb": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "db0c62b5041a5ea0befc9288fab23398",
+    "content-hash": "d80b2c16c7b9cd278e59a3d75caaaa52",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.35.2",
+            "version": "3.36.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a2f01d9e9ed93c1e121d2f4450ae0a047fbbb6e8"
+                "reference": "4bf27e8808e5e08a71b7fbdb951f51918c57a1c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a2f01d9e9ed93c1e121d2f4450ae0a047fbbb6e8",
-                "reference": "a2f01d9e9ed93c1e121d2f4450ae0a047fbbb6e8",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4bf27e8808e5e08a71b7fbdb951f51918c57a1c6",
+                "reference": "4bf27e8808e5e08a71b7fbdb951f51918c57a1c6",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-08-30T16:17:20+00:00"
+            "time": "2017-09-29T19:46:41+00:00"
         },
         {
             "name": "classpreloader/classpreloader",
@@ -305,16 +305,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.6.1",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "244bc4204c22b9e347d470e085f1472f288aec3c"
+                "reference": "4c008848d528131016052c2b513ff6756501cda7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/244bc4204c22b9e347d470e085f1472f288aec3c",
-                "reference": "244bc4204c22b9e347d470e085f1472f288aec3c",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/4c008848d528131016052c2b513ff6756501cda7",
+                "reference": "4c008848d528131016052c2b513ff6756501cda7",
                 "shasum": ""
             },
             "require": {
@@ -327,7 +327,8 @@
                 "zendframework/zend-diactoros": "^1.3"
             },
             "require-dev": {
-                "illuminate/database": "^5.2",
+                "illuminate/database": "^5.3",
+                "illuminate/http": "^5.3",
                 "phpunit/phpunit": "^4.8",
                 "symfony/var-dumper": "^3.1"
             },
@@ -351,7 +352,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2017-08-29T20:31:40+00:00"
+            "time": "2017-09-18T21:37:06+00:00"
         },
         {
             "name": "dosomething/stathat",
@@ -827,16 +828,16 @@
         },
         {
             "name": "jenssegers/mongodb",
-            "version": "v3.1.4",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jenssegers/laravel-mongodb.git",
-                "reference": "e3bea54120cfb45ca6dadffad11ecaed6952e063"
+                "reference": "c0cae3e187999ea80f92cc5ab169de4baa784f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jenssegers/laravel-mongodb/zipball/e3bea54120cfb45ca6dadffad11ecaed6952e063",
-                "reference": "e3bea54120cfb45ca6dadffad11ecaed6952e063",
+                "url": "https://api.github.com/repos/jenssegers/laravel-mongodb/zipball/c0cae3e187999ea80f92cc5ab169de4baa784f2e",
+                "reference": "c0cae3e187999ea80f92cc5ab169de4baa784f2e",
                 "shasum": ""
             },
             "require": {
@@ -849,7 +850,7 @@
             "require-dev": {
                 "mockery/mockery": "^0.9",
                 "orchestra/testbench": "^3.1",
-                "phpunit/phpunit": "^4.0|^5.0",
+                "phpunit/phpunit": "^5.0|^6.0",
                 "satooshi/php-coveralls": "^1.0"
             },
             "suggest": {
@@ -857,10 +858,17 @@
                 "jenssegers/mongodb-session": "Add MongoDB session support to Laravel-MongoDB"
             },
             "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Jenssegers\\Mongodb\\MongodbServiceProvider",
+                        "Jenssegers\\Mongodb\\MongodbQueueServiceProvider"
+                    ]
+                }
+            },
             "autoload": {
                 "psr-0": {
-                    "Jenssegers\\Mongodb": "src/",
-                    "Jenssegers\\Eloquent": "src/"
+                    "Jenssegers\\Mongodb": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -884,7 +892,7 @@
                 "mongo",
                 "mongodb"
             ],
-            "time": "2017-02-14T14:12:04+00:00"
+            "time": "2017-09-05T11:17:05+00:00"
         },
         {
             "name": "jeremeamia/SuperClosure",
@@ -1128,16 +1136,16 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "ddce703826f9c5229781933b1a39069e38e6a0f3"
+                "reference": "0b5930be73582369e10c4d4bb7a12bac927a203c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/ddce703826f9c5229781933b1a39069e38e6a0f3",
-                "reference": "ddce703826f9c5229781933b1a39069e38e6a0f3",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/0b5930be73582369e10c4d4bb7a12bac927a203c",
+                "reference": "0b5930be73582369e10c4d4bb7a12bac927a203c",
                 "shasum": ""
             },
             "require": {
@@ -1182,7 +1190,7 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2016-10-31T20:09:32+00:00"
+            "time": "2017-09-01T08:23:26+00:00"
         },
         {
             "name": "league/csv",
@@ -2025,16 +2033,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4d4896e553f2094e657fe493506dc37c509d4e2b"
+                "reference": "a1e8e1a30e1352f118feff1a8481066ddc2f234a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4d4896e553f2094e657fe493506dc37c509d4e2b",
-                "reference": "4d4896e553f2094e657fe493506dc37c509d4e2b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a1e8e1a30e1352f118feff1a8481066ddc2f234a",
+                "reference": "a1e8e1a30e1352f118feff1a8481066ddc2f234a",
                 "shasum": ""
             },
             "require": {
@@ -2072,20 +2080,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-07-28T14:45:09+00:00"
+            "time": "2017-09-02T17:10:46+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -2120,7 +2128,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:27:32+00:00"
+            "time": "2017-09-27T21:40:39+00:00"
         },
         {
             "name": "parse/php-sdk",
@@ -2347,16 +2355,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "0ef23d1b10cf1bc576e9d865a7e9c47982c5715e"
+                "reference": "45cffe822057a09e05f7bd09ec5fb88eeecd2334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/0ef23d1b10cf1bc576e9d865a7e9c47982c5715e",
-                "reference": "0ef23d1b10cf1bc576e9d865a7e9c47982c5715e",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/45cffe822057a09e05f7bd09ec5fb88eeecd2334",
+                "reference": "45cffe822057a09e05f7bd09ec5fb88eeecd2334",
                 "shasum": ""
             },
             "require": {
@@ -2425,7 +2433,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2017-08-04T13:39:04+00:00"
+            "time": "2017-09-22T20:46:04+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -2601,7 +2609,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.3.8",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -3376,16 +3384,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "1d23172f9dc1687a97c195a777b0199f14f7b26e"
+                "reference": "2faa791b66bac33ca40031d8bce03b7dc8143490"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/1d23172f9dc1687a97c195a777b0199f14f7b26e",
-                "reference": "1d23172f9dc1687a97c195a777b0199f14f7b26e",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/2faa791b66bac33ca40031d8bce03b7dc8143490",
+                "reference": "2faa791b66bac33ca40031d8bce03b7dc8143490",
                 "shasum": ""
             },
             "require": {
@@ -3404,8 +3412,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev",
-                    "dev-develop": "1.6-dev"
+                    "dev-master": "1.6-dev",
+                    "dev-develop": "1.7-dev"
                 }
             },
             "autoload": {
@@ -3424,7 +3432,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-08-22T20:38:56+00:00"
+            "time": "2017-09-13T14:47:08+00:00"
         }
     ],
     "packages-dev": [
@@ -3644,16 +3652,16 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -3694,20 +3702,20 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.3",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f"
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/86e24012a3139b42a7b71155cfaa325389f00f1f",
-                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
                 "shasum": ""
             },
             "require": {
@@ -3739,7 +3747,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-29T19:37:41+00:00"
+            "time": "2017-08-30T18:51:59+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3902,22 +3910,22 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -3928,7 +3936,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -3961,7 +3969,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-09-04T11:05:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4822,7 +4830,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.8",
+            "version": "v3.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/config/app.php
+++ b/config/app.php
@@ -166,6 +166,7 @@ return [
         Fideloper\Proxy\TrustedProxyServiceProvider::class,
         Jenssegers\Mongodb\MongodbServiceProvider::class,
         Jenssegers\Mongodb\Auth\PasswordResetServiceProvider::class,
+        DoSomething\Gateway\Laravel\GatewayServiceProvider::class,
         DoSomething\StatHat\StatHatServiceProvider::class,
         Laravel\Socialite\SocialiteServiceProvider::class,
 

--- a/tests/Console/BackfillCustomerIoProfilesTest.php
+++ b/tests/Console/BackfillCustomerIoProfilesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Carbon\Carbon;
+use DoSomething\Gateway\Blink;
+use Northstar\Models\User;
+
+class BackfillCustomerIoProfilesTest extends TestCase
+{
+    /** @test */
+    public function it_should_backfill_users()
+    {
+        factory(User::class, 2)->create(); // with phone number!
+        factory(User::class, 3)->create(['mobile' => null, 'updated_at' => new Carbon('1/15/2016')]);
+        factory(User::class, 2)->create(['updated_at' => new Carbon('3/14/2017')]);
+
+        // Reset our Blink mock & set expectation that it'll be called twice - once
+        // for each of the users updated between 1/1/2017 and now.
+        $this->mock(Blink::class)->shouldReceive('userCreate')->times(4);
+
+        // Run the Customer.io backfill command.
+        $this->artisan('northstar:cio', ['start' => '1/1/2017']);
+    }
+}

--- a/tests/Console/BackfillCustomerIoProfilesTest.php
+++ b/tests/Console/BackfillCustomerIoProfilesTest.php
@@ -13,8 +13,8 @@ class BackfillCustomerIoProfilesTest extends TestCase
         factory(User::class, 3)->create(['mobile' => null, 'updated_at' => new Carbon('1/15/2016')]);
         factory(User::class, 2)->create(['updated_at' => new Carbon('3/14/2017')]);
 
-        // Reset our Blink mock & set expectation that it'll be called twice - once
-        // for each of the users updated between 1/1/2017 and now.
+        // Reset our Blink mock & set expectation that it'll be called 4 times - once
+        // for each of the users updated after 1/1/2017, & once for each w/ a phone #.
         $this->mock(Blink::class)->shouldReceive('userCreate')->times(4);
 
         // Run the Customer.io backfill command.

--- a/tests/Console/ConvertMobilesCommandTest.php
+++ b/tests/Console/ConvertMobilesCommandTest.php
@@ -42,19 +42,18 @@ class ConvertMobilesCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_should_restart_based_on_skip_argument()
+    public function it_should_not_reprocess_existing_e164_values()
     {
-        $this->createMongoDocument('users', ['mobile' => '7455559417']);
-        $this->createMongoDocument('users', ['mobile' => '6965552100']);
+        $this->createMongoDocument('users', ['mobile' => '7455559417', 'e164' => 'skip']);
+        $this->createMongoDocument('users', ['mobile' => '6965552100', 'e164' => 'skip']);
         $this->createMongoDocument('users', ['mobile' => '2225559999']); // start!
         $this->createMongoDocument('users', ['mobile' => '8145551234']);
 
         // Run the command to convert to E.164 format.
-        $id = User::where('mobile', '2225559999')->first()->id;
-        $this->artisan('northstar:e164', ['start' => $id]);
+        $this->artisan('northstar:e164');
 
-        $this->seeInDatabase('users', ['mobile' => '7455559417', 'e164' => null]); // skipped!
-        $this->seeInDatabase('users', ['mobile' => '6965552100', 'e164' => null]); // skipped!
+        $this->seeInDatabase('users', ['mobile' => '7455559417', 'e164' => 'skip']); // skipped!
+        $this->seeInDatabase('users', ['mobile' => '6965552100', 'e164' => 'skip']); // skipped!
         $this->seeInDatabase('users', ['mobile' => '8145551234', 'e164' => '+18145551234']);
         $this->seeInDatabase('users', ['mobile' => '2225559999', 'e164' => '+12225559999']);
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `northstar:cio` command to send users to Customer.io via Blink. This will allow us to backfill users who either were skipped because they were mobile-only, or had profile updates after our initial "bulk import" back in May.

To run these scripts efficiently, I've made [a custom patch of `jenssegers/laravel-mongodb` v3.2](https://github.com/jenssegers/laravel-mongodb/compare/master...DoSomething:chunkById) which supports using the `chunkById` method on queries. I've also [submitted a pull request](https://git.io/vdcRz) to make this fix against the master branch there as well.

It also updates Northstar to use [the latest Gateway release](https://github.com/DoSomething/gateway/releases/tag/v1.7.0), which removes the need to manually bind some API classes to the app container (that now happens within `GatewayServiceProvider`).

#### How should this be reviewed?
I'd recommend checking out things commit-by-commit for context.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  