### PR TITLE
changing invalid token error to be more explanatory

### DIFF
--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -15,7 +15,7 @@ return [
 
     'password' => 'Passwords must be at least six characters and match the confirmation.',
     'user' => "We can't find a user with that e-mail address.",
-    'token' => 'This password reset token is invalid.',
+    'token' => 'Your password reset link is invalid or has expired. Please reset your password again and use the new password reset link.',
     'sent' => 'We have e-mailed your password reset link!',
     'reset' => 'Your password has been reset!',
 


### PR DESCRIPTION
#### What's this PR do?
Changes the error message set for `'token'` triggered by an invalid (expired and/or non-existant) token to be more (fight-for-the) user friendly. 
- Error copy courtesy of @ngjo -

#### How should this be reviewed?
![image](https://user-images.githubusercontent.com/12417657/32226416-f05ae16c-be1e-11e7-9a32-b9d21d401e37.png)

https://www.pivotaltracker.com/story/show/151948554

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …
