### PR TITLE
northstar:update - Declare variable outside foreach, add unset

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -73,6 +73,8 @@ class UpdateUserFieldsCommand extends Command
         $this->totalCount = count($usersCsv);
         $currentCount = 0;
 
+        $user = null;
+
         foreach ($usersToUpdate as $userToUpdate) {
             $user = User::find($userToUpdate['northstar_id']);
 
@@ -99,6 +101,7 @@ class UpdateUserFieldsCommand extends Command
             }
 
             $this->logPercent();
+            unset($userToUpdate);
         }
 
         $this->line('northstar:update: Done updating users!');


### PR DESCRIPTION
#### What's this PR do?
- Do what someone did [here](https://stackoverflow.com/questions/9985030/how-does-the-garbage-collector-work-in-php), which is declaring the variable that we create in the `foreach` loop outside of it instead
- Unset `$userToUpdate` each time we loop through

#### How should this be reviewed?
Does this make sense to test? Locally I've been seeing different results than @DFurnes or on QA. This didn't make anything better for me, but neither did @DFurnes changes yesterday that helped in QA and for him.

#### Relevant Tickets
…

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
