### PR TITLE
155798781 Add merge logic for `language` and `last_accessed_at`

### DIFF
--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -65,7 +65,6 @@ class MergeController extends Controller
         // Fields that we can automatically merge
         $fieldsToMerge = array_except($duplicateFields, array_keys($intersectedFields));
 
-        // Are there fields we can't automatically merge? Throw an error.
         // Call merge on intersecting fields
         foreach ($intersectedFields as $field => $value) {
             $fieldsToMerge[$field] = $this->merger->merge($field, $target, $duplicate);

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -32,4 +32,22 @@ class Merger
 
         return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
+
+    public function mergeLastAccessedAt($target, $duplicate)
+    {
+        $targetValue = $target->last_accessed_at;
+        $duplicateValue = $duplicate->last_accessed_at;
+
+        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
+    }
+
+    public function mergeLanguage($target, $duplicate)
+    {
+        // should this be last accessed at or last authenticated at?
+        if ($target->last_accessed_at > $duplicate->last_accessed_at) {
+            return $target->language;
+        }
+
+        return $duplicate->language;
+    }
 }

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -43,7 +43,6 @@ class Merger
 
     public function mergeLanguage($target, $duplicate)
     {
-        // should this be last accessed at or last authenticated at?
         if ($target->last_accessed_at > $duplicate->last_accessed_at) {
             return $target->language;
         }

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -19,26 +19,17 @@ class Merger
 
     public function mergeLastAuthenticatedAt($target, $duplicate)
     {
-        $targetValue = $target->last_authenticated_at;
-        $duplicateValue = $duplicate->last_authenticated_at;
-
-        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
+        return $this->chooseMostRecentDate('last_authenticated_at', $target, $duplicate);
     }
 
     public function mergeLastMessagedAt($target, $duplicate)
     {
-        $targetValue = $target->last_messaged_at;
-        $duplicateValue = $duplicate->last_messaged_at;
-
-        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
+        return $this->chooseMostRecentDate('last_messaged_at', $target, $duplicate);
     }
 
     public function mergeLastAccessedAt($target, $duplicate)
     {
-        $targetValue = $target->last_accessed_at;
-        $duplicateValue = $duplicate->last_accessed_at;
-
-        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
+        return $this->chooseMostRecentDate('last_accessed_at', $target, $duplicate);
     }
 
     public function mergeLanguage($target, $duplicate)
@@ -48,5 +39,13 @@ class Merger
         }
 
         return $duplicate->language;
+    }
+
+    public function chooseMostRecentDate($field, $target, $duplicate)
+    {
+        $targetValue = $target->{$field};
+        $duplicateValue = $duplicate->{$field};
+
+        return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds merge logic for `language`
    - Takes language from account that has most recent `last_accessed_at`
- Adds merge logic for `last_accessed_at`
    - Takes most recent one
- Adds tests for both of these mergers

#### How should this be reviewed?
Do the two merge logics make sense? Is `last_accessed_at` the field that should be used when choosing language, or should it be `last_authenticated_at` or another field?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/155798781)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!