### PR TITLE
Update Handler and NorthstarValidationException for 5.5.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -126,17 +126,24 @@ class Handler extends ExceptionHandler
      */
     protected function invalidated($request, $e)
     {
-        if ($request->ajax() || $request->wantsJson()) {
-            return $e->getResponse();
+        $wantsJson = $request->ajax() || $request->wantsJson();
+        if ($wantsJson && $e instanceof ValidationException) {
+            return response()->json([
+                'error' => [
+                    'code' => 422,
+                    'message' => 'Failed validation.',
+                    'fields' => $e->errors(),
+                ],
+            ]);
         }
 
-        if ($e instanceof ValidationException) {
+        if ($wantsJson && $e instanceof NorthstarValidationException) {
             return $e->getResponse();
         }
 
         return redirect()->back()
             ->withInput($request->except('password', 'password_confirmation'))
-            ->withErrors($e->getErrors());
+            ->withErrors($e->errors());
     }
 
     /**

--- a/app/Exceptions/NorthstarValidationException.php
+++ b/app/Exceptions/NorthstarValidationException.php
@@ -55,7 +55,7 @@ class NorthstarValidationException extends Exception
      *
      * @return array
      */
-    public function getErrors()
+    public function errors()
     {
         return $this->errors;
     }


### PR DESCRIPTION
#### What's this PR do?
I noticed that Northstar was not rendering validation exceptions for traditional `Illuminate\Validation\ValidationException` errors, and we were instead just getting blank 200s. No good! This didn't affect most traffic since we use a custom validation class for the user resource, but caused issues when I was trying to create new clients on Aurora.

#### How should this be reviewed?
👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  