### PR TITLE
Password reset email

### DIFF
--- a/app/Auth/Notifications/ResetPassword.php
+++ b/app/Auth/Notifications/ResetPassword.php
@@ -1,0 +1,25 @@
+<?php
+
+    namespace Northstar\Auth\Notifications;
+
+    use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordNotification;
+    use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPassword extends ResetPasswordNotification
+{
+   /**
+     * Build the mail representation of the notification.
+     * (This is our custom override of the default email message.)
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('You are receiving this email because we received a password reset request for your account.')
+            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
+            ->line('This token will expire in 24 hours.')
+            ->line('If you did not request a password reset, no further action is required.');
+    }
+}

--- a/app/Auth/Notifications/ResetPassword.php
+++ b/app/Auth/Notifications/ResetPassword.php
@@ -17,9 +17,9 @@ class ResetPassword extends ResetPasswordNotification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->line('You are receiving this email because we received a password reset request for your account.')
+            ->line('You are receiving this email because we received a password reset request for your DoSomething.org account. Here is the link to reset your password:')
             ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
-            ->line('This token will expire in 24 hours.')
-            ->line('If you did not request a password reset, no further action is required.');
+            ->line('This link will expire in 24 hours. Once you click the button above, you will be asked to reset your password on the page. If you did not request a password reset, you can ignore this email. Your password will not change and your account is safe.')
+            ->line('If you have further questions, please reach out to help@dosomething.org.');
     }
 }

--- a/app/Auth/Notifications/ResetPassword.php
+++ b/app/Auth/Notifications/ResetPassword.php
@@ -1,13 +1,13 @@
 <?php
 
-    namespace Northstar\Auth\Notifications;
+namespace Northstar\Auth\Notifications;
 
-    use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordNotification;
-    use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordNotification;
+use Illuminate\Notifications\Messages\MailMessage;
 
 class ResetPassword extends ResetPasswordNotification
 {
-   /**
+    /**
      * Build the mail representation of the notification.
      * (This is our custom override of the default email message.)
      *

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -36,7 +36,7 @@ $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']]
     $router->post('register', 'AuthController@postRegister');
 
     // Password Reset
-    $this->get('password/reset', 'ForgotPasswordController@showLinkRequestForm');
+    $this->get('password/reset', ['as' => 'password.reset', 'uses' => 'ForgotPasswordController@showLinkRequestForm']);
     $this->post('password/email', 'ForgotPasswordController@sendResetLinkEmail');
     $this->get('password/reset/{token}', 'ResetPasswordController@showResetForm');
     $this->post('password/reset', 'ResetPasswordController@reset');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 use Northstar\Auth\Role;
+use Northstar\Auth\Notifications\ResetPassword as ResetPasswordNotification;
 
 /**
  * The User model. (Fight for the user!)
@@ -425,5 +426,17 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         $this->source = $source ?: client_id();
         $this->source_detail = $detail;
+    }
+
+    /**
+     * Overriding the default method to send a password reset notification email,
+     * using our own custom class for some overrides to the email message.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new ResetPasswordNotification($token));
     }
 }

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Auth\Notifications\ResetPassword;
+use Northstar\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Northstar\Auth\Registrar;


### PR DESCRIPTION
#### What's this PR do?
Makes for a more informative password reset email so that the user knows when their reset token expires.

#### How should this be reviewed?
password email used to be
![image](https://user-images.githubusercontent.com/12417657/32183196-0bb25f68-bd6f-11e7-875b-81c7637176b9.png)
(minus all the extra T's in 'account'.)

Now is:
![image](https://user-images.githubusercontent.com/12417657/32183234-22b8cd1e-bd6f-11e7-872f-4fb8e155b102.png)


I did this by overriding the default `toMail` method that comes out of the box.
https://laravel.com/docs/5.5/passwords#password-customization

Apologies if this implementation is gross and breaks convention, I am painfully novice to the world of Laravel.

https://www.pivotaltracker.com/story/show/151949720

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …
