### PR TITLE
Prevent password overlay overlap in Safari.

### DIFF
--- a/resources/assets/scss/_components/_password-visibility.scss
+++ b/resources/assets/scss/_components/_password-visibility.scss
@@ -1,6 +1,11 @@
 .password-visibility {
   position: relative;
 
+  .text-field {
+    // Prevent browser overlay from overlapping on ours.
+    padding-right: 36px;
+  }
+
   .password-visibility__toggle {
     width: 1em;
     height: 1em;


### PR DESCRIPTION
#### What's this PR do?
This had been bugging me a bit. In Safari, before:

![no good](https://user-images.githubusercontent.com/583202/42909253-7b677004-8ab1-11e8-931a-5b04f062756f.png)

And after:

![good](https://user-images.githubusercontent.com/583202/42909670-f3c119f0-8ab2-11e8-8d16-8e930c22617b.png)


#### How should this be reviewed?
👀

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
