### PR TITLE
Add merges for first and last name, birthdate

### DIFF
--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -41,11 +41,34 @@ class Merger
         return $duplicate->language;
     }
 
+    public function mergeFirstName($target, $duplicate)
+    {
+        return $this->chooseMostRecentFromAudit('first_name', $target, $duplicate);
+    }
+
+    public function mergeLastName($target, $duplicate)
+    {
+        return $this->chooseMostRecentFromAudit('last_name', $target, $duplicate);
+    }
+
+     public function mergeBirthdate($target, $duplicate)
+    {
+        return $this->chooseMostRecentFromAudit('birthdate', $target, $duplicate);
+    }
+
     public function chooseMostRecentDate($field, $target, $duplicate)
     {
         $targetValue = $target->{$field};
         $duplicateValue = $duplicate->{$field};
 
         return $targetValue > $duplicateValue ? $targetValue : $duplicateValue;
+    }
+
+    public function chooseMostRecentFromAudit($field, $target, $duplicate)
+    {
+        $targetUpdatedTimestamp = $target->audit[$field]['updated_at']['date'];
+        $duplicateUpdatedTimestamp = $duplicate->audit[$field]['updated_at']['date'];
+
+        return $targetUpdatedTimestamp > $duplicateUpdatedTimestamp ? $target->{$field} : $duplicate->{$field};
     }
 }

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -51,7 +51,7 @@ class Merger
         return $this->chooseMostRecentFromAudit('last_name', $target, $duplicate);
     }
 
-     public function mergeBirthdate($target, $duplicate)
+    public function mergeBirthdate($target, $duplicate)
     {
         return $this->chooseMostRecentFromAudit('birthdate', $target, $duplicate);
     }

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -69,6 +69,13 @@ class Merger
         $targetUpdatedTimestamp = $target->audit[$field]['updated_at']['date'];
         $duplicateUpdatedTimestamp = $duplicate->audit[$field]['updated_at']['date'];
 
+        // If we have no audit information return the field from the accound that was accessed most recently
+        if (! $targetUpdatedTimestamp && ! $duplicateUpdatedTimestamp) {
+            $choice = ($target->last_accessed_at > $duplicate->last_accessed_at) ? $target->{$field} : $duplicate->{$field};
+
+            return $choice;
+        }
+
         return $targetUpdatedTimestamp > $duplicateUpdatedTimestamp ? $target->{$field} : $duplicate->{$field};
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds merge logic for `first_name`, `last_name`, and `birthdate` as outlined in the card
- Adds tests for merging those fields
- Adds new helper `chooseMostRecentFromAudit` which for a given field and the users to merge, chooses the field to keep by selecting the one which was updated the most recently.
    - If neither account has and `audit` field, we fall back on `last_accessed_at` and choose the field from the account most recently accessed

#### How should this be reviewed?
Is the logic right?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/155853358)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
