### PR TITLE
Logout security

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -155,7 +155,11 @@ class AuthController extends BaseController
     public function getLogout(Request $request)
     {
         // A custom post-logout redirect can be specified with `/logout?redirect=`
-        $redirect = $request->query('redirect', 'login');
+        $redirect = $request->query('redirect');
+
+        if (! $redirect || ! is_dosomething_domain($redirect)) {
+            $redirect = 'login';
+        }
 
         $this->auth->guard('web')->logout();
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -173,6 +173,12 @@ function format_birthdate($birthdate)
     return format_date($birthdate, 'Y-m-d');
 }
 
+/**
+ * Format a legacy phone number to a proper number format.
+ *
+ * @param  string $mobile
+ * @return string
+ */
 function format_legacy_mobile($mobile)
 {
     try {
@@ -184,4 +190,21 @@ function format_legacy_mobile($mobile)
     } catch (\libphonenumber\NumberParseException $e) {
         return null;
     }
+}
+
+/**
+ * Check if the given url is a *.dosomething.org domain.
+ *
+ * @param  string  $url
+ * @return boolean
+ */
+function is_dosomething_domain($url)
+{
+    $parsed = parse_url($url);
+
+    if (! array_key_exists('host', $parsed)) {
+        return false;
+    }
+
+    return strpos($parsed['host'], 'dosomething.org') !== FALSE;
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -196,7 +196,7 @@ function format_legacy_mobile($mobile)
  * Check if the given url is a *.dosomething.org domain.
  *
  * @param  string  $url
- * @return boolean
+ * @return bool
  */
 function is_dosomething_domain($url)
 {
@@ -206,5 +206,5 @@ function is_dosomething_domain($url)
         return false;
     }
 
-    return strpos($parsed['host'], 'dosomething.org') !== FALSE;
+    return strpos($parsed['host'], 'dosomething.org') !== false;
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -206,5 +206,5 @@ function is_dosomething_domain($url)
         return false;
     }
 
-    return strpos($parsed['host'], 'dosomething.org') !== false;
+    return ends_with($parsed['host'], 'dosomething.org') !== false;
 }

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -163,7 +163,7 @@ class WebAuthenticationTest extends TestCase
 
         $this->be($user, 'web');
 
-        $this->get('logout?redirect=http://puppet.sloth.com');
+        $this->get('logout?redirect=http://dosomething.org.sloth.com');
 
         $this->dontSeeIsAuthenticated('web');
         $this->assertResponseStatus(302);

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -154,6 +154,25 @@ class WebAuthenticationTest extends TestCase
     }
 
     /**
+     * Test that we can't be redirected to a third party domain
+     * in the custom post-logout redirect.
+     */
+    public function testLogoutRedirectThirdPartyDomain()
+    {
+        $user = factory(User::class)->create();
+
+        $this->be($user, 'web');
+
+        $this->get('logout?redirect=http://puppet.sloth.com');
+
+        $this->dontSeeIsAuthenticated('web');
+        $this->assertResponseStatus(302);
+
+        $location = $this->response->headers->get('Location');
+        $this->assertNotEquals('http://puppet.sloth.com', $location);
+    }
+
+    /**
      * Test that users can register via the web.
      */
     public function testRegister()

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -169,7 +169,7 @@ class WebAuthenticationTest extends TestCase
         $this->assertResponseStatus(302);
 
         $location = $this->response->headers->get('Location');
-        $this->assertNotEquals('http://puppet.sloth.com', $location);
+        $this->assertNotEquals('http://dosomething.org.sloth.com', $location);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pr checks if the logout redirect is a `*.dosomething.org` domain so a third party cant' hijack a users experience.

#### How should this be reviewed?
Try going to `/logout?redirect="http://heyheyhey.com"` and `/logout?redirect="http://dosomething.org"`

*note: the HTTP part matters. if we have apps not including http in the redirect url they need to be updated as well.

**Fixes**: https://www.pivotaltracker.com/story/show/150597261

#### Checklist
- [x] Tests added for new features/bug fixes.