### PR TITLE
Fix key file permissions

### DIFF
--- a/app/Auth/Repositories/KeyRepository.php
+++ b/app/Auth/Repositories/KeyRepository.php
@@ -77,6 +77,7 @@ class KeyRepository
 
             $key = Storage::get($path);
             file_put_contents($cachedPath, $key);
+            chmod($cachedPath, 0660);
         }
 
         $shouldCheckPermissions = config('app.debug') === false;


### PR DESCRIPTION
#### What's this PR do?
We need `cache/keys` to be executable for traversing, but the key files themselves only need `0660` level permissions (read/write).

#### How should this be reviewed?
Does this let everything read and write properly?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157289052)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
