### PR TITLE
Updating API doc URI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Northstar is built using [Laravel 5.5](https://laravel.com/docs/5.5), [OAuth 2.0
 
 ### Getting Started
 
-Check out the [API Documentation](https://github.com/DoSomething/northstar/blob/dev/documentation/README.md) to start using
+Check out the [API Documentation](https://github.com/DoSomething/northstar/blob/master/documentation/README.md) to start using
 Northstar! :sparkles:
 
 ### Contributing


### PR DESCRIPTION
#### What's this PR do?
Updates README to point to `master` instead of `dev` branch URI for API documentation.

#### How should this be reviewed?
Checkout branch and test URI link!

#### Relevant Tickets
N/A

