### PR TITLE
New `toCustomerIoPayload` function

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -388,6 +388,57 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Transform the user model for Customer.io
+     *
+     * @return array
+     */
+    public function toCustomerIoPayload()
+    {
+        $requiredCustomerIoFields = collect(['id', 'updated_at', 'created_at']);
+
+        // If this user was just created and has an email, mark them as subscribed.
+        $isNewUser = $this->updated_at === $this->created_at;
+        $unsubscribed = ! ($isNewUser && $this->email);
+
+        $data = collect([
+            'id' => $this->id,
+            'email' => $this->email,
+            'phone' => $this->mobile,
+            'mobile_status' => $this->sms_status, // @TODO: Remove!
+            'sms_status' => $this->sms_status,
+            'facebook_id' => $this->facebook_id,
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+            'birthdate' => format_date($this->birthdate, 'Y-m-d'),
+            'role' => $this->role,
+            'addr_city' => $this->addr_city,
+            'addr_state' => $this->addr_state,
+            'addr_zip' => $this->addr_zip,
+            'language' => $this->language,
+            'country' => $this->country,
+            'source' => $this->source,
+            'source_detail' => $this->source_detail,
+            'last_messaged_at' => iso8601($this->last_messaged_at),
+            'last_authenticated_at' => iso8601($this->last_authenticated_at),
+            'updated_at' => iso8601($this->updated_at),
+            'created_at' => iso8601($this->created_at),
+            'unsubscribed' => $unsubscribed,
+        ])->filter(function($value, $key) {
+            // If the field isn't required and has a null value, remove it.
+            if (! $requiredCustomerIoFields->has($key)) {
+                return $value !== null;
+            }
+
+            return true;
+        });
+
+        return [
+            'id' => $this->id,
+            'data' => $data,
+        ];
+    }
+
+    /**
      * Scope a query to get all of the users in a group.
      *
      * @return \Illuminate\Database\Eloquent\Builder

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -423,6 +423,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'created_at' => iso8601($this->created_at),
             'unsubscribed' => $unsubscribed,
         ])->filter(function ($value, $key) use ($requiredCustomerIoFields) {
+            // If it's an address field that isn't a string, get rid of it.
+            if (starts_with($key, 'addr') && gettype($value) !== 'string') {
+                return false;
+            }
+
             // If the field isn't required and has a null value, remove it.
             if (! $requiredCustomerIoFields->has($key)) {
                 return $value !== null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -404,7 +404,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         $data = collect([
             'email' => $this->email,
             'phone' => $this->mobile,
-            'mobile_status' => $this->sms_status, // @TODO: Remove!
             'sms_status' => $this->sms_status,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -397,11 +397,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         $requiredCustomerIoFields = collect(['id', 'updated_at', 'created_at']);
 
         // If this user was just created and has an email, mark them as subscribed.
+        // Otherwise set unsubscribed to null so it's removed in the filter later.
         $isNewUser = $this->updated_at === $this->created_at;
-        $unsubscribed = ! ($isNewUser && $this->email);
+        $unsubscribed = ($this->email && $isNewUser) ? false : null;
 
         $data = collect([
-            'id' => $this->id,
             'email' => $this->email,
             'phone' => $this->mobile,
             'mobile_status' => $this->sms_status, // @TODO: Remove!
@@ -423,7 +423,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'updated_at' => iso8601($this->updated_at),
             'created_at' => iso8601($this->created_at),
             'unsubscribed' => $unsubscribed,
-        ])->filter(function($value, $key) {
+        ])->filter(function($value, $key) use ($requiredCustomerIoFields) {
             // If the field isn't required and has a null value, remove it.
             if (! $requiredCustomerIoFields->has($key)) {
                 return $value !== null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -398,7 +398,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // If this user was just created and has an email, mark them as subscribed.
         // Otherwise set unsubscribed to null so it's removed in the filter later.
-        $isNewUser = $this->updated_at === $this->created_at;
+        $isNewUser = $this->updated_at->timestamp === $this->created_at->timestamp;
         $unsubscribed = ($this->email && $isNewUser) ? false : null;
 
         $data = collect([
@@ -434,7 +434,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         return [
             'id' => $this->id,
-            'data' => $data,
+            'data' => $data->toArray(),
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -423,7 +423,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'updated_at' => iso8601($this->updated_at),
             'created_at' => iso8601($this->created_at),
             'unsubscribed' => $unsubscribed,
-        ])->filter(function($value, $key) use ($requiredCustomerIoFields) {
+        ])->filter(function ($value, $key) use ($requiredCustomerIoFields) {
             // If the field isn't required and has a null value, remove it.
             if (! $requiredCustomerIoFields->has($key)) {
                 return $value !== null;

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -47,8 +47,13 @@ class CustomerIo
      */
     public function updateProfile(User $user)
     {
+        // If the user doesn't have an email or phone number, don't send them.
+        if (! $user->email || ! $user->phone) {
+            return false;
+        }
+
         $response = $this->client->put('customers/'.$user->id, [
-            'json' => $user->toBlinkPayload(),
+            'json' => $user->toCustomerIoPayload(),
             'auth' => $this->getAuthParams(),
         ]);
 


### PR DESCRIPTION
#### What's this PR do?
This PR makes a new function for sending customer io specific data that abides by the rules created by Blink. It's similar to the existing `toBlinkPayload` but adds a few new variables and has a slightly different data structure. 

I additionally made updates to the Customer IO service so we were calling this new function and also ensured a user is never sent to customer io that doesn't have an email or phone.

#### How should this be reviewed
Generic existing admin user
<img width="686" alt="screen shot 2017-10-26 at 3 59 44 pm" src="https://user-images.githubusercontent.com/897368/32074220-b8cdddfa-ba66-11e7-8ebd-85d83e57ddef.png">

New user
<img width="687" alt="screen shot 2017-10-26 at 4 05 35 pm" src="https://user-images.githubusercontent.com/897368/32074482-884451ae-ba67-11e7-8f34-0ad136b5967a.png">

New user with no email
<img width="587" alt="screen shot 2017-10-26 at 4 07 01 pm" src="https://user-images.githubusercontent.com/897368/32074538-b9ded810-ba67-11e7-84f4-d44fa70036c6.png">

User with no email or mobile
<img width="639" alt="screen shot 2017-10-26 at 4 08 11 pm" src="https://user-images.githubusercontent.com/897368/32074584-e449553a-ba67-11e7-86ee-997de3f67942.png">