### PR TITLE
Cleanup voter reg status registration form a/b test

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -173,9 +173,7 @@ class AuthController extends BaseController
      */
     public function getRegister()
     {
-        $showVoterStatusForm = participate('voter-status-reg-form', ['normal_form', 'voter_form']);
-
-        return view('auth.register', ['voter_reg_status_form' => $showVoterStatusForm]);
+        return view('auth.register');
     }
 
     /**
@@ -187,8 +185,6 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
-        convert('voter-status-reg-form');
-
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',
             'birthdate' => 'required|date|before:now',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -66,32 +66,30 @@
                 <span class="password-visibility__toggle -hide"></span>
             </div>
 
-            @if ($voter_reg_status_form === 'voter_form')
-                <div class="form-item">
-                    <label for="voter_registration_status" class="field-label">{{ "Are you registered to vote at your current address?"}}</label>
-                    <div class="form-item -reduced">
-                        <label class="option -radio">
-                          <input type="radio" name="voter_registration_status" value="confirmed">
-                          <span class="option__indicator"></span>
-                          <span>Yes</span>
-                        </label>
-                    </div>
-                    <div class="form-item -reduced">
-                        <label class="option -radio">
-                          <input type="radio" name="voter_registration_status" value="unregistered">
-                          <span class="option__indicator"></span>
-                          <span>No</span>
-                        </label>
-                    </div>
-                    <div class="form-item -reduced">
-                        <label class="option -radio">
-                          <input type="radio" name="voter_registration_status" value="uncertain">
-                          <span class="option__indicator"></span>
-                          <span>I'm not sure</span>
-                        </label>
-                    </div>
+            <div class="form-item">
+                <label for="voter_registration_status" class="field-label">{{ "Are you registered to vote at your current address?"}}</label>
+                <div class="form-item -reduced">
+                    <label class="option -radio">
+                      <input type="radio" name="voter_registration_status" value="confirmed">
+                      <span class="option__indicator"></span>
+                      <span>Yes</span>
+                    </label>
                 </div>
-            @endif
+                <div class="form-item -reduced">
+                    <label class="option -radio">
+                      <input type="radio" name="voter_registration_status" value="unregistered">
+                      <span class="option__indicator"></span>
+                      <span>No</span>
+                    </label>
+                </div>
+                <div class="form-item -reduced">
+                    <label class="option -radio">
+                      <input type="radio" name="voter_registration_status" value="uncertain">
+                      <span class="option__indicator"></span>
+                      <span>I'm not sure</span>
+                    </label>
+                </div>
+            </div>
 
             <div class="form-actions -padded -left">
                 <input type="submit" id="register-submit" class="button" value="{{ trans('auth.log_in.submit') }}">


### PR DESCRIPTION
#### What's this PR do?
We picked a winner! This will change nothing on prod since we chose the winner in sixpack so everyone was seeing the additional question no matter what. This PR:
- Removes the code that created the test and alternatives
- Removes the code that converts a user
- Removes the conditional that checks if a user got the `voter_form` alternative, we want to always display that question

#### How should this be reviewed?
Do you see the voter reg question on the registration form? Did I miss any remnants of this test?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/158556190)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
