### PR TITLE
Ensure 'sms_paused' is sent to C.io as a boolean.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -418,7 +418,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'email' => $this->email,
             'mobile' => $this->mobile, // TODO: Update Blink to just accept 'phone' field.
             'sms_status' => $this->sms_status,
-            'sms_paused' => $this->sms_paused,
+            'sms_paused' => (bool) $this->sms_paused,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,


### PR DESCRIPTION
#### What's this PR do?
Didn't do a good job testing this. 🤦‍♂️ It looks like Laravel gives us `null` for this field when it's false, and so once a user's conversation is paused it'll never be un-paused. This updates the `toBlinkPayload` transformer to match the [same logic we use on the web](https://github.com/DoSomething/northstar/blob/8ca2fcb7f724842b90c1fbbfcb006b6c865d12bd/app/Http/Transformers/UserTransformer.php#L61).

#### How should this be reviewed?
☑️ 👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  