### PR TITLE
Update logging for invalid birthdates in northstar:bday

### DIFF
--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -56,7 +56,7 @@ class StandardizeBirthdates extends Command
                 $user->setBirthdateAttribute($date);
                 $user->save();
 
-                if (!$date) {
+                if (! $date) {
                     info('northstar:bday - removed invalid birthdate from '.$user->id.' - '.$value);
                 } else {
                     info('northstar:bday - updated user '.$user->id.' birthdate from '.$value.' to '.$date);

--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -56,7 +56,11 @@ class StandardizeBirthdates extends Command
                 $user->setBirthdateAttribute($date);
                 $user->save();
 
-                info('northstar:bday - updated user '.$user->id.' birthdate from '.$value.' to '.$date);
+                if (!$date) {
+                    info('northstar:bday - removed invalid birthdate from '.$user->id.' - '.$value);
+                } else {
+                    info('northstar:bday - updated user '.$user->id.' birthdate from '.$value.' to '.$date);
+                }
                 $progressBar->advance();
             }
         });


### PR DESCRIPTION
#### What's this PR do?
- Keep the same logging as before for birthdates that we were able to update:
`northstar:bday - updated user 5acfbf609a89201c340543e4 birthdate from 2015-01-17 21:13:02.000 to 2015-01-17 21:13:02`
- Update the log to be like this when we could not update the birthdate and removed it instead:
`northstar:bday - removed invalid birthdate from 5acfbf609a89201c340543e2 - dogs`

#### How should this be reviewed?
👀 

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/156050050)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
