### PR TITLE
Fix issues with 'failed_jobs' and MongoDB.

### DIFF
--- a/app/Database/MongoFailedJobProvider.php
+++ b/app/Database/MongoFailedJobProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Northstar\Database;
+
+use Carbon\Carbon;
+use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+
+class MongoFailedJobProvider extends DatabaseFailedJobProvider
+{
+    /**
+     * Log a failed job into storage.
+     *
+     * @param  string $connection
+     * @param  string $queue
+     * @param  string $payload
+     *
+     * @return void
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        $failed_at = Carbon::now()->getTimestamp();
+
+        $this->getTable()->insert(compact('connection', 'queue', 'payload', 'failed_at', 'exception'));
+    }
+
+    /**
+     * Get a list of all of the failed jobs.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        $all = $this->getTable()->orderBy('_id', 'desc')->get()->all();
+
+        $all = array_map(function ($job) {
+            return $this->processDatabaseJob($job);
+        }, $all);
+
+        return $all;
+    }
+
+    /**
+     * Get a single failed job.
+     *
+     * @param  mixed $id
+     * @return array
+     */
+    public function find($id)
+    {
+        $job = $this->getTable()->find($id);
+
+        return $this->processDatabaseJob($job);
+    }
+
+    /**
+     * Delete a single failed job from storage.
+     *
+     * @param  mixed $id
+     * @return bool
+     */
+    public function forget($id)
+    {
+        return $this->getTable()->where('_id', $id)->delete() > 0;
+    }
+
+    /**
+     * Cast the return array into an object.
+     *
+     * @return array|null
+     */
+    public function processDatabaseJob($job)
+    {
+        if (! $job) {
+            return null;
+        }
+
+        // We need to cast this to an object (because jenssegers/mongodb
+        // returns query results as an array, and the framework expects an
+        // object. We also need to rename '_id' column  to 'id' while
+        // maintaining key ordering (since some commands rely on that).
+        return (object) [
+            'id' => (string) $job['_id'],
+            'connection' => $job['connection'],
+            'queue' => $job['queue'],
+            'payload' => $job['payload'],
+            'failed_at' => $job['failed_at'],
+            'exception' => $job['exception'],
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Northstar\Providers;
 
 use Northstar\Models\User;
-use DoSomething\Gateway\Blink;
 use Illuminate\Support\ServiceProvider;
+use Northstar\Database\MongoFailedJobProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -65,6 +65,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        // Configure Mongo 'failed_jobs' collection.
+        $this->app->extend('queue.failer', function ($instance, $app) {
+            return new MongoFailedJobProvider(
+                $app['db'],
+                config('queue.failed.database'),
+                config('queue.failed.table')
+            );
+        });
     }
 }

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -47,8 +47,8 @@ class CustomerIo
      */
     public function updateProfile(User $user)
     {
-        // If the user doesn't have an email and phone number, don't send them.
-        if (! $user->email && ! $user->mobile) {
+        // If the user doesn't have an email or phone number, don't send them.
+        if (! $user->email || ! $user->mobile) {
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,13 @@
       "Northstar\\": "app/"
     }
   },
+  "extra": {
+    "laravel": {
+        "dont-discover": [
+            "jenssegers/mongodb"
+        ]
+    }
+  },
   "autoload-dev": {
     "classmap": [
       "tests/BrowserKitTestCase.php",

--- a/config/queue.php
+++ b/config/queue.php
@@ -86,7 +86,8 @@ return [
     */
 
     'failed' => [
-        'database' => 'mysql', 'table' => 'failed_jobs',
+        'database' => 'mongodb',
+        'table' => 'failed_jobs',
     ],
 
 ];


### PR DESCRIPTION
#### What's this PR do?
Always something! Unfortunately the `MongoFailedJobProvider` [included with the package](https://github.com/jenssegers/laravel-mongodb/blob/master/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php) doesn't take into account that Laravel 5.5 expects responses from the query builder to be objects, and it still returns arrays. Frustrating, but an easy-ish fix!

⚙️ Specify that we want to use the `mongodb` connection for failed jobs, not `mysql`. d8c7c97

🍃 Fixes issues reading/writing to MongoDB for this (see comment). eb076ff

📵 Updates `CustomerIo` service to send a user if they have _either_ an email or a mobile, since we want this to run as a _full_ backfill. 90cdafe

#### How should this be reviewed?
The diff isn't too huge, but can't hurt to review commit-by-commit.

References [#153293764](https://www.pivotaltracker.com/story/show/153293764).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  