### PR TITLE
change naming of password.reset for actual reset form route

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -36,9 +36,9 @@ $router->group(['namespace' => 'Web', 'guard' => 'web', 'middleware' => ['web']]
     $router->post('register', 'AuthController@postRegister');
 
     // Password Reset
-    $this->get('password/reset', ['as' => 'password.reset', 'uses' => 'ForgotPasswordController@showLinkRequestForm']);
+    $this->get('password/reset', 'ForgotPasswordController@showLinkRequestForm');
     $this->post('password/email', 'ForgotPasswordController@sendResetLinkEmail');
-    $this->get('password/reset/{token}', 'ResetPasswordController@showResetForm');
+    $this->get('password/reset/{token}', ['as' => 'password.reset', 'uses' => 'ResetPasswordController@showResetForm']);
     $this->post('password/reset', 'ResetPasswordController@reset');
 });
 


### PR DESCRIPTION
#### What's this PR do?
Moves naming of `password.reset` referenced in `toMail` method  to the proper route to have the button in link lead users to proper form.

#### How should this be reviewed?
…

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …
