### PR TITLE
Set sms_status to active upon new registration with phone number

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -201,6 +201,10 @@ class Registrar
 
         $user->fill($input);
 
+        if ($user->mobile) {
+            $user->sms_status = 'active';
+        }
+
         if (! is_null($customizer)) {
             $customizer($user);
         }


### PR DESCRIPTION
#### What's this PR do?
- If someone registers and includes a mobile number, we set their `sms_status` to `active`

This does NOT:
- Change a user's `sms_status` if they change their phone number
- Set `sms_status` for users who do not provide a phone number

#### How should this be reviewed?
Is everything I claimed above true?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157664690)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

cc: @aaronschachter @rapala61 