### PR TITLE
Fix an issue with unsubscribed users being re-subbed.

### DIFF
--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -43,6 +43,7 @@ class SendUserToCustomerIo implements ShouldQueue
         $throttler->then(function () {
             if (config('features.blink')) {
                 $blinkPayload = $this->user->toBlinkPayload();
+                info('blink: user.backfill', $blinkPayload);
                 gateway('blink')->userCreate($blinkPayload);
             }
 


### PR DESCRIPTION
#### What's this PR do?
This fixes an edge case where we might accidentally re-subscribe users to email broadcasts when running the `northstar:cio` script. If a user's `updated_at` and `created_at` are the same, Blink assumes (reasonably!) that it's a new registration & [subscribes them to messaging](https://git.io/vNF3e).

By touching the user's `updated_at` timestamp before we send it to Customer.io, we'll make sure that this issue does not occur anymore (and we should be able to fix existing re-subs [with this CSV](https://dosomething.slack.com/archives/C2C8NLNAY/p1517438053000423))

#### What are the downsides?
Two downsides to this approach (and why we explicitly opted-out of touching records before):

- This will cause users to be re-ingested to Quasar, which could bog down those systems.
- We lose more meaningful "last updated" timestamps. Of course, this value is already a little useless since any "activity" (e.g. `last_accessed_at` or `last_messaged_at`) would touch `updated_at` too.

#### How should this be reviewed?
Anything else that comes to mind? More unintended consequences?

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  