### PR TITLE
Explicitly set  redirect URI on seeded client.

### DIFF
--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -23,6 +23,7 @@ class ClientTableSeeder extends Seeder
             'client_secret' => 'secret1',
             'scope' => collect(Scope::all())->except('admin')->keys()->toArray(),
             // @NOTE: We're omitting 'redirect_uri' here for easy local dev.
+            'redirect_uri' => null,
         ]);
 
         // ..and one for machine authentication:


### PR DESCRIPTION
#### What's this PR do?
Oof, I didn't notice that I had set a `redirect_uri` on the base Client factory, so we need to explicitly set it to `null` here (so that we can use this client for any URL on local dev).

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  