### PR TITLE
Use usleep for accurate sub-second delays.

### DIFF
--- a/app/Console/Commands/BackfillCustomerIoProfiles.php
+++ b/app/Console/Commands/BackfillCustomerIoProfiles.php
@@ -73,10 +73,7 @@ class BackfillCustomerIoProfiles extends Command
 
                 // If the `--throughput #` parameter is set, make sure we can't
                 // process more than # users per minute by taking a little nap.
-                if ($throughput) {
-                    $seconds = 60 / $throughput;
-                    usleep($seconds * 1000000);
-                }
+                throttle($throughput);
             });
         });
     }

--- a/app/Console/Commands/BackfillCustomerIoProfiles.php
+++ b/app/Console/Commands/BackfillCustomerIoProfiles.php
@@ -74,7 +74,8 @@ class BackfillCustomerIoProfiles extends Command
                 // If the `--throughput #` parameter is set, make sure we can't
                 // process more than # users per minute by taking a little nap.
                 if ($throughput) {
-                    sleep(60 / $throughput);
+                    $seconds = 60 / $throughput;
+                    usleep($seconds * 1000000);
                 }
             });
         });

--- a/app/Console/Commands/FixSourcesCommand.php
+++ b/app/Console/Commands/FixSourcesCommand.php
@@ -67,7 +67,8 @@ class FixSourcesCommand extends Command
             // If the `--throughput #` parameter is set, make sure we can't
             // process more than # users per minute by taking a little nap.
             if ($throughput) {
-                sleep(60 / $throughput);
+                $seconds = 60 / $throughput;
+                usleep($seconds * 1000000);
             }
         }
 

--- a/app/Console/Commands/FixSourcesCommand.php
+++ b/app/Console/Commands/FixSourcesCommand.php
@@ -66,10 +66,7 @@ class FixSourcesCommand extends Command
 
             // If the `--throughput #` parameter is set, make sure we can't
             // process more than # users per minute by taking a little nap.
-            if ($throughput) {
-                $seconds = 60 / $throughput;
-                usleep($seconds * 1000000);
-            }
+            throttle($throughput);
         }
 
         $this->info('Done!');

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -208,3 +208,25 @@ function is_dosomething_domain($url)
 
     return ends_with($parsed['host'], 'dosomething.org') !== false;
 }
+
+/**
+ * Throttle a script by setting a limit on the number of
+ * times something can happen per minute.
+ *
+ * @param int $throughput
+ * @return void
+ */
+function throttle($throughput)
+{
+    // Refuse to throttle non-console contexts.
+    if (! app()->runningInConsole()) {
+        throw new InvalidArgumentException('Cannot use throttle() outside of console scripts.');
+    }
+
+    if (empty($throughput)) {
+        return;
+    }
+
+    $seconds = 60 / $throughput;
+    usleep($seconds * 1000000);
+}


### PR DESCRIPTION
#### What's this PR do?
It turns out that PHP's `sleep` [only accepts integers](http://php.net/manual/en/function.sleep.php#54587), and so `sleep(0.5)` would just not sleep at all! Instead, let's use [`usleep`](http://php.net/manual/en/function.usleep.php) which takes an argument in microseconds.

#### How should this be reviewed?
I'm a dummy & only tested this with a really low throughput.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …