### PR TITLE
Add more SMS text to registration page

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -52,6 +52,8 @@
                 <div class="form-item">
                     <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
                     <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
+                </div>
+                <div class="form-item">
                     <p class="footnote"><em>Enter to receive weekly actions you can take and relevant news and reminders from 38383. Message & data rates may apply. Text <strong>STOP</strong> to opt-out, <strong>HELP</strong> for help.</em></p>
                 </div>
             @endif

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -52,6 +52,7 @@
                 <div class="form-item">
                     <label for="mobile" class="field-label">{{ trans('auth.fields.mobile') }} <em>{{ trans('auth.validation.optional') }}</em></label>
                     <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
+                    <p class="footnote"><em>Enter to receive weekly actions you can take and relevant news and reminders from 38383. Message & data rates may apply. Text <strong>STOP</strong> to opt-out, <strong>HELP</strong> for help.</em></p>
                 </div>
             @endif
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -54,7 +54,9 @@
                     <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
                 </div>
                 <div class="form-item">
-                    <p class="footnote"><em>Enter to receive weekly actions you can take and relevant news and reminders from 38383. Message & data rates may apply. Text <strong>STOP</strong> to opt-out, <strong>HELP</strong> for help.</em></p>
+                    <p class="footnote"><em>DoSomething.org will send you updates from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for help. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages.
+                    <br>
+                    T-Mobile is not liable for delayed or undelivered messages.</em></p>
                 </div>
             @endif
 


### PR DESCRIPTION
#### What's this PR do?
- Added the following text under the mobile number form field: 
`
DoSomething.org will send you updates from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text HELP to 38383 for help. Text STOP to 38383 to opt out. Please review our Terms of Service​ and Privacy Policy pages.
T-Mobile is not liable for delayed or undelivered messages.
`

Peep it here:
![image](https://user-images.githubusercontent.com/4240292/41366061-fae7c47e-6f08-11e8-8439-57d6312528d7.png)




#### How should this be reviewed?
Are the words right? Does it look right?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/158306751)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
