### PR TITLE
Remove validation trigger for removed field.

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -62,7 +62,7 @@
 
             <div class="form-item password-visibility">
                 <label for="password" class="field-label">{{ trans('auth.fields.password') }}</label>
-                <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required data-validate-trigger="#password_confirmation" />
+                <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.password') }}" data-validate="password" data-validate-required />
                 <span class="password-visibility__toggle -hide"></span>
             </div>
 


### PR DESCRIPTION
#### What's this PR do?
This pull request removes an unused `data-validate-trigger` from when we had a "password confirmation" field on the registration form. I noticed it due to this error:

![screen shot 2018-07-23 at 2 11 11 pm](https://user-images.githubusercontent.com/583202/43094948-54d709ac-8e82-11e8-8f73-42519b954808.png)

Removing it seems to clear things up when testing on my local.

#### How should this be reviewed?
👀 

#### Relevant Tickets
[#159245841](https://www.pivotaltracker.com/story/show/159245841)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  