### PR TITLE
Remove cached keys before deploy.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -23,11 +23,12 @@ build:
           export REDIS_PORT=$REDIS_PORT_6379_TCP_PORT
           vendor/bin/phpunit
     - script:
-        name: discover production packages
+        name: prepare for production
         code: |-
+          rm -rf storage/cache # clear cached test keys
           rm .env # reset APP_ENV=production
-          composer install --no-dev
-          php artisan package:discover
+          composer install --no-dev # remove dev dependencies
+          php artisan package:discover # discover packages
 
 deploy:
   steps:


### PR DESCRIPTION
#### What's this PR do?
This pull request removes the `storage/cache` directory after running tests so that we do not deploy it to production servers. This was causing incorrect keys to remain cached, even though we'd symlink the correct canonical keys in `storage/app/keys`.

#### How should this be reviewed?
Compare the [old build](https://app.wercker.com/dosomething/northstar/runs/Thor/5b1940237c06ca0001f305c1?step=5b1940b50b3ec700018e4967), where you can see `./storage/cache/keys/private.key` and `./storage/cache/keys/public.key` get included in the "store" step, with this [build](https://app.wercker.com/dosomething/northstar/runs/build/5b193fb51af74e000140270c).

#### Relevant Tickets
#756

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
