### PR TITLE
northstar:update - Note memory when we print percent completion

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -114,7 +114,8 @@ class UpdateUserFieldsCommand extends Command
         $this->currentCount++;
         if ($this->currentCount % 1000 === 0) {
             $percent = ($this->currentCount / $this->totalCount) * 100;
-            $this->line('northstar:update: '.$this->currentCount.'/'.$this->totalCount.' - '.$percent.'% done');
+            $mb = memory_get_peak_usage() / 1000000;
+            $this->line('northstar:update: '.$this->currentCount.'/'.$this->totalCount.' - '.$percent.'% done - '.$mb.' Mb used');
         }
     }
 }


### PR DESCRIPTION
#### What's this PR do?
- When we print the percent, we want to print the max memory used to see if it helps us 🕵️‍♀️ 

#### How should this be reviewed?
👀 

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/160331160)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
