### PR TITLE
Set up merge strategy scaffolding and logic for 2 fields

### DIFF
--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -20,7 +20,6 @@ class MergeController extends Controller
      */
     protected $merger;
 
-
     /**
      * Make a new MergeController, inject dependencies,
      * and set middleware for this controller's methods.
@@ -66,7 +65,6 @@ class MergeController extends Controller
 
         // Fields that we can automatically merge
         $fieldsToMerge = array_except($duplicateFields, array_keys($intersectedFields));
-
         // Are there fields we can't automatically merge? Throw an error.
         if (count(array_intersect_key($target->toArray(), array_flip($duplicateFieldNames)))) {
             $unmergedFields = [];

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -68,24 +68,9 @@ class MergeController extends Controller
         $fieldsToMerge = array_except($duplicateFields, array_keys($intersectedFields));
         // Are there fields we can't automatically merge? Throw an error.
         if ($intersectedFields) {
-            $unmergedFields = [];
-
             // Call merge on intersecting fields
             foreach ($intersectedFields as $field => $value) {
-                $merged = $this->merger->merge($field, $target, $duplicate);
-                if (! $merged) {
-                    array_push($unmergedFields, $field);
-                } else {
-                    $fieldsToMerge[$field] = $merged;
-                }
-            }
-
-            if ($unmergedFields) {
-                $errors = collect($unmergedFields)->map(function ($fieldName) {
-                    return 'Cannot merge "'.$fieldName.'" into non-null field on target.';
-                });
-
-                throw new NorthstarValidationException($errors, ['target' => $target, 'duplicate' => $duplicate]);
+                $fieldsToMerge[$field] = $this->merger->merge($field, $target, $duplicate);
             }
         }
 

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -72,7 +72,7 @@ class MergeController extends Controller
 
             // Call merge on intersecting fields
             foreach ($intersectedFields as $field => $value) {
-                $merged = $this->merger->merge($field, $target->$field, $duplicate->$field);
+                $merged = $this->merger->merge($field, $target, $duplicate);
                 if (! $merged) {
                     array_push($unmergedFields, $field);
                 } else {

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -29,8 +29,9 @@ class MergeController extends Controller
     public function __construct(UserTransformer $transformer, Merger $merger)
     {
         $this->transformer = $transformer;
-        $this->middleware('role:admin,staff');
         $this->merger = $merger;
+
+        $this->middleware('role:admin,staff');
     }
 
     /**
@@ -66,7 +67,7 @@ class MergeController extends Controller
         // Fields that we can automatically merge
         $fieldsToMerge = array_except($duplicateFields, array_keys($intersectedFields));
         // Are there fields we can't automatically merge? Throw an error.
-        if (count(array_intersect_key($target->toArray(), array_flip($duplicateFieldNames)))) {
+        if ($intersectedFields) {
             $unmergedFields = [];
 
             // Call merge on intersecting fields

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -81,14 +81,20 @@ class MergeController extends Controller
                 }
             }
 
-            $errors = collect($unmergedFields)->map(function ($fieldName) {
-                return 'Cannot merge "'.$fieldName.'" into non-null field on target.';
-            });
+            if ($unmergedFields) {
+                $errors = collect($unmergedFields)->map(function ($fieldName) {
+                    return 'Cannot merge "'.$fieldName.'" into non-null field on target.';
+                });
 
-            throw new NorthstarValidationException($errors, ['target' => $target, 'duplicate' => $duplicate]);
+                throw new NorthstarValidationException($errors, ['target' => $target, 'duplicate' => $duplicate]);
+            }
         }
+
         // Copy the "duplicate" account's fields to the target & unset on the dupe account.
-        $target->fill($fieldsToMerge);
+        foreach ($fieldsToMerge as $field => $value) {
+            $target->$field = $fieldsToMerge[$field];
+        }
+
         foreach ($duplicateFieldNames as $field) {
             $duplicate->$field = null;
         }

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -2,11 +2,10 @@
 
 namespace Northstar\Http\Controllers;
 
-use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Models\User;
+use Northstar\Merge\Merger;
 use Illuminate\Http\Request;
 use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Merge\Merger;
 
 class MergeController extends Controller
 {
@@ -42,7 +41,6 @@ class MergeController extends Controller
      * @param Request $request
      *
      * @return \Illuminate\Http\Response
-     * @throws NorthstarValidationException
      */
     public function store($id, Request $request)
     {
@@ -66,6 +64,7 @@ class MergeController extends Controller
 
         // Fields that we can automatically merge
         $fieldsToMerge = array_except($duplicateFields, array_keys($intersectedFields));
+
         // Are there fields we can't automatically merge? Throw an error.
         if ($intersectedFields) {
             // Call merge on intersecting fields

--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -15,7 +15,7 @@ class MergeController extends Controller
     protected $transformer;
 
     /**
-     * @var UserTransformer
+     * @var Merger
      */
     protected $merger;
 
@@ -66,20 +66,15 @@ class MergeController extends Controller
         $fieldsToMerge = array_except($duplicateFields, array_keys($intersectedFields));
 
         // Are there fields we can't automatically merge? Throw an error.
-        if ($intersectedFields) {
-            // Call merge on intersecting fields
-            foreach ($intersectedFields as $field => $value) {
-                $fieldsToMerge[$field] = $this->merger->merge($field, $target, $duplicate);
-            }
+        // Call merge on intersecting fields
+        foreach ($intersectedFields as $field => $value) {
+            $fieldsToMerge[$field] = $this->merger->merge($field, $target, $duplicate);
         }
 
         // Copy the "duplicate" account's fields to the target & unset on the dupe account.
         foreach ($fieldsToMerge as $field => $value) {
-            $target->$field = $fieldsToMerge[$field];
-        }
-
-        foreach ($duplicateFieldNames as $field) {
-            $duplicate->$field = null;
+            $target->{$field} = $fieldsToMerge[$field];
+            $duplicate->{$field} = null;
         }
 
         if (empty($duplicate->email) && empty($duplicate->mobile)) {

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -6,7 +6,6 @@ class Merger
 {
     public function __construct()
     {
-
     }
 
     public function merge($field, $targetValue, $duplicateValue)

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -23,12 +23,12 @@ class Merger
 
     public function mergeLastAuthenticatedAt($targetValue, $duplicateValue)
     {
-        return 'most recent timestamp';
+        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
 
     public function mergeLastMessagedAt($targetValue, $duplicateValue)
     {
-        return 'most recent timestamp';
+        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
 
 

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -9,7 +9,7 @@ class Merger
 
     }
 
-    public function merge ($field, $targetValue, $duplicateValue)
+    public function merge($field, $targetValue, $duplicateValue)
     {
         switch ($field) {
             case 'last_authenticated_at':
@@ -30,6 +30,4 @@ class Merger
     {
         return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
-
-
 }

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Northstar\Merge;
+
+class Merger
+{
+    public function __construct()
+    {
+
+    }
+
+    public function merge ($field, $targetValue, $duplicateValue)
+    {
+        switch ($field) {
+            case 'last_authenticated_at':
+                return $this->mergeLastAuthenticatedAt($targetValue, $duplicateValue);
+            case 'last_messaged_at':
+                return $this->mergeLastMessagedAt($targetValue, $duplicateValue);
+            default:
+                return false;
+        }
+    }
+
+    public function mergeLastAuthenticatedAt($targetValue, $duplicateValue)
+    {
+        return 'most recent timestamp';
+    }
+
+    public function mergeLastMessagedAt($targetValue, $duplicateValue)
+    {
+        return 'most recent timestamp';
+    }
+
+
+}

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -2,6 +2,8 @@
 
 namespace Northstar\Merge;
 
+use InvalidArgumentException;
+
 class Merger
 {
     public function __construct()
@@ -13,8 +15,7 @@ class Merger
         $mergeMethod = 'merge' . studly_case($field);
 
         if (! method_exists($this, $mergeMethod)) {
-            // throw error here
-            return false;
+            throw new InvalidArgumentException('Unable to merge ' . $field . ' field. No merge instructions found.');
         }
 
         return $this->{$mergeMethod}($target, $duplicate);

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -12,10 +12,10 @@ class Merger
 
     public function merge($field, $target, $duplicate)
     {
-        $mergeMethod = 'merge' . studly_case($field);
+        $mergeMethod = 'merge'.studly_case($field);
 
         if (! method_exists($this, $mergeMethod)) {
-            throw new InvalidArgumentException('Unable to merge ' . $field . ' field. No merge instructions found.');
+            throw new InvalidArgumentException('Unable to merge '.$field.' field. No merge instructions found.');
         }
 
         return $this->{$mergeMethod}($target, $duplicate);

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -2,7 +2,7 @@
 
 namespace Northstar\Merge;
 
-use InvalidArgumentException;
+use Northstar\Exceptions\NorthstarValidationException;
 
 class Merger
 {
@@ -15,7 +15,7 @@ class Merger
         $mergeMethod = 'merge'.studly_case($field);
 
         if (! method_exists($this, $mergeMethod)) {
-            throw new InvalidArgumentException('Unable to merge '.$field.' field. No merge instructions found.');
+            throw new NorthstarValidationException(['Unable to merge '.$field.' field. No merge instructions found.'], ['target' => $target, 'duplicate' => $duplicate]);
         }
 
         return $this->{$mergeMethod}($target, $duplicate);

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -8,25 +8,31 @@ class Merger
     {
     }
 
-    public function merge($field, $targetValue, $duplicateValue)
+    public function merge($field, $target, $duplicate)
     {
         switch ($field) {
             case 'last_authenticated_at':
-                return $this->mergeLastAuthenticatedAt($targetValue, $duplicateValue);
+                return $this->mergeLastAuthenticatedAt($target, $duplicate);
             case 'last_messaged_at':
-                return $this->mergeLastMessagedAt($targetValue, $duplicateValue);
+                return $this->mergeLastMessagedAt($target, $duplicate);
             default:
                 return false;
         }
     }
 
-    public function mergeLastAuthenticatedAt($targetValue, $duplicateValue)
+    public function mergeLastAuthenticatedAt($target, $duplicate)
     {
+        $targetValue = $target->last_authenticated_at;
+        $duplicateValue = $duplicate->last_authenticated_at;
+
         return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
 
-    public function mergeLastMessagedAt($targetValue, $duplicateValue)
+    public function mergeLastMessagedAt($target, $duplicate)
     {
+        $targetValue = $target->last_messaged_at;
+        $duplicateValue = $duplicate->last_messaged_at;
+
         return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
 }

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -6,10 +6,6 @@ use Northstar\Exceptions\NorthstarValidationException;
 
 class Merger
 {
-    public function __construct()
-    {
-    }
-
     public function merge($field, $target, $duplicate)
     {
         $mergeMethod = 'merge'.studly_case($field);

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -10,14 +10,14 @@ class Merger
 
     public function merge($field, $target, $duplicate)
     {
-        switch ($field) {
-            case 'last_authenticated_at':
-                return $this->mergeLastAuthenticatedAt($target, $duplicate);
-            case 'last_messaged_at':
-                return $this->mergeLastMessagedAt($target, $duplicate);
-            default:
-                return false;
+        $mergeMethod = 'merge' . studly_case($field);
+
+        if (! method_exists($this, $mergeMethod)) {
+            // throw error here
+            return false;
         }
+
+        return $this->{$mergeMethod}($target, $duplicate);
     }
 
     public function mergeLastAuthenticatedAt($target, $duplicate)

--- a/tests/Http/MergeTest.php
+++ b/tests/Http/MergeTest.php
@@ -74,4 +74,68 @@ class MergeTest extends BrowserKitTestCase
             'drupal_id' => '7175144',
         ]);
     }
+
+    /**
+     * Test last_authenticated_at merge logic.
+     * POST /resets
+     *
+     * @test
+     */
+    public function testMergingLastAuthenticatedAt()
+    {
+        $user = User::forceCreate([
+            'email' => 'target-account@example.com',
+            'last_authenticated_at' => '2018-02-28 00:00:00',
+        ]);
+
+        $duplicate = User::forceCreate([
+            'mobile' => '5551234567',
+            'last_authenticated_at' => '2018-02-28 01:00:00',
+        ]);
+
+        $this->asAdminUser()->json('POST', 'v1/users/'.$user->id.'/merge', [
+            'id' => $duplicate->id,
+        ]);
+
+        // The "target" user should have the dupe's profile fields.
+        $this->assertEquals($user->fresh()->last_authenticated_at->toTimeString(), '01:00:00');
+
+        // The "duplicate" user should have the duplicate fields removed.
+        $this->seeInDatabase('users', [
+            '_id' => $duplicate->id,
+            'last_authenticated_at' => null,
+        ]);
+    }
+
+    /**
+     * Test last_messaged_at merge logic.
+     * POST /resets
+     *
+     * @test
+     */
+    public function testMergingLastMessagedAt()
+    {
+        $user = User::forceCreate([
+            'email' => 'target-account@example.com',
+            'last_messaged_at' => '2018-02-28 00:00:00',
+        ]);
+
+        $duplicate = User::forceCreate([
+            'mobile' => '5551234567',
+            'last_messaged_at' => '2018-02-28 01:00:00',
+        ]);
+
+        $this->asAdminUser()->json('POST', 'v1/users/'.$user->id.'/merge', [
+            'id' => $duplicate->id,
+        ]);
+
+        // The "target" user should have the dupe's profile fields.
+        $this->assertEquals($user->fresh()->last_messaged_at->toTimeString(), '01:00:00');
+
+        // The "duplicate" user should have the duplicate fields removed.
+        $this->seeInDatabase('users', [
+            '_id' => $duplicate->id,
+            'last_authenticated_at' => null,
+        ]);
+    }
 }


### PR DESCRIPTION
#### What's this PR do?
- I did a lot of research about the strategy pattern, and full disclosure this is a toned down version of it. I didn't think we needed a new class for each type of field we can merge, so I took the general idea of the pattern and implemented it as you see here 👀 Seems to me like it will be easy enough to add new merge logic, all you gotta do is add the case to the `merge` function and then add the function with the particular logic that you want. Yay!
- Added fresh hot 🍞 merge logic for `last_authenticated_at` and `last_messaged_at`, as well as tests for those
- Update `MergeController` to:
    - Use the fresh hot 🍞 merging logic
    - Don't use `fill` since some fields can't be `filled` so we might as well manually set them all because that is cleaner

#### How should this be reviewed?
Is this what folks had in mind? Based on the card this is where it sounded like the `Merger` class should live, but if anyone has strong opinions let's hear 'em!

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/155149254)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [X] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  