### PR TITLE
Runs composer update again

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -60,16 +60,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.75.0",
+            "version": "3.76.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b62357d506a43c1377926d531136e5f1fe824732"
+                "reference": "ae331953146493aa71853b5c675f0b7b48c9c952"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b62357d506a43c1377926d531136e5f1fe824732",
-                "reference": "b62357d506a43c1377926d531136e5f1fe824732",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ae331953146493aa71853b5c675f0b7b48c9c952",
+                "reference": "ae331953146493aa71853b5c675f0b7b48c9c952",
                 "shasum": ""
             },
             "require": {
@@ -139,7 +139,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-11-26T09:00:47+00:00"
+            "time": "2018-11-27T05:14:58+00:00"
         },
         {
             "name": "barryvdh/laravel-cors",


### PR DESCRIPTION
#### What's this PR do?
Runs `composer update` again, with an update from yesterday's that broke QA's login. Maybe this will help? ¯\_(ツ)_/¯

New updates:
![screen shot 2018-11-27 at 10 48 26 am](https://user-images.githubusercontent.com/9019452/49093411-04f12800-f232-11e8-872d-307bfaf85f11.png)

#### How should this be reviewed?
👀 

#### Relevant Tickets
[This](https://www.pivotaltracker.com/n/projects/2019429/stories/161648375) Pivotal Card.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
