### PR TITLE
Hook up environment variables for SQS.

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -51,9 +51,9 @@ return [
 
         'sqs' => [
             'driver' => 'sqs',
-            'key' => 'your-public-key',
-            'secret' => 'your-secret-key',
-            'queue' => 'your-queue-url',
+            'key'    => env('SQS_PUBLIC_KEY'),
+            'secret' => env('SQS_SECRET_KEY'),
+            'queue'  => env('SQS_DEFAULT_QUEUE'),
             'region' => 'us-east-1',
         ],
 


### PR DESCRIPTION
#### What's this PR do?
This pull request hooks up some environment variables for queueing jobs with [Amazon SQS](https://aws.amazon.com/sqs/) (which we happily used with Laravel on [northstar-mobilecommonsd](https://github.com/DoSomething/northstar-mobilecommonsd) for a long time).

#### How should this be reviewed?
This allows us to queue up a bunch of API requests to Customer.io and let the queue worker throttle itself & chug along in the background (rather than monitoring a synchronous Artisan script). It's also a test to see whether we find any interesting gotchas with letting apps handle their own queues.

References #697.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!