### PR TITLE
validating name length and birthdate

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -64,6 +64,7 @@ class Registrar
 
         $existingId = isset($existingUser->id) ? $existingUser->id : 'null';
         $rules = [
+            'first_name' => 'max:50',
             'email' => 'email|unique:users,email,'.$existingId.',_id|required_without:mobile',
             'mobile' => 'mobile|unique:users,mobile,'.$existingId.',_id|required_without:email',
             'birthdate' => 'date',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -182,8 +182,8 @@ class AuthController extends BaseController
     public function postRegister(Request $request)
     {
         $this->registrar->validate($request, null, [
-            'first_name' => 'required',
-            'birthdate' => 'required|date',
+            'first_name' => 'required|max:50',
+            'birthdate' => 'required|date|before:now',
             'email' => 'required|email|unique:users',
             'mobile' => 'mobile|unique:users',
             'password' => 'required|min:6|max:512',

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -172,6 +172,27 @@ class WebAuthenticationTest extends TestCase
     }
 
     /**
+     * Test that users can't enter invalid profile info.
+     */
+    public function testRegisterInvalid()
+    {
+        $this->withHeader('X-Fastly-Country-Code', 'US');
+
+        $this->visit('register');
+        $this->submitForm('register-submit', [
+            'first_name' => $this->faker->text(150),
+            'email' => $this->faker->unique->email,
+            'birthdate' => '1/15/2130',
+            'password' => 'secret',
+        ]);
+
+        $this->see('The first name may not be greater than 50 characters');
+        $this->see('The birthdate must be a date before now');
+
+        $this->dontSeeIsAuthenticated('web');
+    }
+
+    /**
      * Test that users can register from other countries
      * and get the correct `country` and `language` fields.
      */


### PR DESCRIPTION
#### What's this PR 
- Validating the length of users first name - limiting to 50 chars
- Validating the birthdate to ensure it is in the past

#### How should this be reviewed?
Try signing up with a name over 50 chars or a BD from the future I dare you!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild! 

---
For review: …
