### PR TITLE
Hide deprecated user endpoints.

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -21,17 +21,26 @@ Endpoint                  | Functionality                                       
 #### Users
 Endpoint                                     | Functionality                                            | Required Scope
 -------------------------------------------- | -------------------------------------------------------- | --------------
+`GET v2/users`                               | [Retrieve All Users](endpoints/v2/users.md#retrieve-all-users) | `role:admin` or `admin`
+`POST v2/users`                              | [Create a User](endpoints/v2/users.md#create-a-user) | `role:admin` or `admin`
+`GET v2/users/:id`                   | [Retrieve a User](endpoints/v2/users.md#retrieve-a-user) 
+`PUT v2/users/:id`                           | [Update a User](endpoints/v2/users.md#update-a-user) | `role:admin` or `admin`
+`DELETE v2/users/:id`                   | [Delete a User](endpoints/v2/users.md#delete-a-user) | `role:admin` or `admin`
+`POST v1/users/:id/merge`               | [Merge User Accounts](endpoints/users.md#merge-user-accounts) | `role:admin,staff` or `admin`
+
+
+<details>
+  <summary>view deprecated endpoints</summary>
+
+Endpoint                                     | Functionality                                            | Required Scope
+-------------------------------------------- | -------------------------------------------------------- | --------------
 `GET v1/users`                               | [Retrieve All Users](endpoints/users.md#retrieve-all-users) | `role:admin` or `admin`
 `POST v1/users`                              | [Create a User](endpoints/users.md#create-a-user) | `role:admin` or `admin`
 `GET v1/users/:term/:identifier`             | [Retrieve a User](endpoints/users.md#retrieve-a-user) 
 `PUT v1/users/:term/:id`                     | [Update a User](endpoints/users.md#update-a-user) | `role:admin` or `admin`
 `DELETE v1/users/:user_id`                   | [Delete a User](endpoints/users.md#delete-a-user) | `role:admin` or `admin`
-`POST v1/users/:user_id/merge`               | [Merge User Accounts](endpoints/users.md#merge-user-accounts) | `role:admin,staff` or `admin`
-`GET v2/users`                               | [Retrieve All Users](endpoints/v2/users.md#retrieve-all-users) | `role:admin` or `admin`
-`POST v2/users`                              | [Create a User](endpoints/v2/users.md#create-a-user) | `role:admin` or `admin`
-`GET v2/users/:identifier`                   | [Retrieve a User](endpoints/v2/users.md#retrieve-a-user) 
-`PUT v2/users/:id`                           | [Update a User](endpoints/v2/users.md#update-a-user) | `role:admin` or `admin`
-`DELETE v2/users/:user_id`                   | [Delete a User](endpoints/v2/users.md#delete-a-user) | `role:admin` or `admin`
+
+</details>
 
 #### Profile
 Endpoint                                     | Functionality                                            | Required Scope


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Northstar's documentation to hide the old `v1/users` endpoints by default.

#### How should this be reviewed?
Here's [how this will look](https://github.com/DoSomething/northstar/tree/hide-deprecated-endpoints/documentation#users) once merged.

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  