### PR TITLE
Audit information

### DIFF
--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -49,7 +49,7 @@ class MergeController extends Controller
         $duplicate = User::findOrFail($request->input('id'));
 
         // Get all profile fields from the duplicate (except metadata like ID or source).
-        $metadata = ['_id', 'updated_at', 'created_at', 'drupal_id', 'source', 'source_detail', 'role'];
+        $metadata = ['_id', 'updated_at', 'created_at', 'drupal_id', 'source', 'source_detail', 'role', 'audit'];
         $duplicateFields = array_except($duplicate->toArray(), $metadata);
         $duplicateFieldNames = array_keys($duplicateFields);
 

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
 
@@ -26,6 +27,13 @@ class Model extends BaseModel
         // Empty strings should be saved as `null`.
         if (empty($this->attributes[$key])) {
             $this->attributes[$key] = null;
+        }
+
+        if ($this->audited) {
+            $this->attributes['audit'][$key] = [
+                'source' => client_id(),
+                'updated_at' => Carbon::now(),
+            ];
         }
 
         return $this;

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -29,7 +29,7 @@ class Model extends BaseModel
             $this->attributes[$key] = null;
         }
 
-        $isDirty = ! array_key_exists($key, $this->original) || $this->original[$key] != $this->attributes[$key];
+        $isDirty = $this->isDirty($key);
         $shouldAudit = ! in_array($key, ['updated_at', 'created_at']);
 
         if ($this->audited && $isDirty && $shouldAudit) {

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -22,6 +22,8 @@ class Model extends BaseModel
      */
     public function setAttribute($key, $value)
     {
+        $currentValue = $this->$key;
+
         parent::setAttribute($key, $value);
 
         // Empty strings should be saved as `null`.
@@ -29,7 +31,10 @@ class Model extends BaseModel
             $this->attributes[$key] = null;
         }
 
-        if ($this->audited) {
+        if ($this->audited &&
+            $currentValue != $this->$key &&
+            ! in_array($key, ['updated_at', 'created_at'])
+        ) {
             $this->attributes['audit'][$key] = [
                 'source' => client_id(),
                 'updated_at' => Carbon::now(),

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -22,8 +22,6 @@ class Model extends BaseModel
      */
     public function setAttribute($key, $value)
     {
-        $currentValue = $this->$key;
-
         parent::setAttribute($key, $value);
 
         // Empty strings should be saved as `null`.
@@ -31,10 +29,10 @@ class Model extends BaseModel
             $this->attributes[$key] = null;
         }
 
-        if ($this->audited &&
-            $currentValue != $this->$key &&
-            ! in_array($key, ['updated_at', 'created_at'])
-        ) {
+        $isDirty = ! array_key_exists($key, $this->original) || $this->original[$key] != $this->attributes[$key];
+        $shouldAudit = ! in_array($key, ['updated_at', 'created_at']);
+
+        if ($this->audited && $isDirty && $shouldAudit) {
             $this->attributes['audit'][$key] = [
                 'source' => client_id(),
                 'updated_at' => Carbon::now(),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -79,7 +79,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 {
     use Authenticatable, Authorizable, Notifiable, CanResetPassword;
 
+    // Set class as 'audited', so audit information will be added on set attributes.
     public $audited = true;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -79,8 +79,13 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 {
     use Authenticatable, Authorizable, Notifiable, CanResetPassword;
 
-    // Set class as 'audited', so audit information will be added on set attributes.
-    public $audited = true;
+    /**
+     * Should changes to this model's attributes be stored
+     * in an audit property on the database record?
+     *
+     * @var bool
+     */
+    protected $audited = true;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -79,6 +79,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 {
     use Authenticatable, Authorizable, Notifiable, CanResetPassword;
 
+    public $audited = true;
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -40,6 +40,6 @@ class ModelTest extends BrowserKitTestCase
         // Make sure the audit prop with audit info is added for the set attribute.
         $document = $this->getMongoDocument('users', $user->id);
         $this->assertArrayHasKey('audit', $document);
-        $this->assertEquals(['source' => 'northstar', 'updated_at' => $time ], $user->audit['first_name']);
+        $this->assertEquals(['source' => 'northstar', 'updated_at' => $time], $user->audit['first_name']);
     }
 }

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -23,4 +23,23 @@ class ModelTest extends BrowserKitTestCase
         $this->assertArrayNotHasKey('mobile', $document);
         $this->assertArrayNotHasKey('last_name', $document);
     }
+
+    /** @test */
+    public function it_should_set_audits_field_for_audited_class()
+    {
+        /** @var User $user */
+        $user = factory(User::class)->create();
+
+        // Freeze time to be able to test it.
+        $time = $this->mockTime();
+
+        // Set an attribute.
+        $user->first_name = 'Jill';
+        $user->save();
+
+        // Make sure the audit prop with audit info is added for the set attribute.
+        $document = $this->getMongoDocument('users', $user->id);
+        $this->assertArrayHasKey('audit', $document);
+        $this->assertEquals(['source' => 'northstar', 'updated_at' => $time ], $user->audit['first_name']);
+    }
 }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -65,7 +65,17 @@ class UserModelTest extends BrowserKitTestCase
 
         $user->first_name = 'Caroline';
         $user->password = 'secret';
+
+        // Freeze time for testing audit info.
+        $time = $this->mockTime();
+
         $user->save();
+
+        // Setting up audit mock example for DRYness.
+        $auditMock = [
+            'source' => 'northstar',
+            'updated_at' => $time,
+        ];
 
         $logger->shouldHaveReceived('debug')->once()->with('updated user', [
             'id' => $user->id,
@@ -73,6 +83,12 @@ class UserModelTest extends BrowserKitTestCase
             'changed' => [
                 'first_name' => 'Caroline',
                 'password' => '*****',
+                'audit' => [
+                    'source' => $auditMock,
+                    '_id' => $auditMock,
+                    'first_name' => $auditMock,
+                    'password' => $auditMock,
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
#### What's this PR do?
Adds optional audit information to models so that upon attribute edits, source and time information will be stored per specific attribute.

Example audit info for updating `first_name` from northstar web:

```
audit => [
 "first_name" => [
   "source" => "northstar",
   "updated_at" => [
     "date" => "2018-01-11 18:07:05.000000",
     "timezone_type" => 3,
     "timezone" => "UTC",
   ],
 ],
...
]
```

This is specifically relevant to [#153181447](https://www.pivotaltracker.com/story/show/153181447) and #693 and would retroactively have us tracking the source for any updated field, thus implicitly tracking address field source information.

#### Questions and Comments

Do we want a whitelist of attributes to not track audit info for (`updated_at` field for example)? 
Also, Upon User creation (manually, say from within `artisan tinker`), audit fields are created for `_id`, `updated_at` `created_at` and `source`, and when creating from northstar web, tons more fields are updated.

Perhaps adding the `audit` logic as an `else` to the empty string conditional, to ensure that only updated fields get audit info?

#### Checklist
- [x] Tests added for new features/bug fixes.