### PR TITLE
Backfill to customer io

### DIFF
--- a/app/Console/Commands/BackfillCustomerIoProfiles.php
+++ b/app/Console/Commands/BackfillCustomerIoProfiles.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Jenssegers\Mongodb\Eloquent\Builder;
 use Northstar\Models\User;
+use Northstar\Services\CustomerIo;
 
 class BackfillCustomerIoProfiles extends Command
 {
@@ -21,7 +22,8 @@ class BackfillCustomerIoProfiles extends Command
                             {start : The date to begin back-filling records from.}
                             {end=now : The date to back-fill records until.}
                             {--created_at : Process records based on their created_at timestamp.}
-                            {--throughput= : The maximum number of records to process per minute.}';
+                            {--throughput= : The maximum number of records to process per minute.}
+                            {--bypassBlink : Bypass Blink and go straight to Customer.io}';
 
     /**
      * The console command description.
@@ -29,6 +31,58 @@ class BackfillCustomerIoProfiles extends Command
      * @var string
      */
     protected $description = 'Send profiles updated after the given date to Customer.io';
+
+    protected $customerIo;
+
+    public function __construct(CustomerIo $customerIO)
+    {
+        $this->customerIo = $customerIO;
+    }
+
+    /**
+     * Mark the given user as either updated or
+     * log the failed id to the console.
+     *
+     * @param  User  $user
+     * @param  boolean $isUpdated
+     */
+    private function markUserAsUpdated($user, $isUpdated)
+    {
+        if ($isUpdated) {
+            $user->cio_backfilled = true;
+            $user->save(['touch' => false]);
+
+            $this->line('Successfully backfilled user '.$user->id);
+        } else {
+            $this->error('Failed to backfill user '.$user->id);
+        }
+    }
+
+    /**
+     * Backfill the given user using Blink.
+     *
+     * @param  User $user
+     */
+    private function backfillWithBlink($user) {
+        try {
+            gateway('blink')->userCreate($user->toBlinkPayload());
+
+            $this->markUserAsUpdated($user, true);
+        } catch (Exception $e) {
+            $this->markUserAsUpdated($user, false);
+        }
+    }
+
+    /**
+     * Backfill the given user directly to Customer.Io
+     *
+     * @param  User $user
+     */
+    private function backfillWithCustomerIo($user) {
+        $response = $this->customerIo->updateProfile($user);
+
+        $this->markUserAsUpdated($user, $response);
+    }
 
     /**
      * Execute the console command.
@@ -42,6 +96,7 @@ class BackfillCustomerIoProfiles extends Command
 
         $byCreatedAt = $this->option('created_at');
         $throughput = $this->option('throughput');
+        $bypassBlink = $this->option('bypassBlink');
 
         if ($byCreatedAt) {
             // If we pass `--created_at` flag, iterate over all users created in that time frame.
@@ -57,18 +112,13 @@ class BackfillCustomerIoProfiles extends Command
         }
 
         $query->chunkById(200, function (Collection $users) use ($throughput) {
-            // Send each of the loaded users to Blink's user queue.
+            // Send each of the loaded users to be processed.
+
             $users->each(function (User $user) use ($throughput) {
-                try {
-                    gateway('blink')->userCreate($user->toBlinkPayload());
-
-                    // Mark this user as processed.
-                    $user->cio_backfilled = true;
-                    $user->save(['touch' => false]);
-
-                    $this->line('Successfully backfilled user '.$user->id);
-                } catch (Exception $e) {
-                    $this->error('Failed to backfill user '.$user->id);
+                if ($bypassBlink) {
+                    $this->backfillWithCustomerIo($user);
+                } else {
+                    $this->backfillWithBlink($user);
                 }
 
                 // If the `--throughput #` parameter is set, make sure we can't

--- a/app/Console/Commands/BackfillCustomerIoProfiles.php
+++ b/app/Console/Commands/BackfillCustomerIoProfiles.php
@@ -54,7 +54,7 @@ class BackfillCustomerIoProfiles extends Command
      * log the failed id to the console.
      *
      * @param  User  $user
-     * @param  boolean $isUpdated
+     * @param  bool $isUpdated
      */
     private function markUserAsUpdated($user, $isUpdated)
     {
@@ -73,7 +73,8 @@ class BackfillCustomerIoProfiles extends Command
      *
      * @param  User $user
      */
-    private function backfillWithBlink($user) {
+    private function backfillWithBlink($user)
+    {
         try {
             gateway('blink')->userCreate($user->toBlinkPayload());
 
@@ -88,7 +89,8 @@ class BackfillCustomerIoProfiles extends Command
      *
      * @param  User $user
      */
-    private function backfillWithCustomerIo($user) {
+    private function backfillWithCustomerIo($user)
+    {
         $response = $this->customerIo->updateProfile($user);
 
         $this->markUserAsUpdated($user, $response);


### PR DESCRIPTION
#### What's this PR do?
This PR lets developers optionally bypass Blink when running the customer io backfill command and integrates the new customer io service.

I basically broke some of the existing logic out into new functions and added the new cli option to determine which to call.

#### How should this be reviewed?
```
php artisan northstar:cio 2017-10-25T18:53:08+00:00 --bypass_blink
```

<img width="860" alt="screen shot 2017-10-26 at 3 17 12 pm" src="https://user-images.githubusercontent.com/897368/32072615-316983aa-ba61-11e7-90de-a1a3ffddda6f.png">

<img width="577" alt="screen shot 2017-10-26 at 3 17 35 pm" src="https://user-images.githubusercontent.com/897368/32072614-3154cd3e-ba61-11e7-93ea-6045d3237bce.png">