### PR TITLE
Accept any string format for 'last_messaged_at'.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -215,24 +215,23 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Mutator to parse non-standard date strings into MongoDates.
+     * Mutator for setting the birthdate field.
      *
      * @param string|Carbon $value
      */
     public function setBirthdateAttribute($value)
     {
-        if (is_null($value)) {
-            $this->attributes['birthdate'] = null;
+        $this->setArbitraryDateString('birthdate', $value);
+    }
 
-            return;
-        }
-
-        // Parse user-entered strings like '10/31/1990' or `October 31st 1990'.
-        if (is_string($value)) {
-            $value = strtotime($value);
-        }
-
-        $this->attributes['birthdate'] = $this->fromDateTime($value);
+    /**
+     * Mutator for setting the last_messaged_at field.
+     *
+     * @param string|Carbon $value
+     */
+    public function setLastMessagedAtAttribute($value)
+    {
+        $this->setArbitraryDateString('last_messaged_at', $value);
     }
 
     /**
@@ -240,10 +239,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @param string|Carbon $value
      */
-    public function setLastMessagedAtAttribute($value)
+    public function setArbitraryDateString($attribute, $value)
     {
         if (is_null($value)) {
-            $this->attributes['last_messaged_at'] = null;
+            $this->attributes[$attribute] = null;
 
             return;
         }
@@ -253,7 +252,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             $value = strtotime($value);
         }
 
-        $this->attributes['last_messaged_at'] = $this->fromDateTime($value);
+        $this->attributes[$attribute] = $this->fromDateTime($value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -236,6 +236,27 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Mutator to parse non-standard date strings into MongoDates.
+     *
+     * @param string|Carbon $value
+     */
+    public function setLastMessagedAtAttribute($value)
+    {
+        if (is_null($value)) {
+            $this->attributes['last_messaged_at'] = null;
+
+            return;
+        }
+
+        // Parse user-entered strings like '10/31/1990' or `October 31st 1990'.
+        if (is_string($value)) {
+            $value = strtotime($value);
+        }
+
+        $this->attributes['last_messaged_at'] = $this->fromDateTime($value);
+    }
+
+    /**
      * Accessor for the `role` field.
      *
      * @return string

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -368,13 +368,13 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $newTimestamp = '2017-10-23T02:09:20+00:00';
+        $newTimestamp = '2017-11-02T18:42:00.000Z';
         $this->asAdminUser()->putJson('v1/users/id/'.$user->id, [
             'last_messaged_at' => $newTimestamp,
         ]);
 
         $this->assertResponseStatus(200);
-        $this->assertEquals($newTimestamp, $user->fresh()->last_messaged_at->toIso8601String());
+        $this->assertEquals('2017-11-02T18:42:00+00:00', $user->fresh()->last_messaged_at->toIso8601String());
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
It turns out `toIsoString()` in Javascript provides something different than in PHP, fab! For now, we'll use `strtodate` to parse any ol' time & revisit this later.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
