### PR TITLE
Update birthdate un-borker to update directly in the DB

### DIFF
--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -57,7 +57,7 @@ class StandardizeBirthdates extends Command
                     $user->save();
                 }
 
-                if (! $date) {
+                if (! $user->birthdate) {
                     info('northstar:bday - removed invalid birthdate from '.$user->id.' - '.$value);
                 } else {
                     info('northstar:bday - updated user '.$user->id.' birthdate from '.$value.' to '.$date);

--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -51,7 +51,7 @@ class StandardizeBirthdates extends Command
                 try {
                     $date = Carbon::parse($value);
                     app('db')->collection('users')->where(['_id' => $user->id])
-                ->update(['birthdate' => new UTCDateTime($date->getTimestamp() * 1000)]);
+                        ->update(['birthdate' => new UTCDateTime($date->getTimestamp() * 1000)]);
                 } catch (\Exception $e) {
                     $user->setBirthdateAttribute(null);
                     $user->save();

--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -4,6 +4,7 @@ namespace Northstar\Console\Commands;
 
 use Carbon\Carbon;
 use Northstar\Models\User;
+use MongoDB\BSON\UTCDateTime;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
@@ -49,12 +50,12 @@ class StandardizeBirthdates extends Command
                 // If possible, switch the birthday to a date type, otherwise, wipe it!
                 try {
                     $date = Carbon::parse($value);
+                    app('db')->collection('users')->where(['_id' => $user->id])
+                ->update(['birthdate' => new UTCDateTime($date->getTimestamp() * 1000)]);
                 } catch (\Exception $e) {
-                    $date = null;
+                    $user->setBirthdateAttribute(null);
+                    $user->save();
                 }
-
-                $user->setBirthdateAttribute($date);
-                $user->save();
 
                 if (! $date) {
                     info('northstar:bday - removed invalid birthdate from '.$user->id.' - '.$value);

--- a/tests/Console/StandardizeBirthdatesTest.php
+++ b/tests/Console/StandardizeBirthdatesTest.php
@@ -12,7 +12,7 @@ class StandardizeBirthdatesTest extends TestCase
 
         // Create some regular and borked birthday users
         factory(User::class, 5)->create();
-        $this->createMongoDocument('users', ['birthdate' => '2018-03-15 00:00:00.000']);
+        $this->createMongoDocument('users', ['birthdate' => '2018-03-15 00:00:00']);
         $this->createMongoDocument('users', ['birthdate' => 'I love dogs']);
 
         // Make sure we are registering 2 borked users


### PR DESCRIPTION
#### What's this PR do?
Updates the birthdate un-borker to update date-like strings to actual dates directly in the database (we have to do it this way due to a bug in the mongo package we use, PR on that front coming soon).

#### How should this be reviewed?
Question about exception catching: @DFurnes and I talked about only catching the specific exception thrown when calling `Carbon::parse($value)` on a `$value` that can't be converted to a date. We only want to catch the specific exception thrown because if we catch one, we will unset `birthdate` on that user. However, the exception thrown in that case is of class `Exception`, so it seems like we _have_ to catch that?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/156050050)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
