### PR TITLE
Use SendUserToCustomerIo in model events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,6 @@ APP_KEY=
 
 # Feature Flags
 DS_ENABLE_BLINK=false
-DS_ENABLE_BLINK_UPDATES=false
 DS_ENABLE_RATE_LIMITING=false
 
 # DB_HOST=localhost

--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -41,13 +41,18 @@ class SendUserToCustomerIo implements ShouldQueue
         // Rate limit Blink/Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
         $throttler->then(function () {
-            if (config('features.blink')) {
-                // @TODO: update logging to be like in Rogue
+            // Send to Customer.io
+            $shouldSendToCustomerIo = config('features.blink');
+            if ($shouldSendToCustomerIo) {
                 $blinkPayload = $this->user->toCustomerIoPayload();
-                info('blink: user', $blinkPayload);
                 gateway('blink')->userCreate($blinkPayload);
             }
 
+            // Log
+            $verb = $shouldSendToCustomerIo ? 'sent' : 'would have been sent';
+            info('User ' . $this->user->id . ' ' . $verb . ' to Customer.io');
+
+            // KATIE - IS THIS TRUE????
             // @NOTE: Queue runner does not fire model events, so this will
             // not trigger another Blink/C.io call. See 'AppServiceProvider'.
             $this->user->cio_full_backfill = true;
@@ -56,5 +61,15 @@ class SendUserToCustomerIo implements ShouldQueue
             // Could not obtain lock... release to the queue.
             return $this->release(10);
         });
+    }
+
+    /**
+     * Get the id of the user we are sending to Customer.io
+     *
+     * @return int
+     */
+    public function getUserId()
+    {
+        return $this->user->id;
     }
 }

--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -50,7 +50,7 @@ class SendUserToCustomerIo implements ShouldQueue
 
             // Log
             $verb = $shouldSendToCustomerIo ? 'sent' : 'would have been sent';
-            info('User ' . $this->user->id . ' ' . $verb . ' to Customer.io');
+            info('User '.$this->user->id.' '.$verb.' to Customer.io');
         }, function () {
             // Could not obtain lock... release to the queue.
             return $this->release(10);

--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -42,8 +42,9 @@ class SendUserToCustomerIo implements ShouldQueue
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
         $throttler->then(function () {
             if (config('features.blink')) {
+                // @TODO: update logging to be like in Rogue
                 $blinkPayload = $this->user->toCustomerIoPayload();
-                info('blink: user.backfill', $blinkPayload);
+                info('blink: user', $blinkPayload);
                 gateway('blink')->userCreate($blinkPayload);
             }
 

--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -56,14 +56,4 @@ class SendUserToCustomerIo implements ShouldQueue
             return $this->release(10);
         });
     }
-
-    /**
-     * Get the id of the user we are sending to Customer.io
-     *
-     * @return int
-     */
-    public function getUserId()
-    {
-        return $this->user->id;
-    }
 }

--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -51,12 +51,6 @@ class SendUserToCustomerIo implements ShouldQueue
             // Log
             $verb = $shouldSendToCustomerIo ? 'sent' : 'would have been sent';
             info('User ' . $this->user->id . ' ' . $verb . ' to Customer.io');
-
-            // KATIE - IS THIS TRUE????
-            // @NOTE: Queue runner does not fire model events, so this will
-            // not trigger another Blink/C.io call. See 'AppServiceProvider'.
-            $this->user->cio_full_backfill = true;
-            $this->user->save();
         }, function () {
             // Could not obtain lock... release to the queue.
             return $this->release(10);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,9 +38,7 @@ class AppServiceProvider extends ServiceProvider
 
         User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            if (config('features.blink-updates')) {
-                SendUserToCustomerIo::dispatch($user);
-            }
+            SendUserToCustomerIo::dispatch($user);
         });
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,7 +38,6 @@ class AppServiceProvider extends ServiceProvider
 
         User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            // KATIE - what is features.blink-updates?
             if (config('features.blink-updates')) {
                 SendUserToCustomerIo::dispatch($user);
             }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,9 +23,7 @@ class AppServiceProvider extends ServiceProvider
 
         User::created(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            if (config('features.blink')) {
-                SendUserToCustomerIo::dispatch($user);
-            }
+            SendUserToCustomerIo::dispatch($user);
 
             // Send metrics to StatHat.
             app('stathat')->ezCount('user created');
@@ -40,7 +38,8 @@ class AppServiceProvider extends ServiceProvider
 
         User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            if (config('features.blink') && config('features.blink-updates')) {
+            // KATIE - what is features.blink-updates?
+            if (config('features.blink-updates')) {
                 SendUserToCustomerIo::dispatch($user);
             }
         });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace Northstar\Providers;
 
 use Northstar\Models\User;
 use Illuminate\Support\ServiceProvider;
+use Northstar\Jobs\SendUserToCustomerIo;
 use Northstar\Database\MongoFailedJobProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -22,11 +23,8 @@ class AppServiceProvider extends ServiceProvider
 
         User::created(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-
-            $blinkPayload = $user->toCustomerIoPayload();
-            info('blink: user.create', $blinkPayload);
             if (config('features.blink')) {
-                gateway('blink')->userCreate($blinkPayload);
+                SendUserToCustomerIo::dispatch($user);
             }
 
             // Send metrics to StatHat.
@@ -42,10 +40,8 @@ class AppServiceProvider extends ServiceProvider
 
         User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            $blinkPayload = $user->toCustomerIoPayload();
-            info('blink: user.update', $blinkPayload);
             if (config('features.blink') && config('features.blink-updates')) {
-                gateway('blink')->userCreate($blinkPayload);
+                SendUserToCustomerIo::dispatch($user);
             }
         });
     }

--- a/config/features.php
+++ b/config/features.php
@@ -14,8 +14,6 @@ return [
 
     'blink' => env('DS_ENABLE_BLINK'),
 
-    'blink-updates' => env('DS_ENABLE_BLINK_UPDATES'),
-
     'password-grant' => env('DS_ENABLE_PASSWORD_GRANT', true),
 
     'rate-limiting' => env('DS_ENABLE_RATE_LIMITING'),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,6 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DS_ENABLE_BLINK" value="true"/>
-        <env name="DS_ENABLE_BLINK_UPDATES" value="true"/>
         <env name="DS_ENABLE_RATE_LIMITING" value="true"/>
         <env name="DS_ENABLE_PASSWORD_GRANT" value="true"/>
     </php>

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -2,16 +2,27 @@
 
 use Northstar\Models\User;
 use DoSomething\Gateway\Blink;
+use Northstar\Jobs\SendUserToCustomerIo;
 
 class BackfillCustomerIoTest extends BrowserKitTestCase
 {
     /** @test */
     public function it_should_backfill_users()
     {
-        factory(User::class, 5)->create();
+        // Bus::fake();
 
-        // Mock Blink client & set expectation that it'll be called 10 times.
-        $this->mock(Blink::class)->shouldReceive('userCreate')->times(10);
+        $users = factory(User::class, 5)->create();
+
+        // with this there is really no way to tell that each got sent over twice
+        // Mock SendUserToCustomerIo job & make sure it gets called for each new user
+        // foreach ($users as $user) {
+        //     Bus::assertDispatched(SendUserToCustomerIo::class, function ($job) use ($user) {
+        //             return $user->id === $job->getUserId();
+        //     });
+        // }
+
+        // I think that this is the best way to test this (5 times when created, 5 times when we call the command)
+        $this->blinkMock->shouldHaveReceived('userCreate')->times(10);
 
         // Run the Customer.io backfill command.
         $this->artisan('northstar:cio');

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -2,7 +2,6 @@
 
 use Northstar\Models\User;
 use DoSomething\Gateway\Blink;
-use Northstar\Jobs\SendUserToCustomerIo;
 
 class BackfillCustomerIoTest extends BrowserKitTestCase
 {

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -9,22 +9,12 @@ class BackfillCustomerIoTest extends BrowserKitTestCase
     /** @test */
     public function it_should_backfill_users()
     {
-        // Bus::fake();
-
         $users = factory(User::class, 5)->create();
-
-        // with this there is really no way to tell that each got sent over twice
-        // Mock SendUserToCustomerIo job & make sure it gets called for each new user
-        // foreach ($users as $user) {
-        //     Bus::assertDispatched(SendUserToCustomerIo::class, function ($job) use ($user) {
-        //             return $user->id === $job->getUserId();
-        //     });
-        // }
-
-        // I think that this is the best way to test this (5 times when created, 5 times when we call the command)
-        $this->blinkMock->shouldHaveReceived('userCreate')->times(10);
 
         // Run the Customer.io backfill command.
         $this->artisan('northstar:cio');
+
+        // I think that this is the best way to test this (5 times when created, 5 times when we call the command)
+        $this->blinkMock->shouldHaveReceived('userCreate')->times(10);
     }
 }

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Northstar\Models\User;
-use DoSomething\Gateway\Blink;
 
 class BackfillCustomerIoTest extends BrowserKitTestCase
 {

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -14,7 +14,7 @@ class BackfillCustomerIoTest extends BrowserKitTestCase
         // Run the Customer.io backfill command.
         $this->artisan('northstar:cio');
 
-        // I think that this is the best way to test this (5 times when created, 5 times when we call the command)
+        // Make sure we send to Customer.io the expected number of times (5 times when created, 5 times when we call the command)
         $this->blinkMock->shouldHaveReceived('userCreate')->times(10);
     }
 }

--- a/tests/Console/StandardizeBirthdatesTest.php
+++ b/tests/Console/StandardizeBirthdatesTest.php
@@ -7,6 +7,9 @@ class StandardizeBirthdatesTest extends TestCase
     /** @test */
     public function it_should_fix_birthdates()
     {
+        // We are creating some bad data on purpose, so don't try to send it to Customer.io
+        Bus::fake();
+
         // Create some regular and borked birthday users
         factory(User::class, 5)->create();
         $this->createMongoDocument('users', ['birthdate' => '2018-03-15 00:00:00.000']);

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -43,7 +43,7 @@ class UserModelTest extends BrowserKitTestCase
     /** @test */
     public function it_should_send_updated_users_to_blink()
     {
-        config(['features.blink' => true, 'features.blink-updates' => true]);
+        config(['features.blink' => true]);
 
         /** @var User $user */
         $user = factory(User::class)->create();


### PR DESCRIPTION
#### What's this PR do?
- Updates the model events to call `SendUserToCustomerIo` when a user is created or updated
- Update the `SendUserToCustomerIo` job to check if we should actually send to Customer.io and update logging so we get a message regardless
- Update `BackfillCustomerIoTest` - I have updated it to expect 10 calls to the Blink `userCreate` method for several reasons:
    - I tried using `assertDispatched` to check that the job was dispatched and we can do that and we can verify that it got dispatched for each Northstar ID that we want. We cannot (as far as I can tell) however, make sure that it got sent TWICE for each user. It should get triggered twice for each user because it gets triggered when we create the user and then when we run the command.
    - Checking that Blink `userCreate` was hit 5 times really only tells us that it got hit when we created the users, and what we really want to test is that it gets hit when the command gets called
- Adds `Bus::fake()` to `StandardizeBirthdatesTest` because we make a User with an improperly formatted birthday on purpose, and we don't want to trigger an event to Blink on that because it will error out (alternatively, should Blink be off for tests?)

#### How should this be reviewed?
- Question: What does the `DS_ENABLE_BLINK_UPDATES` environment variable do? It seems that it is only used in conjunction with `DS_ENABLE_BLINK` before sending an updated user to Customer.io. In this update, the `DS_ENABLE_BLINK_UPDATES` check happens in the same place, and the `DS_ENABLE_BLINK` check happens in the `SendUserToCustomerIo` job, but I'm wondering if the first check can be remove.

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/156774352)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
