### PR TITLE
Add voter_registration_status to users and payloads

### DIFF
--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -51,6 +51,9 @@ class UserTransformer extends TransformerAbstract
             // Subscription status
             $response['sms_status'] = $user->sms_status;
             $response['sms_paused'] = (bool) $user->sms_paused;
+
+            // Voter registration status
+            $response['voter_registration_status'] = $user->voter_registration_status;
         }
 
         $response['language'] = $user->language;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -59,6 +59,9 @@ class UserTransformer extends TransformerAbstract
             // Subscription status
             $response['sms_status'] = $user->sms_status;
             $response['sms_paused'] = (bool) $user->sms_paused;
+
+            // Voter registration status
+            $response['voter_registration_status'] = $user->voter_registration_status;
         }
 
         $response['language'] = $user->language;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ use Northstar\Auth\Role;
  * @property array  $interests
  * @property string $source
  * @property string $source_detail
+ * @property string $voter_registration_status
  * @property string $role - The user's role, e.g. 'user', 'staff', or 'admin'
  *
  * @property string $addr_street1
@@ -98,7 +99,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'email', 'mobile', 'password', 'role',
 
         // Profile:
-        'first_name', 'last_name', 'birthdate', 'photo', 'interests',
+        'first_name', 'last_name', 'birthdate', 'photo', 'interests', 'voter_registration_status',
 
         // @TODO: Remove these? We get these from Niche but don't use anywhere.
         'school_id', 'college_name', 'degree_type', 'major_name', 'hs_gradyear', 'hs_name',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -430,6 +430,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'addr_zip' => $this->addr_zip,
             'language' => $this->language,
             'country' => $this->country,
+            'voter_registration_status' => $this->voter_registration_status,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
             'last_messaged_at' => optional($this->last_messaged_at)->timestamp,

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -253,6 +253,7 @@ curl -X GET \
         "birthdate": "12/17/91",
         "first_name": "First",
         "last_name": "Last",
+        "voter_registration_status": "register-form",
         "role": "user",
         "updated_at": "2016-02-25T19:33:24+0000",
         "created_at": "2016-02-25T19:33:24+0000"

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -15,7 +15,6 @@ class UserModelTest extends BrowserKitTestCase
         ]);
 
         // We should have made one "create" request to Blink.
-        // $this->blinkMock->shouldHaveReceived('userCreate')->once();
         $this->blinkMock->shouldHaveReceived('userCreate')->once()->with([
             'id' => $user->id,
             'first_name' => $user->first_name,
@@ -30,6 +29,7 @@ class UserModelTest extends BrowserKitTestCase
             'addr_state' => $user->addr_state,
             'addr_zip' => $user->addr_zip,
             'country' => $user->country,
+            'voter_registration_status' => $user->voter_registration_status,
             'language' => $user->language,
             'source' => $user->source,
             'source_detail' => $user->source_detail,


### PR DESCRIPTION
#### What's this PR do?
- Adds `voter_registration_status` field to User model
- Returns that field in v2 transformer and when sending to Customer.io

#### How should this be reviewed?
Is this what we want to call this field? Should it be returned anywhere else?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/156820648)

#### Checklist
- [x] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
