### PR TITLE
Print to stdout instead of using logger.

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -57,7 +57,7 @@ class UpdateUserFieldsCommand extends Command
     {
         // Make a local copy of the CSV
         $path = $this->argument('path');
-        print('northstar:update: Loading in csv from '.$path.PHP_EOL);
+        $this->line('northstar:update: Loading in csv from '.$path);
 
         $temp = tempnam(sys_get_temp_dir(), 'command_csv');
         file_put_contents($temp, fopen($this->argument('path'), 'r'));
@@ -67,7 +67,7 @@ class UpdateUserFieldsCommand extends Command
         $usersCsv->setHeaderOffset(0);
         $usersToUpdate = $usersCsv->getRecords();
 
-        print('northstar:update: Updating '.count($usersCsv).' users...'.PHP_EOL);
+        $this->line('northstar:update: Updating '.count($usersCsv).' users...');
         $fieldsToUpdate = $this->argument('fields');
 
         $this->totalCount = count($usersCsv);
@@ -77,7 +77,7 @@ class UpdateUserFieldsCommand extends Command
             $user = User::find($userToUpdate['northstar_id']);
 
             if (! $user) {
-                print('northstar:update: Oops! Could not find user: '.$userToUpdate['northstar_id'].PHP_EOL);
+                $this->line('northstar:update: Oops! Could not find user: '.$userToUpdate['northstar_id']);
 
                 $this->logPercent();
 
@@ -93,15 +93,15 @@ class UpdateUserFieldsCommand extends Command
             $user->save();
 
             if ($this->option('verbose')) {
-                print('northstar:update: Updated user - '.$user->id.PHP_EOL);
+                $this->line('northstar:update: Updated user - '.$user->id);
                 $mb = memory_get_peak_usage() / 1000000;
-                print('northstar:update: '.$mb.' Mb used'.PHP_EOL);
+                $this->line('northstar:update: '.$mb.' Mb used');
             }
 
             $this->logPercent();
         }
 
-        print('northstar:update: Done updating users!'.PHP_EOL);
+        $this->line('northstar:update: Done updating users!');
     }
 
     /**
@@ -114,7 +114,7 @@ class UpdateUserFieldsCommand extends Command
         $this->currentCount++;
         if ($this->currentCount % 1000 === 0) {
             $percent = ($this->currentCount / $this->totalCount) * 100;
-            print('northstar:update: '.$this->currentCount.'/'.$this->totalCount.' - '.$percent.'% done'.PHP_EOL);
+            $this->line('northstar:update: '.$this->currentCount.'/'.$this->totalCount.' - '.$percent.'% done');
         }
     }
 }

--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -57,7 +57,7 @@ class UpdateUserFieldsCommand extends Command
     {
         // Make a local copy of the CSV
         $path = $this->argument('path');
-        info('northstar:update: Loading in csv from '.$path);
+        print('northstar:update: Loading in csv from '.$path.PHP_EOL);
 
         $temp = tempnam(sys_get_temp_dir(), 'command_csv');
         file_put_contents($temp, fopen($this->argument('path'), 'r'));
@@ -67,7 +67,7 @@ class UpdateUserFieldsCommand extends Command
         $usersCsv->setHeaderOffset(0);
         $usersToUpdate = $usersCsv->getRecords();
 
-        info('northstar:update: Updating '.count($usersCsv).' users...');
+        print('northstar:update: Updating '.count($usersCsv).' users...'.PHP_EOL);
         $fieldsToUpdate = $this->argument('fields');
 
         $this->totalCount = count($usersCsv);
@@ -77,7 +77,7 @@ class UpdateUserFieldsCommand extends Command
             $user = User::find($userToUpdate['northstar_id']);
 
             if (! $user) {
-                info('northstar:update: Oops! Could not find user: '.$userToUpdate['northstar_id']);
+                print('northstar:update: Oops! Could not find user: '.$userToUpdate['northstar_id'].PHP_EOL);
 
                 $this->logPercent();
 
@@ -93,15 +93,15 @@ class UpdateUserFieldsCommand extends Command
             $user->save();
 
             if ($this->option('verbose')) {
-                info('northstar:update: Updated user - '.$user->id);
+                print('northstar:update: Updated user - '.$user->id.PHP_EOL);
                 $mb = memory_get_peak_usage() / 1000000;
-                info('northstar:update: '.$mb.' Mb used');
+                print('northstar:update: '.$mb.' Mb used'.PHP_EOL);
             }
 
             $this->logPercent();
         }
 
-        info('northstar:update: Done updating users!');
+        print('northstar:update: Done updating users!'.PHP_EOL);
     }
 
     /**
@@ -114,7 +114,7 @@ class UpdateUserFieldsCommand extends Command
         $this->currentCount++;
         if ($this->currentCount % 1000 === 0) {
             $percent = ($this->currentCount / $this->totalCount) * 100;
-            info('northstar:update: '.$this->currentCount.'/'.$this->totalCount.' - '.$percent.'% done');
+            print('northstar:update: '.$this->currentCount.'/'.$this->totalCount.' - '.$percent.'% done'.PHP_EOL);
         }
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request replaces logging with Laravel's `info()` helper to instead print to standard output. This should help us sidestep an issue with [Monolog leaking memory in long-running scripts](https://dfurn.es/2OyUkuP).

#### How should this be reviewed?
We've tested this [on dosomething-northstar-qa](https://dosomething.slack.com/archives/C02BBRN5A/p1537205813000100) and memory usage is flat.

#### Relevant Tickets
[#160331160](https://www.pivotaltracker.com/story/show/160331160)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  