### PR TITLE
Removes alpha validation from last name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # This will automatically request the following users to review
 # pull requests made on this repository.
 
-*       @dosomething/team-rocket
+*       @dosomething/team-bleed

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -87,7 +87,7 @@ class UserController extends BaseController
 
         $this->registrar->validate($request, $user, [
             'first_name' => 'required|max:50',
-            'last_name' => 'nullable',
+            'last_name' => 'nullable|max:50',
             'birthdate' => 'nullable|required|date',
             'password' => 'nullable|min:6|max:512|confirmed', // @TODO: Split into separate form.
         ]);

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -87,7 +87,7 @@ class UserController extends BaseController
 
         $this->registrar->validate($request, $user, [
             'first_name' => 'required|max:50',
-            'last_name' => 'nullable|alpha',
+            'last_name' => 'nullable',
             'birthdate' => 'nullable|required|date',
             'password' => 'nullable|min:6|max:512|confirmed', // @TODO: Split into separate form.
         ]);

--- a/tests/Http/Web/WebUserTest.php
+++ b/tests/Http/Web/WebUserTest.php
@@ -60,14 +60,14 @@ class WebUserTest extends BrowserKitTestCase
 
         $this->visit('users/'.$user->id.'/edit')
              ->type('Jean-Paul', 'first_name')
-             ->type('Beaubier', 'last_name')
+             ->type('Beaubier-Lee', 'last_name')
              ->press('Save')
              ->seePageIs('/');
 
         $updatedUser = User::find($user->id);
 
         $this->assertEquals('Jean-Paul', $updatedUser->first_name);
-        $this->assertEquals('Beaubier', $updatedUser->last_name);
+        $this->assertEquals('Beaubier-Lee', $updatedUser->last_name);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Changes the last name validation to allow all characters so a user can submit their last name if they have `'` or `-`. 

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

---
For review: …
