### PR TITLE
Set max-age on cached user profiles.

### DIFF
--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -139,8 +139,9 @@ class UserController extends Controller
         $response = $this->item($user);
 
         if (Auth::guest()) {
+            // If this is an anonymous request, cache in Fastly until it changes.
             $response->headers->set('Surrogate-Key', 'user-'.$user->id);
-            $response->setPublic();
+            $response->setPublic()->setMaxAge(60 * 60 * 24 * 365);
         }
 
         return $response;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -148,8 +148,9 @@ class UserController extends Controller
         $response = $this->item($user);
 
         if (Auth::guest()) {
+            // If this is an anonymous request, cache in Fastly until it changes.
             $response->headers->set('Surrogate-Key', 'user-'.$user->id);
-            $response->setPublic();
+            $response->setPublic()->setMaxAge(60 * 60 * 24 * 365);
         }
 
         return $response;


### PR DESCRIPTION
#### What's this PR do?
This pull request sets a `max-age` of a year when caching user profiles in Fastly (this seems to be [considered a reasonable maximum](https://stackoverflow.com/a/25201898/811624), and is what Glide uses for image responses in Rogue).

#### How should this be reviewed?
Here's an example of the headers set for `v2/users/5bc4bfc5fdce270a29006472` on my local:

```http
Cache-Control: max-age=31536000, public
Surrogate-Key: user-5bc4bfc5fdce270a29006472
```

#### Relevant Tickets
DoSomething/infrastructure#31

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  