### PR TITLE
Add Discovery & Key endpoints.

### DIFF
--- a/app/Http/Controllers/DiscoveryController.php
+++ b/app/Http/Controllers/DiscoveryController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+class DiscoveryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @see http://openid.net/specs/openid-connect-discovery-1_0.html
+     * @return array
+     */
+    public function index()
+    {
+        // Grab the canonical app URL from config.
+        $url = config('app.url');
+
+        return [
+            'issuer' => $url,
+            'authorization_endpoint' => url($url.'/authorize'),
+            'token_endpoint' => url($url.'/v2/auth/token'),
+            'userinfo_endpoint' => url($url.'/v2/auth/info'),
+
+            'response_types_supported' => ['code'],
+            'subject_types_supported' => ['public'],
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ];
+    }
+}

--- a/app/Http/Controllers/DiscoveryController.php
+++ b/app/Http/Controllers/DiscoveryController.php
@@ -20,6 +20,7 @@ class DiscoveryController extends Controller
             'authorization_endpoint' => url($url.'/authorize'),
             'token_endpoint' => url($url.'/v2/auth/token'),
             'userinfo_endpoint' => url($url.'/v2/auth/info'),
+            'jwks_uri' => url($url.'/v2/keys'),
 
             'response_types_supported' => ['code'],
             'subject_types_supported' => ['public'],

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -2,6 +2,9 @@
 
 namespace Northstar\Http\Controllers;
 
+use JOSE_JWK;
+use phpseclib\Crypt\RSA;
+
 class KeyController extends Controller
 {
     /**
@@ -10,7 +13,27 @@ class KeyController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('role:admin');
+        $this->middleware('role:admin', ['only' => 'show']);
+    }
+
+    /**
+     * Return the public key formatted as a JWK, which can be
+     * used by other resource servers to verify JWTs.
+     *
+     * @return array
+     */
+    public function index()
+    {
+        $path = base_path('storage/keys/public.key');
+        $key = new RSA();
+
+        // Create the JWK payload for our public key.
+        $key->loadKey(file_get_contents($path));
+        $jwk = json_decode((string) JOSE_JWK::encode($key));
+
+        return [
+            'keys' => [$jwk],
+        ];
     }
 
     /**

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -95,6 +95,11 @@ $router->group(['prefix' => 'v1', 'as' => 'v1.', 'middleware' => ['api']], funct
     $router->resource('reportbacks', 'Legacy\ReportbackController', ['only' => ['index', 'show', 'store']]);
 });
 
+// Discovery
+$router->group(['prefix' => '.well-known'], function () use ($router) {
+    $router->get('openid-configuration', 'DiscoveryController@index');
+});
+
 // Simple health check endpoint
 $router->get('/status', function () {
     return ['status' => 'good'];

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -62,7 +62,8 @@ $router->group(['prefix' => 'v2', 'as' => 'v2.', 'middleware' => ['api']], funct
     $router->resource('resets', 'ResetController', ['only' => 'store']);
 
     // Public Key
-    $router->get('key', 'KeyController@show');
+    $router->get('keys', 'KeyController@index');
+    $router->get('key', 'KeyController@show'); // Deprecated.
 
     // Scopes
     $router->get('scopes', 'ScopeController@index');

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "dosomething/gateway": "^1.7.0",
     "laravel/socialite": "~2.0.20",
     "league/csv": "^8.0",
-    "giggsey/libphonenumber-for-php": "^7.0"
+    "giggsey/libphonenumber-for-php": "^7.0",
+    "gree/jose": "^2.2"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "46a7e6a3fe51bf3b8d4db46d9b1f4231",
+    "content-hash": "bdb156d9163abaef53087747dc80b4bc",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -560,6 +560,62 @@
             ],
             "description": "Locale functions required by libphonenumber-for-php",
             "time": "2017-04-07T18:45:42+00:00"
+        },
+        {
+            "name": "gree/jose",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nov/jose-php.git",
+                "reference": "445d702ffc8b17abd22d664b334a4046a0ed0b8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nov/jose-php/zipball/445d702ffc8b17abd22d664b334a4046a0ed0b8e",
+                "reference": "445d702ffc8b17abd22d664b334a4046a0ed0b8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpseclib/phpseclib": ">=2.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JOSE": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "src/"
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nov Matake",
+                    "email": "nov@matake.jp",
+                    "homepage": "http://matake.jp"
+                }
+            ],
+            "description": "JWT, JWS and JWS implementation in PHP",
+            "homepage": "https://github.com/nov/jose",
+            "keywords": [
+                "ID Token",
+                "JOSE",
+                "JSON Web Encryption",
+                "JSON Web Signature",
+                "JSON Web Token",
+                "JWE",
+                "JWS",
+                "OpenID Connect",
+                "jwt"
+            ],
+            "time": "2016-09-14T07:47:41+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2191,6 +2247,98 @@
                 "sdk"
             ],
             "time": "2016-01-25T19:05:20+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "34a7699e6f31b1ef4035ee36444407cecf9f56aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/34a7699e6f31b1ef4035ee36444407cecf9f56aa",
+                "reference": "34a7699e6f31b1ef4035ee36444407cecf9f56aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "~4.0",
+                "sami/sami": "~2.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "time": "2017-06-05T06:31:10+00:00"
         },
         {
             "name": "psr/http-message",


### PR DESCRIPTION
#### What's this PR do?
This pull request adds [OpenID Connect Discovery](http://openid.net/specs/openid-connect-discovery-1_0.html) and [JSON Web Key](https://tools.ietf.org/html/draft-ietf-jose-json-web-key-41) endpoints to Northstar. This will allow resource servers to automatically load Northstar's public key [using a command in Gateway](https://github.com/DoSomething/gateway/pull/85).

The "discovery endpoint" is a standardized way to communicate information about how an OpenID Connect server works, and is specifically useful here so we don't have to hardcode the JWKS endpoint into Gateway. Here's [Google's discovery endpoint](https://accounts.google.com/.well-known/openid-configuration) for comparison.

The JWKS endpoint is a standardized way to share public keys with the world. This is useful for setting up other servers with Northstar's public key (rather than using `scp` to bop a file around), and especially handy for quickly setting up local environments! Here's [Google's](https://www.googleapis.com/oauth2/v3/certs) and [Twitch's](https://api.twitch.tv/api/oidc/keys) for comparison.

References [#151957763](https://www.pivotaltracker.com/story/show/151957763).

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  