### PR TITLE
Some fixes for OpenID Connect.

### DIFF
--- a/app/Auth/Responses/BearerTokenResponse.php
+++ b/app/Auth/Responses/BearerTokenResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Northstar\Auth\Responses;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse as BaseTokenResponse;
+
+class BearerTokenResponse extends BaseTokenResponse
+{
+    /**
+     * Add custom fields to your Bearer Token response here.
+     *
+     * @param AccessTokenEntityInterface $accessToken
+     *
+     * @return array
+     */
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        $jwtAccessToken = $this->accessToken->convertToJWT($this->privateKey);
+
+        return ['id_token' => (string) $jwtAccessToken];
+    }
+}

--- a/app/Http/Controllers/DiscoveryController.php
+++ b/app/Http/Controllers/DiscoveryController.php
@@ -19,7 +19,7 @@ class DiscoveryController extends Controller
             'issuer' => $url,
             'authorization_endpoint' => url($url.'/authorize'),
             'token_endpoint' => url($url.'/v2/auth/token'),
-            'userinfo_endpoint' => url($url.'/v2/auth/info'),
+            'userinfo_endpoint' => url($url.'/v2/userinfo'),
             'jwks_uri' => url($url.'/v2/keys'),
 
             'response_types_supported' => ['code'],

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -65,6 +65,7 @@ class OAuthController extends Controller
     /**
      * Show the user info for the authorized user.
      *
+     * @deprecated
      * @return \Illuminate\Http\Response
      */
     public function info()

--- a/app/Http/Controllers/UserInfoController.php
+++ b/app/Http/Controllers/UserInfoController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+class UserInfoController extends Controller
+{
+    /**
+     * Make a new UserInfoController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth:api');
+    }
+
+    /**
+     * Show the user info for the authorized user.
+     *
+     * @return array
+     */
+    public function show()
+    {
+        $user = auth()->user();
+
+        // User data, formatted according to OpenID Connect spec, section 5.3.
+        // @see http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+        return [
+            'sub' => $user->id,
+            'given_name' => $user->first_name,
+            'family_name' => $user->last_name,
+            'email' => $user->email,
+            'phone_number' => format_legacy_mobile($user->mobile),
+            'birthdate' => format_date($user->birthdate, 'Y-m-d'),
+            'updated_at' => $user->updated_at->timestamp,
+            'created_at' => $user->created_at->timestamp,
+        ];
+    }
+}

--- a/app/Providers/OAuthServiceProvider.php
+++ b/app/Providers/OAuthServiceProvider.php
@@ -27,6 +27,7 @@ use Northstar\Auth\Repositories\ClientRepository;
 use Northstar\Auth\Repositories\RefreshTokenRepository;
 use Northstar\Auth\Repositories\ScopeRepository;
 use Northstar\Auth\Repositories\UserRepository;
+use Northstar\Auth\Responses\BearerTokenResponse;
 
 class OAuthServiceProvider extends ServiceProvider
 {
@@ -76,7 +77,8 @@ class OAuthServiceProvider extends ServiceProvider
                 app(AccessTokenRepositoryInterface::class),
                 app(ScopeRepositoryInterface::class),
                 $this->makeCryptKey('private.key'),
-                config('app.key')
+                config('app.key'),
+                app(BearerTokenResponse::class)
             );
 
             // Define which OAuth grants we'll accept.

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,7 +14,8 @@ $router->group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     // Authentication
     $this->post('auth/token', 'OAuthController@createToken');
     $this->delete('auth/token', 'OAuthController@invalidateToken');
-    $this->get('auth/info', 'OAuthController@info');
+    $this->get('auth/info', 'OAuthController@info'); // Deprecated.
+    $this->get('userinfo', 'UserInfoController@show');
 
     // Users
     // ...


### PR DESCRIPTION
#### What's this PR do?
This pull request includes two fixes for parts of the OpenID Connect spec that I hadn't implemented faithfully (it may make sense to polish some of this up and contribute to the community as a package):

🆔 Adds a separate `id_token` field to the token response (for now, the same as the `access_token`, but can optionally include some of the same claims included in `userinfo` endpoint).

ℹ️ Adds a new `v2/userinfo` endpoint that doesn't have the nested `data` wrapper like `v2/auth/info`. This isn't in the spec, and so causes some clients (specifically [node-openid-client](https://github.com/panva/node-openid-client)) to fail.

#### How should this be reviewed?
Tests should still pass!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  