### PR TITLE
Voter registration status mutator

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -75,6 +75,7 @@ class Registrar
             'sms_paused' => 'boolean',
             'last_messaged_at' => 'date',
             'email_frequency' => 'in:active,none',
+            'voter_registration_status' => 'in:uncertain,ineligible,confirmed,registration_complete',
         ];
 
         // If existing user is provided, merge indexes into the request so

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -464,4 +464,28 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     {
         $this->notify(new ResetPasswordNotification($token));
     }
+
+    /**
+     * Set the voter_registration_status based on the hierarchy.
+     *
+     * @param string $status
+     */
+    public function setVoterRegistrationStatusAttribute($status)
+    {
+        $statusHierarchy = [
+            'uncertain',
+            'ineligible',
+            'confirmed',
+            'registration_complete',
+        ];
+
+        $indexOfCurrentStatus = array_search($this->voter_registration_status, $statusHierarchy);
+        $indexOfNewStatus = array_search($status, $statusHierarchy);
+
+        if ($indexOfCurrentStatus > $indexOfNewStatus) {
+            return;
+        }
+
+        $this->attributes['voter_registration_status'] = $status;
+    }
 }

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -701,7 +701,7 @@ class LegacyUserTest extends BrowserKitTestCase
     {
         $user = User::create([
             'email' => 'votetest@dosomething.org',
-            'voter_registration_status' => 'ineligible'
+            'voter_registration_status' => 'ineligible',
         ]);
 
         // Update to a higher status
@@ -733,7 +733,7 @@ class LegacyUserTest extends BrowserKitTestCase
     {
         $user = User::create([
             'email' => 'votetest@dosomething.org',
-            'voter_registration_status' => 'registration_complete'
+            'voter_registration_status' => 'registration_complete',
         ]);
 
         // Try to update to a lower status


### PR DESCRIPTION
#### What's this PR do?
- Adds a setter for `voter_registration_status` to compare the old status and the new status, and only update to the new status if it is higher up on the voter registration status hierarchy
- Adds 2 tests:
    - One to make sure a user can be updated to a higher status
    - One to make sure that a user cannot be updated to a lower status

#### How should this be reviewed?
These are the values we want to use?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/160807904)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
