### PR TITLE
adds email_frequency to v2 user transformer

### DIFF
--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -51,6 +51,7 @@ class UserTransformer extends TransformerAbstract
             // Subscription status
             $response['sms_status'] = $user->sms_status;
             $response['sms_paused'] = (bool) $user->sms_paused;
+            $response['email_frequency'] = $user->email_frequency;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;


### PR DESCRIPTION
#### What's this PR do?
- adds `email_frequency` to v2 user transformer (already in v1 user transformer from #801). 
  - keeping in v1 user transformer too because I'm unsure if anyone is still using v1 so should probably expose there as well! 

#### How should this be reviewed?
- `email_frequency` should be exposed when hitting `GET v1/users` and `GET v2/users`

#### Relevant Tickets
#801 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
