### PR TITLE
Last setup steps for Customer.io queued backfill.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,15 +42,19 @@ namespace :deploy do
     run "cd #{release_path} && php artisan cache:clear"
   end
 
+  task :artisan_queue_restart do
+    run "cd #{release_path} && php artisan queue:restart"
+  end
+
   task :restart_php do
     run "sudo /usr/sbin/service php7.0-fpm restart"
   end
-
 end
 
 after "deploy:update", "deploy:cleanup"
 after "deploy:symlink", "deploy:link_folders"
 after "deploy:link_folders", "deploy:artisan_migrate"
 after "deploy:artisan_migrate", "deploy:artisan_cache_clear"
-after "deploy:artisan_cache_clear", "deploy:restart_php"
+after "deploy:artisan_cache_clear", "deploy:artisan_queue_restart"
+after "deploy:artisan_queue_restart", "deploy:restart_php"
 

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
+use DoSomething\Gateway\Blink;
 
 class BackfillCustomerIoTest extends BrowserKitTestCase
 {
@@ -10,8 +10,8 @@ class BackfillCustomerIoTest extends BrowserKitTestCase
     {
         factory(User::class, 5)->create();
 
-        // Mock Customer.io API & set expectation that it'll be called 5 times.
-        $this->mock(CustomerIo::class)->shouldReceive('updateProfile')->times(5)->andReturn(true);
+        // Mock Blink client & set expectation that it'll be called 5 times.
+        $this->mock(Blink::class)->shouldReceive('userCreate')->times(5);
 
         // Run the Customer.io backfill command.
         $this->artisan('northstar:cio');


### PR DESCRIPTION
#### What's this PR do?
Two last bits before we kick this off:

1. Going to continue routing things through Blink for now. I don't want to accidentally introduce any issues with mis-formatted fields while running this, and this should also set us up for queueing _all_ Customer.io API calls in a future update.

2. Restarts the queue worker whenever we make deploys! References DoSomething/devops#365.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  