### PR TITLE
Fix issue loading OIDC Discovery route.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,3 +7,10 @@ location / {
     index index.php;
     try_files $uri $uri/ /index.php?$query_string;
 }
+
+# Allow our application to serve '.well-known' routes.
+location ^~ /.well-known/ {
+    allow all;
+    index index.php;
+    try_files $uri $uri/ /index.php?$query_string;
+}


### PR DESCRIPTION
#### What's this PR do?
We're currently getting a `403 Forbidden` response from Northstar's [OpenID Connect Discovery route](https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/discovery.md) when running on Heroku. This is necessary for clients to auto-configure themselves, like Gateway's `gateway:key` command & our GraphQL service both do.

![screen shot 2018-06-15 at 10 49 00 am](https://user-images.githubusercontent.com/583202/41474345-ba974cb4-7089-11e8-8246-4ed37b47461f.png)

#### How should this be reviewed?
By default, Heroku [denies access to hidden directories](https://github.com/heroku/heroku-buildpack-php/blob/2840e48240769316777d6548409aa75fef16de09/conf/nginx/heroku.conf.php#L62-L65) like this, so we need to explicitly allow it.

To test, I've deployed this branch to `dosomething-northstar-dev`. You can see it in action here:

[![screen shot 2018-06-15 at 10 50 15 am](https://user-images.githubusercontent.com/583202/41474418-e9770ae2-7089-11e8-90d3-a8349d9140fa.png)](https://identity-dev.dosomething.org/.well-known/openid-configuration)

#### Relevant Tickets
DoSomething/devops#383

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  