### PR TITLE
Rename seeded development clients for consistency.

### DIFF
--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -20,7 +20,7 @@ class ClientTableSeeder extends Seeder
             'title' => 'Local Development',
             'description' => 'This is an example web OAuth client seeded with your local Northstar installation.',
             'allowed_grant' => 'authorization_code',
-            'client_id' => 'oauth-test-client',
+            'client_id' => 'dev-oauth',
             'client_secret' => 'secret1',
             'scope' => collect(Scope::all())->except('admin')->keys()->toArray(),
             // @NOTE: We're omitting 'redirect_uri' here for easy local dev.
@@ -32,7 +32,7 @@ class ClientTableSeeder extends Seeder
             'title' => 'Local Development (Machine)',
             'description' => 'This is an example machine OAuth client seeded with your local Northstar installation.',
             'allowed_grant' => 'client_credentials',
-            'client_id' => 'machine-test-client',
+            'client_id' => 'dev-machine',
             'client_secret' => 'secret2',
             'scope' => collect(Scope::all())->keys()->toArray(),
         ]);

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -36,5 +36,9 @@ class ClientTableSeeder extends Seeder
             'client_secret' => 'secret2',
             'scope' => collect(Scope::all())->keys()->toArray(),
         ]);
+
+        // ...and a few other random ones for good measure!
+        factory(Client::class, 'authorization_code', 2)->create();
+        factory(Client::class, 'client_credentials', 2)->create();
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request renames `oauth-test-client` and `machine-test-client` to `dev-oauth` and `dev-machine` for consistency with the "development" clients in our dev, QA, and prod environments. I've also added a few random clients to the seeder so it fills out the Aurora index on local dev.

#### How should this be reviewed?
👀

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  