### PR TITLE
Add source of `sms_status` to customer.io payload

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -384,6 +384,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'email' => $this->email,
             'mobile' => $this->mobile, // TODO: Update Blink to just accept 'phone' field.
             'sms_status' => $this->sms_status,
+            'sms_status_source' => $this->audit['sms_status']['source'],
             'sms_paused' => (bool) $this->sms_paused,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -384,7 +384,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'email' => $this->email,
             'mobile' => $this->mobile, // TODO: Update Blink to just accept 'phone' field.
             'sms_status' => $this->sms_status,
-            'sms_status_source' => $this->audit['sms_status']['source'],
+            'sms_status_source' => (isset($this->audit['sms_status']['source'])) ? $this->audit['sms_status']['source'] : null,
             'sms_paused' => (bool) $this->sms_paused,
             'facebook_id' => $this->facebook_id,
             'first_name' => $this->first_name,

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -24,6 +24,7 @@ class UserModelTest extends BrowserKitTestCase
             'mobile' => $user->mobile,
             'sms_status' => $user->sms_status,
             'sms_paused' => (bool) $user->sms_paused,
+            'sms_status_source' => 'northstar',
             'facebook_id' => $user->facebook_id,
             'addr_city' => $user->addr_city,
             'addr_state' => $user->addr_state,


### PR DESCRIPTION
#### What's this PR do?
- Adds the `sms_status` source from the `audit` property on a user to the Customer.io payload

#### How should this be reviewed?
@DoSomething/team-odoyle does the field name `sms_status_source` make sense or would you like something different?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/158543813)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
