### PR TITLE
Fix accidentally swapped conditional.

### DIFF
--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -48,7 +48,7 @@ class CustomerIo
     public function updateProfile(User $user)
     {
         // If the user doesn't have an email or phone number, don't send them.
-        if (! $user->email || ! $user->mobile) {
+        if (empty($user->email) && empty($user->mobile)) {
             return false;
         }
 


### PR DESCRIPTION
#### What's this PR do?
I misread this line in 90cdafe1af85597853a346ce53576a01aee89f1a... the comment was wrong, but the conditional was actually right! I also switched this to use `empty()` for hopefully improved readability. 👀

#### How should this be reviewed?
We want to skip sending a user to Customer.io if they do not have _either_ an email or mobile (since then we couldn't message them & would just be paying for nothing)! Hopefully that's what this now does. 🙃

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  