### PR TITLE
Anonymous `v2/user/:id` requests should return public profile.

### DIFF
--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -110,8 +110,9 @@ class Scope
      */
     public static function gate($scope)
     {
-        if (has_middleware('web')) {
-            return true;
+        // Only check scopes if request is made with an OAuth token.
+        if (! request()->attributes->has('oauth_access_token_id')) {
+            return;
         }
 
         if (! static::allows($scope)) {

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -83,7 +83,30 @@ class UserTest extends BrowserKitTestCase
      *
      * @return void
      */
-    public function testV2GetPublicDataFromUser()
+    public function testV2GetPublicDataAsAnonymousUser()
+    {
+        $user = factory(User::class)->create();
+
+        // Test that we can view public profile as another user.
+        $this->get('v2/users/'.$user->id);
+        $this->assertResponseStatus(200);
+
+        // And test that private profile fields are hidden for the other user.
+        $data = $this->decodeResponseJson()['data'];
+        $this->assertArrayHasKey('first_name', $data);
+        $this->assertArrayNotHasKey('last_name', $data);
+        $this->assertArrayNotHasKey('email', $data);
+        $this->assertArrayNotHasKey('mobile', $data);
+        $this->assertArrayNotHasKey('facebook_id', $data);
+    }
+
+    /**
+     * Test that retrieving a user as a non-admin returns limited profile.
+     * GET /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2GetPublicDataAsAuthenticatedUser()
     {
         $user = factory(User::class)->create();
         $viewer = factory(User::class)->create();


### PR DESCRIPTION
#### What's this PR do?
We want to lock down "privileged" access to resources by using scopes (so that, for example, if an app doesn't _need_ full user profiles we just don't give it access to them). This is helpful because internal apps that use the Client Credentials grants are always given admin privileges, and so a bug or leaked key could get up to a lot of mischief!

HOWEVER, we also have scenarios where we want anonymous access to those same resources – for example, to grab first names for a set of Northstar IDs in a photo gallery. In these cases, the request won't have a scope because it doesn't have an access token at all!

This pull request updates Northstar's `RequireScope` middleware to ignore scopes on anonymous requests, just [like we did in Gateway](https://github.com/DoSomething/gateway/pull/114).

#### How should this be reviewed?
I added a failing test in f4b9bdb, and the fix in 4e7e409.

#### Relevant Tickets
I ran into this issue while working on GraphQL galleries for [#155944555](https://www.pivotaltracker.com/story/show/155944555).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  