### PR TITLE
Enable CORS for Northstar's API.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -39,6 +39,7 @@ class Kernel extends HttpKernel
         'api' => [
             \Northstar\Http\Middleware\ParseOAuthHeader::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \Barryvdh\Cors\HandleCors::class,
             'guard:api',
         ],
     ];

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
     }
   ],
   "require": {
-    "php": "~7.2.9",
+    "php": "~7.2.0",
     "aws/aws-sdk-php": "^3.46",
+    "barryvdh/laravel-cors": "^0.11.2",
     "dfurnes/environmentalist": "0.0.2",
     "dosomething/gateway": "^1.14.3",
     "dosomething/stathat": "^2.0.0",
@@ -31,9 +32,9 @@
     "league/oauth2-server": "^7.0.0",
     "mongodb/mongodb": "~1.2.0",
     "predis/predis": "^1.1",
+    "seatgeek/sixpack-php": "^2.1",
     "symfony/psr-http-message-bridge": "^1.0.0",
-    "zendframework/zend-diactoros": "^1.3",
-    "seatgeek/sixpack-php": "^2.1"
+    "zendframework/zend-diactoros": "^1.3"
   },
   "require-dev": {
     "filp/whoops": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,60 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "477f4d54ef83caf5e4163a8d6385cc4f",
+    "content-hash": "7c82671d8c26dd0ac32ef1d55324af8a",
     "packages": [
+        {
+            "name": "asm89/stack-cors",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/asm89/stack-cors.git",
+                "reference": "c163e2b614550aedcf71165db2473d936abbced6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/c163e2b614550aedcf71165db2473d936abbced6",
+                "reference": "c163e2b614550aedcf71165db2473d936abbced6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/http-foundation": "~2.7|~3.0|~4.0",
+                "symfony/http-kernel": "~2.7|~3.0|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8.10",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Asm89\\Stack\\": "src/Asm89/Stack/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander",
+                    "email": "iam.asm89@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library and stack middleware",
+            "homepage": "https://github.com/asm89/stack-cors",
+            "keywords": [
+                "cors",
+                "stack"
+            ],
+            "time": "2017-12-20T14:37:45+00:00"
+        },
         {
             "name": "aws/aws-sdk-php",
             "version": "3.67.5",
@@ -85,6 +137,68 @@
                 "sdk"
             ],
             "time": "2018-09-04T21:04:34+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-cors",
+            "version": "v0.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-cors.git",
+                "reference": "7969a52f52d0d9a04b42565d25ac9994b8c83332"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-cors/zipball/7969a52f52d0d9a04b42565d25ac9994b8c83332",
+                "reference": "7969a52f52d0d9a04b42565d25ac9994b8c83332",
+                "shasum": ""
+            },
+            "require": {
+                "asm89/stack-cors": "^1.2",
+                "illuminate/support": "5.5.x|5.6.x|5.7.x",
+                "php": ">=7",
+                "symfony/http-foundation": "^3.1|^4",
+                "symfony/http-kernel": "^3.1|^4"
+            },
+            "require-dev": {
+                "laravel/framework": "^5.5",
+                "orchestra/testbench": "3.3.x|3.4.x|3.5.x|3.6.x|3.7.x",
+                "phpunit/phpunit": "^4.8|^5.2|^7.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Cors\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Laravel application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain",
+                "laravel"
+            ],
+            "time": "2018-09-06T13:20:53+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -5898,7 +6012,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.0"
+        "php": "~7.2.0"
     },
     "platform-dev": []
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: dosomething/ds-docker-php
+box: dosomething/ds-docker-php:7.2
 
 services:
   - redis


### PR DESCRIPTION
#### What's this PR do?
This pull request enables [cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) for Northstar (for example, so we can load a user's profile from https://vote.dosomething.org). We'd previously overridden this in Fastly in DoSomething/devops#416, but I'd like to clean this up and move it into the application now.

#### How should this be reviewed?
Here's an working example from my local (simulating an AJAX request from [example.com](https://example.com)):

<img width="706" alt="screen shot 2018-09-14 at 2 24 07 pm" src="https://user-images.githubusercontent.com/583202/45568148-da462480-b829-11e8-81d6-5fd8f6b01426.png">

One note – I had to change our PHP version constraint to accept any `7.2.*` release since my Homestead [is running PHP 7.2.7 and so failing with the `~7.2.9` constraint](https://user-images.githubusercontent.com/583202/45568047-7c194180-b829-11e8-94bc-dbd32df7716a.png) we'd added in #794.

#### Relevant Tickets
DoSomething/devops#439

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  