### PR TITLE
Send proper HTTP status for standard 422s.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -134,7 +134,7 @@ class Handler extends ExceptionHandler
                     'message' => 'Failed validation.',
                     'fields' => $e->errors(),
                 ],
-            ]);
+            ], 422);
         }
 
         if ($wantsJson && $e instanceof NorthstarValidationException) {

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -50,6 +50,21 @@ class ClientTest extends BrowserKitTestCase
     /**
      * Verify an admin is able to create a new client.
      */
+    public function testStoreWithValidationErrors()
+    {
+        $this->asAdminUser()->json('POST', 'v2/clients', [
+            // Oops I forgot the request body!
+        ]);
+
+        $this->assertResponseStatus(422);
+        $this->seeJsonStructure([
+            'error' => ['code', 'message', 'fields'],
+        ]);
+    }
+
+    /**
+     * Verify an admin is able to create a new client.
+     */
     public function testStoreAsAdminUser()
     {
         $this->asAdminUser()->json('POST', 'v2/clients', [


### PR DESCRIPTION
#### What's this PR do?
I'm surprised we didn't have a test case for this already (looks like we only covered validation errors on the users routes). This PR fixes an issue introduced in #709 where we'd send the proper validation response but the wrong HTTP status code:

![screen shot 2018-02-16 at 3 04 26 pm](https://user-images.githubusercontent.com/583202/36327077-6597100c-132b-11e8-9512-51ab282fb5cf.png)

#### How should this be reviewed?
❌ ✅ 👀

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  