### PR TITLE
Accept dates in ISO-8601 format.

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -9,10 +9,16 @@ use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
  * Base model class
  *
  * @mixin \Jenssegers\Mongodb\Query\Builder
- * @method chunkFromId($count, $startId, \Closure $callback, $column)
  */
 class Model extends BaseModel
 {
+    /**
+     * The expected format for stringified dates.
+     *
+     * @var string
+     */
+    protected $dateFormat = 'Y-m-d\TH:i:sP';
+
     /**
      * Set a given attribute on the model.
      *

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -359,6 +359,25 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that ISO-8601 formatted date strings are accepted.
+     * PUT /v1/users/id/:id
+     *
+     * @return void
+     */
+    public function testDateFields()
+    {
+        $user = factory(User::class)->create();
+
+        $newTimestamp = '2017-10-23T02:09:20+00:00';
+        $this->asAdminUser()->putJson('v1/users/id/'.$user->id, [
+            'last_messaged_at' => $newTimestamp,
+        ]);
+
+        $this->assertResponseStatus(200);
+        $this->assertEquals($newTimestamp, $user->fresh()->last_messaged_at->toIso8601String());
+    }
+
+    /**
      * Test that users get created_at & updated_at fields.
      * POST /v1/users/
      *


### PR DESCRIPTION
#### What's this PR do?
This should be a quick fix for an issue that we're seeing on staging & Thor (which was introduced in #677 when we removed some of the fancier date logic we'd been relying on).

```
[2017-11-02 17:32:52] production.ERROR: InvalidArgumentException: Unexpected data found.
Trailing data in /var/www/northstar/releases/20171102153405/vendor/nesbot/carbon/src/Carbon/Carbon.php:582
Stack trace:
#0 /var/www/northstar/releases/20171102153405/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(709): Carbon\Carbon::createFromFormat('Y-m-d H:i:s', '2017-11-02T16:1...')
#1 /var/www/northstar/releases/20171102153405/vendor/jenssegers/mongodb/src/Jenssegers/Mongodb/Eloquent/Model.php(81): Illuminate\Database\Eloquent\Model->asDateTime('2017-11-02T16:1...')
#2 /var/www/northstar/releases/20171102153405/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(526): Jenssegers\Mongodb\Eloquent\Model->fromDateTime('2017-11-02T16:1...')
#3 /var/www/northstar/releases/20171102153405/vendor/jenssegers/mongodb/src/Jenssegers/Mongodb/Eloquent/Model.php(180): Illuminate\Database\Eloquent\Model->setAttribute('last_messaged_a...', '2017-11-02T16:1...')
#4 /var/www/northstar/releases/20171102153405/app/Models/Model.php(25): Jenssegers\Mongodb\Eloquent\Model->setAttribute('last_messaged_a...', '2017-11-02T16:1...')
#5 /var/www/northstar/releases/20171102153405/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(234): Northstar\Models\Model->setAttribute('last_messaged_a...', '2017-11-02T16:1...')
#6 /var/www/northstar/releases/20171102153405/app/Auth/Registrar.php(202): Illuminate\Database\Eloquent\Model->fill(Array)
#7 /var/www/northstar/releases/20171102153405/app/Http/Controllers/UserController.php(170): Northstar\Auth\Registrar->register(Array, Object(Northstar\Models\User))
#8 [internal function]: Northstar\Http\Controllers\UserController->update('_id', '5547be89469c64e...', Object(Illuminate\Http\Request))
```

#### How should this be reviewed?
~I'll add a test case for this in a sec.~ Added in 401b8e2!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  