### PR TITLE
displaying non-null field name in merge user errors

### DIFF
--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -55,7 +55,10 @@ class MergeController extends Controller
 
         // Are there fields we can't automatically merge? Throw an error.
         if (count(array_intersect_key($target->toArray(), array_flip($duplicateFieldNames)))) {
-            $errors = array_fill_keys($duplicateFieldNames, 'Cannot merge into non-null field on target.');
+            $errors = collect($duplicateFieldNames)->map(function ($fieldName) {
+                return 'Cannot merge "'.$fieldName.'" into non-null field on target.';
+            });
+
             throw new NorthstarValidationException($errors, ['target' => $target, 'duplicate' => $duplicate]);
         }
 


### PR DESCRIPTION
#### What's this PR do?
Adds `non-null` field names to the errors returned for user merge making for more insightful error messages.
(Forgot to commit this way back when.)
#### How should this be reviewed?
🔎 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …
