### PR TITLE
Specify grants for seeded clients.

### DIFF
--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -19,6 +19,7 @@ class ClientTableSeeder extends Seeder
         factory(Client::class, 'authorization_code')->create([
             'title' => 'Local Development',
             'description' => 'This is an example web OAuth client seeded with your local Northstar installation.',
+            'allowed_grant' => 'authorization_code',
             'client_id' => 'oauth-test-client',
             'client_secret' => 'secret1',
             'scope' => collect(Scope::all())->except('admin')->keys()->toArray(),
@@ -30,6 +31,7 @@ class ClientTableSeeder extends Seeder
         factory(Client::class, 'client_credentials')->create([
             'title' => 'Local Development (Machine)',
             'description' => 'This is an example machine OAuth client seeded with your local Northstar installation.',
+            'allowed_grant' => 'client_credentials',
             'client_id' => 'machine-test-client',
             'client_secret' => 'secret2',
             'scope' => collect(Scope::all())->keys()->toArray(),


### PR DESCRIPTION
#### What's this PR do?
This pull request specifies which grants each of our seeded clients are allowed to use (by setting the `allowed_grant` property). This should fix up `unsupported_grant_type` when connecting to a local Northstar instance for development.

#### How should this be reviewed?
Pull down this branch & test!

#### Relevant Tickets
#653

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  