### PR TITLE
sends birthdate to customer.io as timestamp instead of formatted date

### DIFF
--- a/app/Console/Commands/BackfillCustomerIo.php
+++ b/app/Console/Commands/BackfillCustomerIo.php
@@ -31,6 +31,7 @@ class BackfillCustomerIo extends Command
     public function handle()
     {
         // @TODO: Running this command will cause users to be sent to customer.io twice
+        $query = $this->newQuery(User::class);
         $progress = $this->output->createProgressBar($query->count());
 
         $query->chunkById(200, function (Collection $users) use ($progress) {

--- a/app/Console/Commands/BackfillCustomerIo.php
+++ b/app/Console/Commands/BackfillCustomerIo.php
@@ -31,7 +31,6 @@ class BackfillCustomerIo extends Command
     public function handle()
     {
         // @TODO: Running this command will cause users to be sent to customer.io twice
-        $query = User::where('cio_full_backfill', '!=', true);
         $progress = $this->output->createProgressBar($query->count());
 
         $query->chunkById(200, function (Collection $users) use ($progress) {

--- a/app/Console/Commands/BackfillCustomerIo.php
+++ b/app/Console/Commands/BackfillCustomerIo.php
@@ -30,7 +30,6 @@ class BackfillCustomerIo extends Command
      */
     public function handle()
     {
-        // @TODO: Running this command will cause users to be sent to customer.io twice
         $query = (new User)->newQuery();
         $progress = $this->output->createProgressBar($query->count());
 

--- a/app/Console/Commands/BackfillCustomerIo.php
+++ b/app/Console/Commands/BackfillCustomerIo.php
@@ -31,7 +31,7 @@ class BackfillCustomerIo extends Command
     public function handle()
     {
         // @TODO: Running this command will cause users to be sent to customer.io twice
-        $query = $this->newQuery(User::class);
+        $query = (new User)->newQuery();
         $progress = $this->output->createProgressBar($query->count());
 
         $query->chunkById(200, function (Collection $users) use ($progress) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -423,7 +423,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
-            'birthdate' => strtotime($this->birthdate),
+            'birthdate' => optional($this->birthdate)->timestamp,
             'addr_city' => $this->addr_city,
             'addr_state' => $this->addr_state,
             'addr_zip' => $this->addr_zip,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -423,7 +423,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
-            'birthdate' => format_date($this->birthdate, 'Y-m-d'),
+            'birthdate' => strtotime($this->birthdate),
             'addr_city' => $this->addr_city,
             'addr_state' => $this->addr_state,
             'addr_zip' => $this->addr_zip,

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -20,7 +20,7 @@ class UserModelTest extends BrowserKitTestCase
             'id' => $user->id,
             'first_name' => $user->first_name,
             'last_name' => $user->last_name,
-            'birthdate' => '1990-01-02',
+            'birthdate' => '631238400',
             'email' => $user->email,
             'mobile' => $user->mobile,
             'sms_status' => $user->sms_status,


### PR DESCRIPTION
#### What's this PR do?
- Customer.io wants the user's birthdate sent as a timestamp, not formatted date. This PR updates the logic to do that! 

#### How should this be reviewed?
👀 

#### Relevant Tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/156696372) Pivotal Card.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
