### PR TITLE
Restrict grants per client.

### DIFF
--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -50,7 +50,12 @@ class ClientRepository implements ClientRepositoryInterface
      */
     public function clientCanUseGrant($client, $grantType)
     {
-        // @TODO: Limit this based on the 'allowed_grants' field on the Client.
-        return true;
+        // The refresh token grant can be used by password or auth code tokens.
+        if ($grantType === 'refresh_token') {
+            return in_array($client->allowed_grant, ['password', 'authorization_code']);
+        }
+
+        // Otherwise, the client must always match the grant being used.
+        return $client->allowed_grant === $grantType;
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -10,7 +10,8 @@ namespace Northstar\Models;
  * @property string $description
  * @property string $client_id
  * @property string $client_secret
- * @property string $redirect_uri
+ * @property string $allowed_grant
+ * @property array $redirect_uri
  * @property array $scope
  */
 class Client extends Model

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -59,3 +59,34 @@ $factory->defineAs(Northstar\Models\User::class, 'admin', function (Faker\Genera
         'role' => 'admin',
     ];
 });
+
+$factory->defineAs(\Northstar\Models\Client::class, 'authorization_code', function (Faker\Generator $faker) {
+    return [
+        'client_id' => $faker->unique()->numerify('phpunit-###'),
+        'title' => $faker->company,
+        'description' => $faker->sentence,
+        'allowed_grant' => 'authorization_code',
+        'scope' => ['user', 'openid', 'profile', 'role:staff', 'role:admin'],
+        'redirect_uri' => $faker->url,
+    ];
+});
+
+$factory->defineAs(\Northstar\Models\Client::class, 'password', function (Faker\Generator $faker) {
+    return [
+        'client_id' => $faker->unique()->numerify('phpunit-###'),
+        'title' => $faker->company,
+        'description' => $faker->sentence,
+        'allowed_grant' => 'password',
+        'scope' => ['user', 'profile', 'role:staff', 'role:admin'],
+    ];
+});
+
+$factory->defineAs(\Northstar\Models\Client::class, 'client_credentials', function (Faker\Generator $faker) {
+    return [
+        'client_id' => $faker->unique()->numerify('phpunit-###'),
+        'title' => $faker->company,
+        'description' => $faker->sentence,
+        'allowed_grant' => 'client_credentials',
+        'scope' => ['user', 'admin'],
+    ];
+});

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -15,24 +15,23 @@ class ClientTableSeeder extends Seeder
     {
         DB::table('clients')->delete();
 
-        // For easy testing, we'll seed one client with all scopes...
-        Client::create([
-            'title' => 'Trusted Test Client',
-            'description' => 'This is an example OAuth client seeded with your local Northstar installation. It was automatically given all scopes that were defined when it was created.',
-            'client_id' => 'trusted-test-client',
+        // For easy testing, we'll seed one client for web authentication:
+        factory(Client::class, 'authorization_code')->create([
+            'title' => 'Local Development',
+            'description' => 'This is an example web OAuth client seeded with your local Northstar installation.',
+            'client_id' => 'oauth-test-client',
             'client_secret' => 'secret1',
-            'allowed_grants' => ['authorization_code', 'password', 'client_credentials'],
-            'scope' => collect(Scope::all())->keys()->toArray(),
+            'scope' => collect(Scope::all())->except('admin')->keys()->toArray(),
+            // @NOTE: We're omitting 'redirect_uri' here for easy local dev.
         ]);
 
-        // ..and one with limited scopes.
-        Client::create([
-            'title' => 'Untrusted Test Client',
-            'description' => 'This is an example OAuth client seeded with your local Northstar installation. It is only given the user scope, and can be used to simulate untrusted clients (for example, the mobile app).',
-            'client_id' => 'untrusted-test-client',
+        // ..and one for machine authentication:
+        factory(Client::class, 'client_credentials')->create([
+            'title' => 'Local Development (Machine)',
+            'description' => 'This is an example machine OAuth client seeded with your local Northstar installation.',
+            'client_id' => 'machine-test-client',
             'client_secret' => 'secret2',
-            'allowed_grants' => ['password'],
-            'scope' => ['user'],
+            'scope' => collect(Scope::all())->keys()->toArray(),
         ]);
     }
 }

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -254,7 +254,7 @@ class WebAuthenticationTest extends TestCase
      */
     public function testAuthorizeSessionVariablesExist()
     {
-        $client = Client::create(['client_id' => 'phpunit', 'scope' => ['user'], 'redirect_uri' => 'http://example.com/']);
+        $client = factory(Client::class, 'authorization_code')->create();
 
         $this->get('authorize?'.http_build_query([
             'response_type' => 'code',


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Northstar to restrict which grants a particular client is allowed to use. This was always informally enforced, but now we can't accidentally misuse a client due to user error.

References [#150598196](https://www.pivotaltracker.com/story/show/150598196).

#### How should this be reviewed?
I've set `allowed_grant` and `redirect_uri` fields for all clients on QA, Thor, and production.

I had to update the test suites to ensure all those clients have `allowed_grant` specified. I also updated the clients seeded with `php artisan db:seed` to be more clear with how we actually use them in practice (and I'll update other `.env.example` files to match).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  