### PR TITLE
Always return redirect_uri as an array.

### DIFF
--- a/app/Http/Transformers/ClientTransformer.php
+++ b/app/Http/Transformers/ClientTransformer.php
@@ -22,7 +22,7 @@ class ClientTransformer extends TransformerAbstract
             'scope' => $client->scope,
 
             'allowed_grant' => $client->allowed_grant,
-            'redirect_uri' => $client->redirect_uri,
+            'redirect_uri' => is_array($client->redirect_uri) ? $client->redirect_uri : [$client->redirect_uri],
 
             'refresh_tokens' => $client->getRefreshTokenCount(),
 


### PR DESCRIPTION
#### What's this PR do?
We have some `redirect_uri` fields stored as strings. To make our logic easier on Aurora, let's always return these as an array from Northstar (since that's how we'll be setting them from now on).

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  