### PR TITLE
Voter registration status on registration form a/b test

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -174,17 +174,9 @@ class AuthController extends BaseController
      */
     public function getRegister()
     {
-        $experiment = false;
+        $showVoterStatusForm = participate('voter-status-reg-form', ['normal_form', 'voter_form']);
 
-        if (config('services.sixpack.enabled')) {
-            $sixpack = app(Sixpack::class);
-            $alt = $sixpack->participate('voter-status-reg-form', ['normal_form', 'voter_form'])->getAlternative();
-            if ($alt == 'voter_form') {
-                $experiment = true;
-            }
-        }
-
-        return view('auth.register', ['voter_reg_status_form' => $experiment]);
+        return view('auth.register', ['voter_reg_status_form' => $showVoterStatusForm]);
     }
 
     /**
@@ -196,10 +188,7 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
-        if (config('services.sixpack.enabled')) {
-            $sixpack = app(Sixpack::class);
-            $sixpack->convert('voter-status-reg-form');
-        }
+        convert('voter-status-reg-form');
 
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -196,8 +196,10 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
-        $sixpack = app(Sixpack::class);
-        $sixpack->convert('voter-status-reg-form');
+        if (config('services.sixpack.enabled')) {
+            $sixpack = app(Sixpack::class);
+            $sixpack->convert('voter-status-reg-form');
+        }
 
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Northstar\Auth\Entities\UserEntity;
 use Psr\Http\Message\ServerRequestInterface;
 use League\OAuth2\Server\AuthorizationServer;
-use SeatGeek\Sixpack\Session\Base as Sixpack;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Routing\Controller as BaseController;
 use Northstar\Exceptions\NorthstarValidationException;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -265,7 +265,8 @@ function get_client_environment_vars()
 
  * @return string
  */
-function participate($experiment, $alternatives) {
+function participate($experiment, $alternatives)
+{
     if (! config('services.sixpack.enabled')) {
         return false;
     }
@@ -282,7 +283,8 @@ function participate($experiment, $alternatives) {
  *
  * @return SeatGeek\Sixpack\Response\Conversion
  */
-function convert($experiment) {
+function convert($experiment)
+{
     if (! config('services.sixpack.enabled')) {
         return;
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,11 +2,12 @@
 
 use Carbon\Carbon;
 use Illuminate\Support\Str;
-use Illuminate\Support\HtmlString;
-use libphonenumber\PhoneNumberFormat;
-use libphonenumber\PhoneNumberUtil;
-use Northstar\Auth\Normalizer;
 use Northstar\Models\Client;
+use Northstar\Auth\Normalizer;
+use Illuminate\Support\HtmlString;
+use libphonenumber\PhoneNumberUtil;
+use libphonenumber\PhoneNumberFormat;
+use SeatGeek\Sixpack\Session\Base as Sixpack;
 
 /**
  * Normalize the given value.
@@ -254,4 +255,37 @@ function get_client_environment_vars()
     return [
         'PUCK_URL' => config('services.puck.url'),
     ];
+}
+
+/**
+ * Setup a Sixpack experiment
+ *
+ * @param string $experiment
+ * @param array $alternatives
+
+ * @return string
+ */
+function participate($experiment, $alternatives) {
+    if (! config('services.sixpack.enabled')) {
+        return false;
+    }
+
+    return app(Sixpack::class)
+        ->participate($experiment, $alternatives)
+        ->getAlternative();
+}
+
+/**
+ * Convert a Sixpack experiment
+ *
+ * @param string $experiment
+ *
+ * @return SeatGeek\Sixpack\Response\Conversion
+ */
+function convert($experiment) {
+    if (! config('services.sixpack.enabled')) {
+        return;
+    }
+
+    return app(Sixpack::class)->convert($experiment);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -262,7 +262,7 @@ function get_client_environment_vars()
  *
  * @param string $experiment
  * @param array $alternatives
-
+ *
  * @return string
  */
 function participate($experiment, $alternatives)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,5 +23,6 @@
         <env name="DS_ENABLE_BLINK" value="true"/>
         <env name="DS_ENABLE_RATE_LIMITING" value="true"/>
         <env name="DS_ENABLE_PASSWORD_GRANT" value="true"/>
+        <env name="SIXPACK_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -28,7 +28,7 @@
             </div>
         @endif
 
-        @if ($voter_reg_status_form)
+        @if ($voter_reg_status_form === 'voter_form')
             <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
                 <input name="_token" type="hidden" value="{{ csrf_token() }}">
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -64,21 +64,27 @@
 
                 <div class="form-item">
                     <label for="voter_registration_status" class="field-label">{{ "Are you registered to vote at your current address?"}}</label>
-                    <label class="option -radio">
-                      <input type="radio" name="voter_registration_status" value="confirmed">
-                      <span class="option__indicator"></span>
-                      <span>Yes</span>
-                    </label>
-                    <label class="option -radio">
-                      <input type="radio" name="voter_registration_status" value="no">
-                      <span class="option__indicator"></span>
-                      <span>No</span>
-                    </label>
-                    <label class="option -radio">
-                      <input type="radio" name="voter_registration_status" value="uncertain">
-                      <span class="option__indicator"></span>
-                      <span>I'm not sure</span>
-                    </label>
+                    <div class="form-item -reduced">
+                        <label class="option -radio">
+                          <input type="radio" name="voter_registration_status" value="confirmed">
+                          <span class="option__indicator"></span>
+                          <span>Yes</span>
+                        </label>
+                    </div>
+                    <div class="form-item -reduced">
+                        <label class="option -radio">
+                          <input type="radio" name="voter_registration_status" value="no">
+                          <span class="option__indicator"></span>
+                          <span>No</span>
+                        </label>
+                    </div>
+                    <div class="form-item -reduced">
+                        <label class="option -radio">
+                          <input type="radio" name="voter_registration_status" value="uncertain">
+                          <span class="option__indicator"></span>
+                          <span>I'm not sure</span>
+                        </label>
+                    </div>
                 </div>
 
                 <div class="form-actions -padded -left">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -73,7 +73,7 @@
                     </div>
                     <div class="form-item -reduced">
                         <label class="option -radio">
-                          <input type="radio" name="voter_registration_status" value="no">
+                          <input type="radio" name="voter_registration_status" value="unregistered">
                           <span class="option__indicator"></span>
                           <span>No</span>
                         </label>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -28,7 +28,6 @@
             </div>
         @endif
 
-        @if ($voter_reg_status_form === 'voter_form')
             <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
                 <input name="_token" type="hidden" value="{{ csrf_token() }}">
 
@@ -62,6 +61,7 @@
                     <span class="password-visibility__toggle -hide"></span>
                 </div>
 
+            @if ($voter_reg_status_form === 'voter_form')
                 <div class="form-item">
                     <label for="voter_registration_status" class="field-label">{{ "Are you registered to vote at your current address?"}}</label>
                     <div class="form-item -reduced">
@@ -86,51 +86,12 @@
                         </label>
                     </div>
                 </div>
+            @endif
 
                 <div class="form-actions -padded -left">
                     <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
                 </div>
             </form>
-        @else
-            <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
-                <input name="_token" type="hidden" value="{{ csrf_token() }}">
-
-                <div>
-                    <div class="form-item -reduced">
-                        <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
-                        <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
-                    </div>
-
-                    <div class="form-item -reduced">
-                        <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
-                        <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
-                    </div>
-                </div>
-
-                <div class="form-item">
-                    <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
-                    <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
-                </div>
-
-                @if (App::getLocale() === 'en')
-                    <div class="form-item">
-                        <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
-                        <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
-                    </div>
-                @endif
-
-                <div class="form-item password-visibility">
-                    <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
-                    <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
-                    <span class="password-visibility__toggle -hide"></span>
-                </div>
-
-                <div class="form-actions -padded -left">
-                    <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
-                </div>
-            </form>
-        @endif
-
     </div>
 
     <div class="container__block -centered">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -28,38 +28,38 @@
             </div>
         @endif
 
-            <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
-                <input name="_token" type="hidden" value="{{ csrf_token() }}">
+        <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
+            <input name="_token" type="hidden" value="{{ csrf_token() }}">
 
-                <div>
-                    <div class="form-item -reduced">
-                        <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
-                        <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
-                    </div>
-
-                    <div class="form-item -reduced">
-                        <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
-                        <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
-                    </div>
+            <div>
+                <div class="form-item -reduced">
+                    <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
+                    <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
                 </div>
 
+                <div class="form-item -reduced">
+                    <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
+                    <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                </div>
+            </div>
+
+            <div class="form-item">
+                <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
+                <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
+            </div>
+
+            @if (App::getLocale() === 'en')
                 <div class="form-item">
-                    <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
-                    <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
+                    <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
+                    <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
                 </div>
+            @endif
 
-                @if (App::getLocale() === 'en')
-                    <div class="form-item">
-                        <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
-                        <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
-                    </div>
-                @endif
-
-                <div class="form-item password-visibility">
-                    <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
-                    <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
-                    <span class="password-visibility__toggle -hide"></span>
-                </div>
+            <div class="form-item password-visibility">
+                <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
+                <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
+                <span class="password-visibility__toggle -hide"></span>
+            </div>
 
             @if ($voter_reg_status_form === 'voter_form')
                 <div class="form-item">
@@ -88,10 +88,10 @@
                 </div>
             @endif
 
-                <div class="form-actions -padded -left">
-                    <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
-                </div>
-            </form>
+            <div class="form-actions -padded -left">
+                <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
+            </div>
+        </form>
     </div>
 
     <div class="container__block -centered">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -28,43 +28,103 @@
             </div>
         @endif
 
-        <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
-            <input name="_token" type="hidden" value="{{ csrf_token() }}">
+        @if ($voter_reg_status_form)
+            <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
+                <input name="_token" type="hidden" value="{{ csrf_token() }}">
 
-            <div>
-                <div class="form-item -reduced">
-                    <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
-                    <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
+                <div>
+                    <div class="form-item -reduced">
+                        <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
+                        <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
+                    </div>
+
+                    <div class="form-item -reduced">
+                        <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
+                        <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                    </div>
                 </div>
 
-                <div class="form-item -reduced">
-                    <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
-                    <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
-                </div>
-            </div>
-
-            <div class="form-item">
-                <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
-                <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
-            </div>
-
-            @if (App::getLocale() === 'en')
                 <div class="form-item">
-                    <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
-                    <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
+                    <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
+                    <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
                 </div>
-            @endif
 
-            <div class="form-item password-visibility">
-                <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
-                <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
-                <span class="password-visibility__toggle -hide"></span>
-            </div>
+                @if (App::getLocale() === 'en')
+                    <div class="form-item">
+                        <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
+                        <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
+                    </div>
+                @endif
 
-            <div class="form-actions -padded -left">
-                <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
-            </div>
-        </form>
+                <div class="form-item password-visibility">
+                    <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
+                    <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
+                    <span class="password-visibility__toggle -hide"></span>
+                </div>
+
+                <div class="form-item">
+                    <label for="voter_registration_status" class="field-label">{{ "Are you registered to vote at your current address?"}}</label>
+                    <label class="option -radio">
+                      <input type="radio" name="voter_registration_status" value="confirmed">
+                      <span class="option__indicator"></span>
+                      <span>Yes</span>
+                    </label>
+                    <label class="option -radio">
+                      <input type="radio" name="voter_registration_status" value="no">
+                      <span class="option__indicator"></span>
+                      <span>No</span>
+                    </label>
+                    <label class="option -radio">
+                      <input type="radio" name="voter_registration_status" value="uncertain">
+                      <span class="option__indicator"></span>
+                      <span>I'm not sure</span>
+                    </label>
+                </div>
+
+                <div class="form-actions -padded -left">
+                    <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
+                </div>
+            </form>
+        @else
+            <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
+                <input name="_token" type="hidden" value="{{ csrf_token() }}">
+
+                <div>
+                    <div class="form-item -reduced">
+                        <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
+                        <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
+                    </div>
+
+                    <div class="form-item -reduced">
+                        <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
+                        <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                    </div>
+                </div>
+
+                <div class="form-item">
+                    <label for="email" class="field-label">{{ trans('auth.fields.email') }}</label>
+                    <input name="email" type="text" id="email" class="text-field required js-validate" placeholder="puppet-sloth@example.org" value="{{ old('email') }}" data-validate="email" data-validate-required />
+                </div>
+
+                @if (App::getLocale() === 'en')
+                    <div class="form-item">
+                        <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
+                        <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
+                    </div>
+                @endif
+
+                <div class="form-item password-visibility">
+                    <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
+                    <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
+                    <span class="password-visibility__toggle -hide"></span>
+                </div>
+
+                <div class="form-actions -padded -left">
+                    <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">
+                </div>
+            </form>
+        @endif
+
     </div>
 
     <div class="container__block -centered">


### PR DESCRIPTION
#### What's this PR do?
Creates an a/b called `voter-status-reg-form` test to include a question about voter registration status as part of the registration form. Users who see the new form will see this:
![image](https://user-images.githubusercontent.com/4240292/40566776-4a92ba60-6040-11e8-86a4-32533f4b375e.png)
The new question is optional and no `voter_registration_status` will be saved to their profile if they do not answer. If they do answer, we save it!

QUESTIONS:
1. What do we want to call the "no" option? For yes I have it saving as "confirmed" and for not sure I have it saving as "uncertain" to follow the conventions that we currently use with TurboVote.

2. Right now folks only convert if they submit the registration form. Meaning, folks who hit this page and click “login” will count as unconverted participants. However, traffic is split equally among the two options (new form and original form), so I’d expect there to be an equal number of folks already registered and trying to login hitting each alternative of the experiment. Therefore, while this will deflate conversion rates on both tests, I think it will do so approximately equally and we will still get all the information we need to know. I’ve also never done a/b testing before and there could be some incorrect assumptions in there, so this is in the questions section to make sure this is okay.

#### How should this be reviewed?
Does the form look okay? Are we converting the right folks? Saving the right information?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157196236)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
