### PR TITLE
Fix update users command and bump php up

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -57,7 +57,7 @@ class UpdateUserFieldsCommand extends Command
         $path = $this->argument('path');
         info('northstar:update: Loading in csv from '.$path);
 
-        $temp = tempnam('temp', 'command_csv');
+        $temp = tempnam(sys_get_temp_dir(), 'command_csv');
         file_put_contents($temp, fopen($this->argument('path'), 'r'));
 
         // Load the user updates from the CSV

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0.0",
+    "php": "~7.2.9",
     "aws/aws-sdk-php": "^3.46",
     "dfurnes/environmentalist": "0.0.2",
     "dosomething/gateway": "^1.14.3",


### PR DESCRIPTION
#### What's this PR do?
- Bumps php version to `~7.2.9`. Previously we had it as `>=7.0.0`, so this is the version that we were using on Heroku already anyway.
- Fixes `northstar:update` to use `sys_get_temp_dir()` (what we had before broke because we were on php `7.2.9`)

#### How should this be reviewed?
👀 Tests passing? Good to go?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/157479967)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
