### PR TITLE
northstar:update - do not crash on bad user ids

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -58,6 +58,12 @@ class UpdateUserFieldsCommand extends Command
         foreach ($usersToUpdate as $userToUpdate) {
             $user = User::find($userToUpdate['northstar_id']);
 
+            if (! $user) {
+                $this->line('Oops! Could not find user: ' . $userToUpdate['northstar_id']);
+
+                continue;
+            }
+
             foreach ($fieldsToUpdate as $field) {
                 if (! empty($userToUpdate[$field])) {
                     $user->{$field} = $userToUpdate[$field];


### PR DESCRIPTION
#### What's this PR do?
- Updates `northstar:update` to note any bad user IDs and just skip them. Some CSVs may have mangled/truncated user ids ([examples in this card](https://www.pivotaltracker.com/story/show/157135043)).

#### How should this be reviewed?
Will we be able to track bad user IDs? Will the command crash?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157135043)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
