### PR TITLE
Update comment and fix sms_status getting set to active

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -185,7 +185,7 @@ class Registrar
     }
 
     /**
-     * Create a new user.
+     * Create a new user OR update an existing user (if given).
      *
      * @param array $input - Profile fields
      * @param User $user - Optionally, user to update
@@ -200,10 +200,6 @@ class Registrar
         }
 
         $user->fill($input);
-
-        if ($user->mobile) {
-            $user->sms_status = 'active';
-        }
 
         if (! is_null($customizer)) {
             $customizer($user);

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -205,6 +205,11 @@ class AuthController extends BaseController
 
             // Set language based on locale (either 'en', 'es-mx')
             $user->language = app()->getLocale();
+
+            // Set sms_status, if applicable
+            if ($user->mobile) {
+                $user->sms_status = 'active';
+            }
         });
 
         $this->auth->guard('web')->login($user, true);


### PR DESCRIPTION
#### What's this PR do?
Fixes an issue where all users who had a mobile number and got an update made to their account had their `sms_status` set to `active`. Turns out the `register()` doubles as the method to update a user!

#### How should this be reviewed?
👀 

#### Relevant Tickets
none! all Slack

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
