### PR TITLE
Allow 'stop' as a SMS status.

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -71,7 +71,7 @@ class Registrar
             'country' => 'nullable|country',
             'password' => 'nullable|min:6|max:512',
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
-            'sms_status' => 'in:active,less,undeliverable,unknown',
+            'sms_status' => 'in:active,less,stop,undeliverable,unknown',
             'sms_paused' => 'boolean',
             'last_messaged_at' => 'date',
         ];

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -151,7 +151,7 @@ Either a mobile number or email is required.
   slack_id: String
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
-  sms_status: String // Either 'active', 'less', 'undeliverable' or 'unknown'
+  sms_status: String // Either 'active', 'stop', 'less', 'undeliverable' or 'unknown'
   sms_paused: Boolean // Whether a user is in a support conversation.
   source: String // Immutable. Will only be set on new records.
   source_detail: String // Only accepted alongside a valid 'source'.
@@ -306,7 +306,7 @@ PUT /v1/users/drupal_id/<drupal_id>
   parse_installation_ids: String // CSV values or array will be appended to existing interests
   interests: String, Array // CSV values or array will be appended to existing interests
   role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
-  sms_status: String // Either 'active', 'less', 'undeliverable' or 'unknown'
+  sms_status: String // Either 'active', 'stop', less', 'undeliverable' or 'unknown'
   sms_paused: Boolean // Whether a user is in a support conversation.
 
   // Hidden fields (optional):


### PR DESCRIPTION
#### What's this PR do?
Team O'Doyle want to be able to store `stop` as a distinct status from `undeliverable` (so we can differentiate people who opt-out from messaging versus hard bounces).

This allows them to do that! 📝

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
