### PR TITLE
Change some fields we send to Blink.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -416,7 +416,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         return [
             'id' => $this->id,
             'email' => $this->email,
-            'mobile' => $this->mobile,
+            'mobile' => $this->mobile, // TODO: Update Blink to just accept 'phone' field.
             'sms_status' => $this->sms_status,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,
@@ -429,10 +429,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'country' => $this->country,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
-            'last_authenticated_at' => iso8601($this->last_authenticated_at),
-            'updated_at' => iso8601($this->updated_at),
-            'created_at' => iso8601($this->created_at),
             'last_messaged_at' => optional($this->last_messaged_at)->timestamp,
+            'last_authenticated_at' => iso8601($this->last_authenticated_at), // TODO: Update Blink to just accept timestamp.
+            'updated_at' => iso8601($this->updated_at), // TODO: Update Blink to just accept timestamp.
+            'created_at' => iso8601($this->created_at), // TODO: Update Blink to just accept timestamp.
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -417,7 +417,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'id' => $this->id,
             'email' => $this->email,
             'mobile' => $this->mobile,
-            'mobile_status' => $this->sms_status, // @TODO: Remove!
             'sms_status' => $this->sms_status,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -429,10 +429,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'country' => $this->country,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
-            'last_messaged_at' => iso8601($this->last_messaged_at),
             'last_authenticated_at' => iso8601($this->last_authenticated_at),
             'updated_at' => iso8601($this->updated_at),
             'created_at' => iso8601($this->created_at),
+            'last_messaged_at' => optional($this->last_messaged_at)->timestamp,
         ];
     }
 


### PR DESCRIPTION
#### What's this PR do?
🔥 Stop sending along a `mobile_status` field since Blink [no longer uses it](https://github.com/DoSomething/blink/pull/133). ab5d439

⏲ Send `last_messaged_at` as UNIX timestamp, rather than sending as ISO-8601 and forcing Blink to convert it to a timestamp for us. 166ab07

🇹🇬 Add TODOs for some future field changes we may want to do (mainly for context). aaee064

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  