### PR TITLE
Adding Redis URL parsing for Heroku

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,14 @@
 <?php
 
+// Convert Heroku's `REDIS_URL` to standard `REDIS_HOST`, `REDIS_PORT`,
+// and `REDIS_PASSWORD` environment variables:
+if (env('REDIS_URL')) {
+    $url = parse_url(env('REDIS_URL'));
+    putenv('REDIS_HOST='.$url['host']);
+    putenv('REDIS_PORT='.$url['port']);
+    putenv('REDIS_PASSWORD='.$url['pass']);
+}
+
 return [
 
     /*
@@ -91,9 +100,10 @@ return [
         'cluster' => false,
 
         'default' => [
-            'host' => env('REDIS_HOST', '127.0.0.1'),
+            'host' => env('REDIS_HOST', 'localhost'),
+            'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
-            'database' => 0,
+            'database' => env('REDIS_DATABASE', 0),
         ],
 
     ],


### PR DESCRIPTION
#### What's this PR do?  
This adds Redis URL parsing so that we can just enter the REDIS_URL environment variable in Heroku

#### How should this be reviewed?
I've deployed this as a test to dosomething-northstar-dev and it appears to be connecting to the Redis DB successfully. The app still has a public key error, but that's a separate issue. https://cl.ly/0S0d2O2w043O

