### PR TITLE
Remove unnecessary data and make it unfillable

### DIFF
--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -13,7 +13,7 @@ class UnsetFieldCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:unset {field*}';
+    protected $signature = 'northstar:unset {field*} {--force}';
 
     /**
      * The console command description.
@@ -40,11 +40,16 @@ class UnsetFieldCommand extends Command
     public function handle()
     {
         $fieldsToRemove = $this->argument('field');
+        $force = $this->option('force');
 
         foreach ($fieldsToRemove as $field) {
-            $burnItDown = $this->confirm('Are you sure you want to remove this field from ALL USERS? `'.$field.'`');
+            $burnItDown = false;
 
-            if ($burnItDown) {
+            if (! $force) {
+                $burnItDown = $this->confirm('Are you sure you want to remove this field from ALL USERS? `'.$field.'`');
+            }
+
+            if ($burnItDown || $this->option('force')) {
                 info('Removing field from all users: '.$field);
 
                 $usersToUnset = (new User)->newQuery();
@@ -62,6 +67,8 @@ class UnsetFieldCommand extends Command
 
                 $progressBar->finish();
                 info('Field removed: '.$field);
+            } else {
+                $this->line('Did NOT remove '.$field);
             }
         }
     }

--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class UnsetFieldCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:unset {field*}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Unset the given field from all users.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $fieldsToRemove = $this->argument('field');
+        /** @var \Jenssegers\Mongodb\Connection $connection */
+        $connection = app('db')->connection('mongodb');
+
+        foreach ($fieldsToRemove as $field) {
+            $burnItDown = $this->confirm('Are you sure you want to remove this field from ALL USERS? `'.$field.'`');
+
+            if ($burnItDown) {
+                info('Removing field from all users: '.$field);
+                // Unset $field
+                $connection->collection('users')
+                    ->whereRaw([$field => ['$exists' => true]])
+                    ->unset([$field]);
+                info('Field removed: '.$field);
+            }
+        }
+    }
+}

--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -3,7 +3,6 @@
 namespace Northstar\Console\Commands;
 
 use DB;
-use Northstar\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
@@ -60,7 +59,7 @@ class UnsetFieldCommand extends Command
 
                     $usersLeft = DB::collection('users')->whereRaw([$field => ['$exists' => true]])->count();
 
-                    if (!$usersLeft) {
+                    if (! $usersLeft) {
                         $this->line('Field removed from all users: '.$field);
                     } else {
                         $this->line('Oops! '.$usersLeft.' users still have field: '.$field);

--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -52,8 +52,7 @@ class UnsetFieldCommand extends Command
             if ($burnItDown || $this->option('force')) {
                 info('Removing field from all users: '.$field);
 
-                $usersToUnset = (new User)->newQuery();
-                $usersToUnset->whereRaw([$field => ['$exists' => true]]);
+                $usersToUnset = User::whereRaw([$field => ['$exists' => true]]);
 
                 $this->line('Progess removing '.$field.':');
                 $progressBar = $this->output->createProgressBar($usersToUnset->count());

--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Console\Commands;
 
+use Northstar\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
@@ -39,18 +40,27 @@ class UnsetFieldCommand extends Command
     public function handle()
     {
         $fieldsToRemove = $this->argument('field');
-        /** @var \Jenssegers\Mongodb\Connection $connection */
-        $connection = app('db')->connection('mongodb');
 
         foreach ($fieldsToRemove as $field) {
             $burnItDown = $this->confirm('Are you sure you want to remove this field from ALL USERS? `'.$field.'`');
 
             if ($burnItDown) {
                 info('Removing field from all users: '.$field);
-                // Unset $field
-                $connection->collection('users')
-                    ->whereRaw([$field => ['$exists' => true]])
-                    ->unset([$field]);
+
+                $usersToUnset = (new User)->newQuery();
+                $usersToUnset->whereRaw([$field => ['$exists' => true]]);
+
+                $this->line('Progess removing '.$field.':');
+                $progressBar = $this->output->createProgressBar($usersToUnset->count());
+
+                $usersToUnset->chunkById(200, function (Collection $users) use ($progressBar, $field) {
+                    $users->each(function (User $user) use ($progressBar, $field) {
+                        $user->unset([$field]);
+                        $progressBar->advance();
+                    });
+                });
+
+                $progressBar->finish();
                 info('Field removed: '.$field);
             }
         }

--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -39,9 +39,10 @@ class UnsetFieldCommand extends Command
      */
     public function handle()
     {
-        if ($this->confirm('Have you made sure that there is NOT a broadcast in progress or starting soon?')) {
+        $force = $this->option('force');
+
+        if ($force || $this->confirm('Have you made sure that there is NOT a broadcast in progress or starting soon?')) {
             $fieldsToRemove = $this->argument('field');
-            $force = $this->option('force');
 
             foreach ($fieldsToRemove as $field) {
                 $burnItDown = false;

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -25,14 +25,14 @@ class UserTransformer extends TransformerAbstract
         }
 
         $response['last_initial'] = $user->last_initial;
-        $response['photo'] = $user->photo;
+        $response['photo'] = null;
 
         if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['email'] = $user->email;
             $response['mobile'] = format_legacy_mobile($user->mobile);
             $response['facebook_id'] = $user->facebook_id;
 
-            $response['interests'] = $user->interests;
+            $response['interests'] = [];
             $response['birthdate'] = format_date($user->birthdate, 'Y-m-d');
 
             $response['addr_street1'] = $user->addr_street1;
@@ -46,7 +46,7 @@ class UserTransformer extends TransformerAbstract
             $response['source_detail'] = $user->source_detail;
 
             // Internal & third-party service IDs:
-            $response['slack_id'] = $user->slack_id;
+            $response['slack_id'] = null;
 
             // Subscription status
             $response['sms_status'] = $user->sms_status;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -27,14 +27,14 @@ class UserTransformer extends TransformerAbstract
         }
 
         $response['last_initial'] = $user->last_initial;
-        $response['photo'] = $user->photo;
+        $response['photo'] = null;
 
         if (Scope::allows('admin') || Gate::allows('view-full-profile', $user)) {
             $response['email'] = $user->email;
             $response['mobile'] = format_legacy_mobile($user->mobile);
             $response['facebook_id'] = $user->facebook_id;
 
-            $response['interests'] = $user->interests;
+            $response['interests'] = [];
             $response['birthdate'] = format_date($user->birthdate, 'Y-m-d');
 
             $response['addr_street1'] = $user->addr_street1;
@@ -51,7 +51,7 @@ class UserTransformer extends TransformerAbstract
             $response['source_detail'] = $user->source_detail;
 
             // Internal & third-party service IDs:
-            $response['slack_id'] = $user->slack_id;
+            $response['slack_id'] = null;
             $response['mobilecommons_id'] = $user->mobilecommons_id;
             $response['mobilecommons_status'] = $user->sms_status; // @DEPRECATED: Will be removed.
             $response['parse_installation_ids'] = $user->parse_installation_ids;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,8 +27,6 @@ use Northstar\Auth\Role;
  * @property string $first_name
  * @property string $last_name
  * @property Carbon $birthdate
- * @property string $photo
- * @property array  $interests
  * @property string $source
  * @property string $source_detail
  * @property string $voter_registration_status
@@ -45,26 +43,10 @@ use Northstar\Auth\Role;
  * Source for the address fields (e.g. 'sms')
  * @property string $addr_source
  *
- * We also collect a bunch of fields from Niche.com users:
- * @property string $race
- * @property string $religion
- * @property string $school_id
- * @property string $college_name
- * @property string $degree_type
- * @property string $major_name
- * @property string $hs_gradyear
- * @property string $hs_name
- * @property int $sat_math
- * @property int $sat_verbal
- * @property int $sat_writing
- *
  * And we store some external service IDs for hooking things together:
  * @property string $mobilecommons_id
- * @property string $cgg_id
  * @property string $drupal_id
- * @property string $agg_id
  * @property string $facebook_id
- * @property string $slack_id
  *
  * Messaging subscription status:
  * @property string $sms_status
@@ -99,18 +81,14 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'email', 'mobile', 'password', 'role',
 
         // Profile:
-        'first_name', 'last_name', 'birthdate', 'photo', 'interests', 'voter_registration_status',
-
-        // @TODO: Remove these? We get these from Niche but don't use anywhere.
-        'school_id', 'college_name', 'degree_type', 'major_name', 'hs_gradyear', 'hs_name',
-        'sat_math', 'sat_verbal', 'sat_writing', 'race', 'religion',
+        'first_name', 'last_name', 'birthdate', 'voter_registration_status',
 
         // Address:
         'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip',
         'country', 'language', 'addr_source',
 
         // External profiles:
-        'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'slack_id',
+        'mobilecommons_id', 'mobilecommons_status', 'facebook_id',
         'sms_status', 'sms_paused', 'email_frequency', 'last_messaged_at',
     ];
 
@@ -121,7 +99,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $internal = [
-        'cgg_id', 'drupal_id', 'agg_id', 'role', 'facebook_id', 'slack_id',
+        'drupal_id', 'role', 'facebook_id',
         'mobilecommons_id', 'mobilecommons_status', 'sms_status', 'sms_paused',
         'last_messaged_at',
     ];
@@ -177,7 +155,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     protected $casts = [
-        'cgg_id' => 'integer',
         'birthdate' => 'date',
         'sms_paused' => 'boolean',
     ];
@@ -202,19 +179,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setEmailAttribute($value)
     {
         $this->attributes['email'] = normalize('email', $value);
-    }
-
-    /**
-     * Mutator to add interests to the user's interests array, either by
-     * passing an array or a comma-separated list of values.
-     *
-     * @param string|array $value
-     */
-    public function setInterestsAttribute($value)
-    {
-        $interests = is_array($value) ? $value : array_map('trim', explode(',', $value));
-
-        $this->push('interests', $interests, true);
     }
 
     /**

--- a/tests/Console/UnsetFieldsTest.php
+++ b/tests/Console/UnsetFieldsTest.php
@@ -4,7 +4,7 @@ use Northstar\Models\User;
 
 class UnsetFieldsTest extends TestCase
 {
-     /** @test */
+    /** @test */
     public function it_should_remove_fields()
     {
         // Create some users

--- a/tests/Console/UnsetFieldsTest.php
+++ b/tests/Console/UnsetFieldsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Northstar\Models\User;
+
+class UnsetFieldsTest extends TestCase
+{
+     /** @test */
+    public function it_should_remove_fields()
+    {
+        // Create some users
+        factory(User::class, 5)->create();
+
+        // Make sure all users have a `city`
+        $usersWithCity = User::whereRaw([
+            'city' => [
+                '$exists' => true,
+            ],
+        ])->count();
+        $this->assertEquals($usersWithCity, 5);
+
+        // Make sure all users have a `sms_status`
+        $usersWithSmsStatus = User::whereRaw([
+            'sms_status' => [
+                '$exists' => true,
+            ],
+        ])->count();
+        $this->assertEquals($usersWithSmsStatus, 5);
+
+        // Make sure all users have a `country`
+        $usersWithCountry = User::whereRaw([
+            'country' => [
+                '$exists' => true,
+            ],
+        ])->count();
+        $this->assertEquals($usersWithCountry, 5);
+
+        // Run the command to unset `city` and `country`
+        $this->artisan('northstar:unset', ['field' => ['city', 'country'], '--force' => true]);
+
+        // Make sure NO users have a `city`
+        $usersWithCity = User::whereRaw([
+            'city' => [
+                '$exists' => true,
+            ],
+        ])->count();
+        $this->assertEquals($usersWithCity, 0);
+
+        // Make sure all users have a `sms_status`
+        $usersWithSmsStatus = User::whereRaw([
+            'sms_status' => [
+                '$exists' => true,
+            ],
+        ])->count();
+        $this->assertEquals($usersWithSmsStatus, 5);
+
+        // Make sure NO users have a `country`
+        $usersWithCountry = User::whereRaw([
+            'country' => [
+                '$exists' => true,
+            ],
+        ])->count();
+        $this->assertEquals($usersWithCountry, 0);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
- Removes the attributes specified [here](https://www.pivotaltracker.com/n/projects/2019429/stories/157162537) as fillable fields on a User
- Removes `setInterestsAttribute` because that field was removed
- Removes `cgg_id` from `$casts`
- Creates `northstar:unset` (instead of a migration because the equivalent of "dropping columns" in Mongo requires going through every user)
    - Takes as arguments all the fields that you want to 🔥 and shoves them into an array
    - Asks the user to confirm that they really want to remove that field (since we are deleting a bunch of stuff this felt nice and safe)

Example run of `northstar:unset`:
```
vagrant@homestead:~/Sites/northstar$ php artisan northstar:unset pig dog cat

 Have you made sure that there is NOT a broadcast in progress or starting soon? (yes/no) [no]:
 > yes

 Are you sure you want to remove this field from ALL USERS? `pig` (yes/no) [no]:
 > yes

Field removed from all users: pig

 Are you sure you want to remove this field from ALL USERS? `dog` (yes/no) [no]:
 > no

Did NOT remove dog

 Are you sure you want to remove this field from ALL USERS? `cat` (yes/no) [no]:
 > yes

Field removed from all users: cat
```

#### How should this be reviewed?
Can we use this to unset all the fields that we want to? Did I fail to remove any fields? 

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157162537)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
