### PR TITLE
Add command for fixing borked birthdays

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,3 @@
 - [ ] Documentation added for changed endpoints.
 - [ ] Tests added for new features/bug fixes.
 - [ ] Post a message in #api if this includes something that causes a rebuild!  
-
----
-For review: …

--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -43,7 +43,7 @@ class StandardizeBirthdates extends Command
         $progressBar = $this->output->createProgressBar($query->count());
 
         $query->chunkById(200, function (Collection $users) use ($progressBar) {
-            forEach ($users as $user) {
+            foreach ($users as $user) {
                 $value = $user->getOriginal('birthdate');
 
                 // If possible, switch the birthday to a date type, otherwise, wipe it!
@@ -56,7 +56,7 @@ class StandardizeBirthdates extends Command
                 $user->setBirthdateAttribute($date);
                 $user->save();
 
-                info('northstar:bday - updated user ' . $user->id . ' birthdate from ' . $value . ' to ' . $date);
+                info('northstar:bday - updated user '.$user->id.' birthdate from '.$value.' to '.$date);
                 $progressBar->advance();
             }
         });

--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class StandardizeBirthdates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:bday';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update invalid birthdates to be valid, if possible.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        info('northstar:bday - Starting up!');
+        // Get users whose `birthdate` is not the correct type
+        $query = User::whereRaw([
+            'birthdate' => [
+                '$exists' => true,
+                '$not' => [
+                    '$type' => 9,
+                ],
+            ],
+        ]);
+        $progressBar = $this->output->createProgressBar($query->count());
+
+        $query->chunkById(200, function (Collection $users) use ($progressBar) {
+            forEach ($users as $user) {
+                $value = $user->getOriginal('birthdate');
+
+                // If possible, switch the birthday to a date type, otherwise, wipe it!
+                try {
+                    $date = Carbon::parse($value);
+                } catch (\Exception $e) {
+                    $date = null;
+                }
+
+                $user->setBirthdateAttribute($date);
+                $user->save();
+
+                info('northstar:bday - updated user ' . $user->id . ' birthdate from ' . $value . ' to ' . $date);
+                $progressBar->advance();
+            }
+        });
+
+        $progressBar->finish();
+        info('northstar:bday - All done!');
+    }
+}

--- a/tests/Console/StandardizeBirthdatesTest.php
+++ b/tests/Console/StandardizeBirthdatesTest.php
@@ -9,8 +9,8 @@ class StandardizeBirthdatesTest extends TestCase
     {
         // Create some regular and borked birthday users
         factory(User::class, 5)->create();
-        $this->createMongoDocument('users', ['birthdate' => "2018-03-15 00:00:00.000"]);
-        $this->createMongoDocument('users', ['birthdate' => "I love dogs"]);
+        $this->createMongoDocument('users', ['birthdate' => '2018-03-15 00:00:00.000']);
+        $this->createMongoDocument('users', ['birthdate' => 'I love dogs']);
 
         // Make sure we are registering 2 borked users
         $borkedUsersCount = User::whereRaw([

--- a/tests/Console/StandardizeBirthdatesTest.php
+++ b/tests/Console/StandardizeBirthdatesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Northstar\Models\User;
+
+class StandardizeBirthdatesTest extends TestCase
+{
+    /** @test */
+    public function it_should_fix_birthdates()
+    {
+        // Create some regular and borked birthday users
+        factory(User::class, 5)->create();
+        $this->createMongoDocument('users', ['birthdate' => "2018-03-15 00:00:00.000"]);
+        $this->createMongoDocument('users', ['birthdate' => "I love dogs"]);
+
+        // Make sure we are registering 2 borked users
+        $borkedUsersCount = User::whereRaw([
+            'birthdate' => [
+                '$exists' => true,
+                '$not' => [
+                    '$type' => 9,
+                ],
+            ],
+        ])->count();
+        $this->assertEquals($borkedUsers, 2);
+
+        // Run the Birthdate Standardizer command.
+        $this->artisan('northstar:bday');
+
+        // Make sure we have 0 borked users
+        $borkedUsersCount = User::whereRaw([
+            'birthdate' => [
+                '$exists' => true,
+                '$not' => [
+                    '$type' => 9,
+                ],
+            ],
+        ])->count();
+        $this->assertEquals($borkedUsers, 0);
+    }
+}

--- a/tests/Console/StandardizeBirthdatesTest.php
+++ b/tests/Console/StandardizeBirthdatesTest.php
@@ -21,7 +21,7 @@ class StandardizeBirthdatesTest extends TestCase
                 ],
             ],
         ])->count();
-        $this->assertEquals($borkedUsers, 2);
+        $this->assertEquals($borkedUsersCount, 2);
 
         // Run the Birthdate Standardizer command.
         $this->artisan('northstar:bday');
@@ -35,6 +35,6 @@ class StandardizeBirthdatesTest extends TestCase
                 ],
             ],
         ])->count();
-        $this->assertEquals($borkedUsers, 0);
+        $this->assertEquals($borkedUsersCount, 0);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- Includes a new command to un-bork birthdays that have been borked
    - If a birthday that is NOT a date can be made into a date (aka it's a string like `2018-03-15 00:00:00.000`), make it a date
    - Otherwise, set it to `null`
- Includes a test to make sure this command works!

#### How should this be reviewed?
Am I logging too much/not enough? Any gotchas I'm missing (I'm new here ✨).

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/155831854)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!