### PR TITLE
Improve puck integration

### DIFF
--- a/resources/assets/js/utilities/Puck.js
+++ b/resources/assets/js/utilities/Puck.js
@@ -12,12 +12,12 @@ function init() {
     $('.facebook-login').on('click', () => (
       puck.trackEvent('clicked facebook auth')
     ));
-  });
 
-  const $validationErrors = $('.validation-error');
-  if ($validationErrors && $validationErrors.length) {
-    puck.trackEvent('has validation errors');
-  }
+    const $validationErrors = $('.validation-error');
+    if ($validationErrors && $validationErrors.length) {
+      puck.trackEvent('has validation errors');
+    }
+  });
 }
 
 export default { init };

--- a/resources/assets/js/utilities/Puck.js
+++ b/resources/assets/js/utilities/Puck.js
@@ -15,7 +15,14 @@ function init() {
 
     const $validationErrors = $('.validation-error');
     if ($validationErrors && $validationErrors.length) {
-      puck.trackEvent('has validation errors');
+      const errors = window.ERRORS || {};
+      const invalidFields = Object.keys(errors);
+      const validationMessages = Object.values(errors);
+
+      puck.trackEvent('has validation errors', {
+        invalidFields,
+        validationMessages,
+      });
     }
   });
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -36,6 +36,7 @@
     @include('layouts.variables')
     {{ scriptify(auth()->user() ? auth()->user()->id : null, 'NORTHSTAR_ID') }}
     {{ scriptify(get_client_environment_vars(), 'ENV') }}
+    {{ scriptify(count($errors) > 0 ? $errors->default : null, 'ERRORS') }}
     <script src="{{ elixir('app.js', 'dist') }}"></script>
     @include('layouts.google_analytics')
 </body>


### PR DESCRIPTION
#### What's this PR do?
- This PR appends validation errors to the window object so they can be parsed by Puck. 
- Puck takes these values and stashes them to the data property of the `has validation errors` event.
- Finally, I wrapped this validation code in the same document.ready as the Facebook tracker to ensure consistency when binding to the dom.

QUESTION: In the `scriptify` function I passed `$errors->default`. I can't find any case where the errors are under a different subkey besides default, but curious if anyone feels the need to flag this.

#### How should this be reviewed?
Check out `window.ERRORS` and look at the Puck event.

<img width="486" alt="screen shot 2017-11-08 at 3 06 20 pm" src="https://user-images.githubusercontent.com/897368/32571961-2fc7d7d2-c497-11e7-9d2c-af75a23953e9.png">
<img width="1214" alt="screen shot 2017-11-08 at 2 55 19 pm" src="https://user-images.githubusercontent.com/897368/32571962-2fd4a066-c497-11e7-9371-176f1638f164.png">