### PR TITLE
Adds `activity` and `write` scopes

### DIFF
--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -41,6 +41,9 @@ class Scope
         'activity' => [
             'description' => 'Allows access to user activity.',
         ],
+        'write' => [
+            'description' => 'Allows access to create/update/delete endpoints.'
+        ],
     ];
 
     /**

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -38,6 +38,9 @@ class Scope
         'client' => [
             'description' => 'Allows access to the client resource.',
         ],
+        'activity' => [
+            'description' => 'Allows access to user activity.',
+        ],
     ];
 
     /**

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -42,7 +42,7 @@ class Scope
             'description' => 'Allows access to user activity.',
         ],
         'write' => [
-            'description' => 'Allows access to create/update/delete endpoints.'
+            'description' => 'Allows access to create/update/delete endpoints.',
         ],
     ];
 

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -85,7 +85,7 @@ trait WithAuthentication
     }
 
     /**
-     * Make the following request as an admin user with the `user` and `role:admin` scopes.
+     * Make the following request as an admin user with the `user`, `client`, and `role:admin` scopes.
      *
      * @return $this
      */


### PR DESCRIPTION
#### What's this PR do?
Adds `activity` and `write` scopes so we can require `activity` to read/write to Rogue and the `write` scope is required for any create/update/delete endpoints, so that we can easily make read-only clients.  

#### How should this be reviewed?
👀 

#### Relevant Tickets
Tasks 1 and 3 in [this](https://www.pivotaltracker.com/n/projects/2019429/stories/155367548) Pivotal Card.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
