### PR TITLE
Add tests for nullable fields.

### DIFF
--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -169,6 +169,38 @@ class UserTest extends BrowserKitTestCase
         $this->assertNotEquals('Hamilton', $user->last_name);
     }
 
+    /** @test */
+    public function testUnsetFieldWithEmptyString()
+    {
+        $user = factory(User::class)->create();
+        $staff = factory(User::class, 'staff')->create();
+
+        $this->asUser($staff, ['user', 'role:staff'])->json('PUT', 'v1/users/id/'.$user->id, [
+            'mobile' => '',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The user field should have been removed.
+        $this->assertNull($user->fresh()->mobile);
+    }
+
+    /** @test */
+    public function testUnsetFieldWithNull()
+    {
+        $user = factory(User::class)->create();
+        $staff = factory(User::class, 'staff')->create();
+
+        $this->asUser($staff, ['user', 'role:staff'])->json('PUT', 'v1/users/id/'.$user->id, [
+            'mobile' => null,
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The user field should have been removed.
+        $this->assertNull($user->fresh()->mobile);
+    }
+
     /**
      * Test that a staffer cannot change a user's role.
      * GET /users/:term/:id


### PR DESCRIPTION
#### What's this PR do?
~A fun bug I noticed when upgrading Aurora – when we [updated Northstar to Laravel 5.3](https://github.com/DoSomething/northstar/pull/600), we forgot to add the `nullable` validation rule. This means that explicitly setting `null` for a field would fail. Luckily we don't usually do that (we either sent empty strings from Aurora, or partial fields from other clients).~

~However, now that [Aurora is on Laravel 5.5](https://github.com/DoSomething/aurora/pull/163), the default `TrimStrings` middleware turns empty strings into nulls, which causes this to be a big deal! This pull request adds a test case to demonstrate the problem and fixes the unexpected behavior by marking fields as nullable~ 

...kidding, this pull request just adds a few tests (since the actual issue was fixed in #677).

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  