### PR TITLE
Rename email_status to email_frequency

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,7 +69,7 @@ use Northstar\Auth\Role;
  * Messaging subscription status:
  * @property string $sms_status
  * @property bool   $sms_paused
- * @property string $email_status
+ * @property string $email_frequency
  *
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
@@ -111,7 +111,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'slack_id',
-        'sms_status', 'sms_paused', 'email_status', 'last_messaged_at',
+        'sms_status', 'sms_paused', 'email_frequency', 'last_messaged_at',
     ];
 
     /**
@@ -440,9 +440,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         ];
 
         // Only include email subscription status if we have that information
-        if ($this->email_status) {
-            $payload['email_status'] = $this->email_status;
-            $payload['unsubscribed'] = ($this->email_status === 'stop');
+        if ($this->email_frequency) {
+            $payload['email_frequency'] = $this->email_frequency;
+            $payload['unsubscribed'] = ($this->email_frequency === 'stop');
         }
 
         return $payload;

--- a/database/migrations/2018_05_09_183441_RenameEmailStatusField.php
+++ b/database/migrations/2018_05_09_183441_RenameEmailStatusField.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class RenameEmailStatusField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->renameField('users', 'email_status', 'email_frequency');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->renameField('users', 'email_frequency', 'email_status');
+    }
+
+    /**
+     * Rename the given field on any documents in the collection.
+     *
+     * @param string $collection
+     * @param string $old
+     * @param string $new
+     */
+    public function renameField($collection, $old, $new)
+    {
+        /** @var \Jenssegers\Mongodb\Connection $connection */
+        $connection = app('db')->connection('mongodb');
+
+        // Rename 'mobile_status' to 'mobilecommons_status'.
+        $connection->collection($collection)
+            ->whereRaw([$old => ['$exists' => true]])
+            ->update(['$rename' => [$old => $new]]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
- Renames `email_status` to `email_frequency` in the database and updates all the references to that field. 
- In the migration, I re-used the [`renameField`](https://github.com/DoSomething/northstar/blob/master/database/migrations/2017_09_15_152015_RenameMobileStatusField.php#L27-L43) function from the `RenameMobileStatusField` migration.

#### How should this be reviewed?
Are all the old `email_status`s now `email_frequency`s? 

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157162083)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
