### PR TITLE
Fix usage

### DIFF
--- a/app/Console/Commands/RevertCustomerIoImport.php
+++ b/app/Console/Commands/RevertCustomerIoImport.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Console\Commands;
 
+use Illuminate\Support\Collection;
 use Illuminate\Console\Command;
 use Northstar\Models\User;
 

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -47,8 +47,8 @@ class CustomerIo
      */
     public function updateProfile(User $user)
     {
-        // If the user doesn't have an email or phone number, don't send them.
-        if (! $user->email || ! $user->phone) {
+        // If the user doesn't have an email and phone number, don't send them.
+        if (! $user->email && ! $user->mobile) {
             return false;
         }
 


### PR DESCRIPTION
#### What's this PR do?
Ok this PR fixes 3 things

1. When copying over the command for reverting, I removed the `use Illuminate\Support\Collection` statement which meant it tried using `Northstar\Console\Commands\Collection`. This is only happening on production, which is strange.

2. Updated the `updateProfile` function so it checks for `mobile`, not `phone`.

3. Updated the `updateProfile` function so it checks the user is missing BOTH mobile and phone. 