### PR TITLE
Throttle password resets

### DIFF
--- a/app/Http/Controllers/Web/ForgotPasswordController.php
+++ b/app/Http/Controllers/Web/ForgotPasswordController.php
@@ -25,5 +25,6 @@ class ForgotPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+        $this->middleware('throttle', ['only' => ['sendResetLinkEmail']]);
     }
 }

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -27,7 +27,6 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
-        $this->middleware('throttle', ['only' => ['postEmail']]);
     }
 
     /**

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -58,7 +58,8 @@ class PasswordResetTest extends TestCase
     }
 
     /**
-     * Test that users can't brute-force resetting a user's password via enumeration.
+     * Test that users can't request a password reset for another user and flood their email,
+     * and mitigate brute-force guessing an existing email via enumeration.
      */
     public function testPasswordResetRateLimited()
     {

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -65,7 +65,7 @@ class PasswordResetTest extends TestCase
     {
         for ($i = 0; $i < 10; $i++) {
             $this->visit('password/reset');
-            $this->submitForm('Request New Password',[
+            $this->submitForm('Request New Password', [
                 'email' => 'nonexistant@example.com',
             ]);
 
@@ -75,7 +75,7 @@ class PasswordResetTest extends TestCase
         $this->expectsEvents(\Northstar\Events\Throttled::class);
 
         $this->visit('password/reset');
-        $this->submitForm('Request New Password',[
+        $this->submitForm('Request New Password', [
             'email' => 'nonexistant@example.com',
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
This PR moves the middleware throttle for resetting a password out of the `ResetPasswordController` and into the `ForgotPasswordController` for the corresponding method that actually sends out the reset link email (`sendResetLinkEmail`).

#### How should this be reviewed?
👁 

#### Checklist
- [x] Tests added for new features/bug fixes.

---
For review: @DFurnes @itsjoekent @mendelB 
