### PR TITLE
Some tweaks for more helpful log messages.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -189,4 +189,16 @@ class Handler extends ExceptionHandler
 
         return response()->json($response, $code);
     }
+
+    /**
+     * Get the default context variables for logging exceptions.
+     *
+     * @return array
+     */
+    protected function context()
+    {
+        // We handle adding context in AppServiceProvider, and specifically
+        // want to disable Laravel's default behavior of appending email here.
+        return [];
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -133,7 +133,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @var array
      */
-    protected $hidden = ['drupal_password', 'password'];
+    protected $hidden = ['drupal_password', 'password', 'audit'];
 
     /**
      * The attributes that should be mutated to dates.

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -76,16 +76,10 @@ class UserModelTest extends BrowserKitTestCase
 
         $logger->shouldHaveReceived('debug')->once()->with('updated user', [
             'id' => $user->id,
-            'client_id' => 'northstar',
             'changed' => [
                 'first_name' => 'Caroline',
                 'password' => '*****',
-                'audit' => [
-                    'source' => $auditMock,
-                    '_id' => $auditMock,
-                    'first_name' => $auditMock,
-                    'password' => $auditMock,
-                ],
+                'audit' => '*****',
             ],
         ]);
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request makes some updates so that we store more useful log messages, especially now that we're on Heroku & Papertrail. Three changes:

🔇 Hides the `audit` property from log messages, since this just adds a lot of noise.

🏷 Attaches `user_id`, `client_id`, and `request_id` to each log message so we get more context.

📥 Remove Laravel's [default behavior](https://github.com/laravel/framework/blob/02be861ac3471cded2329aa0865529346fb3c0b5/src/Illuminate/Foundation/Exceptions/Handler.php#L143-L158) of trying to append a user's email to exceptions.

#### How should this be reviewed?
👀

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  