### PR TITLE
Adding addr source field to user

### DIFF
--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -43,6 +43,9 @@ class UserTransformer extends TransformerAbstract
             $response['addr_state'] = $user->addr_state;
             $response['addr_zip'] = $user->addr_zip;
 
+            // Source for the address fields (e.g. 'sms')
+            $response['addr_source'] = $user->addr_source;
+
             // Signup source (e.g. drupal, cgg, mobile...)
             $response['source'] = $user->source;
             $response['source_detail'] = $user->source_detail;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,9 @@ use Northstar\Auth\Role;
  * @property string $country
  * @property string $language
  *
+ * Source for the address fields (e.g. 'sms')
+ * @property string $addr_source
+ *
  * We also collect a bunch of fields from Niche.com users:
  * @property string $race
  * @property string $religion
@@ -94,7 +97,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // Address:
         'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip',
-        'country', 'language',
+        'country', 'language', 'addr_source',
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'slack_id',


### PR DESCRIPTION
#### What's this PR do?
Adds an `addr_source` field for `users`, in the User models `$fillable` fields as well as the `UserTransformer`.

closes #693 
https://www.pivotaltracker.com/story/show/153096331
