### PR TITLE
Reduce 'max_execution_time' to match Fastly timeout.

### DIFF
--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,3 +1,8 @@
 # Reduce memory limit (from default 128MB) so
 # we can process more concurrent requests.
 memory_limit = 32M
+
+# Reduce max execution time (from default 30s)
+# so we don't continue processing requests that
+# Fastly has already returned a 503 for.
+max_execution_time = 15

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,1 +1,3 @@
+# Reduce memory limit (from default 128MB) so
+# we can process more concurrent requests.
 memory_limit = 32M


### PR DESCRIPTION
#### What's this PR do?
I've noticed some 503s when this app is under load that aren't ending up in our logs, and I think that's because Fastly is cutting things off while the request continues to process behind the scenes. This pull request reduces the max amount of time we'll let PHP process a request on this application so we can see how much this is actually happening.

#### How should this be reviewed?
Here's [the Heroku default](https://github.com/heroku/heroku-buildpack-php/blob/b5c4a0b77a725c4ab9dc1736e5a8217824790093/support/build/_conf/php/php.ini#L437-L440) and [PHP documentation](https://github.com/heroku/heroku-buildpack-php/blob/b5c4a0b77a725c4ab9dc1736e5a8217824790093/support/build/_conf/php/php.ini#L437-L440).

#### Relevant Tickets
References DoSomething/devops#435.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  