### PR TITLE
Discard 'X-Forwarded' and 'X-Forwarded-For' headers.

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -31,10 +31,10 @@ return [
      * Change these if the proxy does not send the default header names.
      */
     'headers' => [
-        \Illuminate\Http\Request::HEADER_FORWARDED    => 'FORWARDED',
-        \Illuminate\Http\Request::HEADER_CLIENT_IP    => 'X_FORWARDED_FOR',
-        \Illuminate\Http\Request::HEADER_CLIENT_HOST  => 'X_FORWARDED_HOST',
-        \Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
-        \Illuminate\Http\Request::HEADER_CLIENT_PORT  => 'X_FORWARDED_PORT',
+        \Illuminate\Http\Request::HEADER_FORWARDED => null, // Not set on AWS or Heroku.
+        \Illuminate\Http\Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
+        \Illuminate\Http\Request::HEADER_X_FORWARDED_HOST => null, // Not set on AWS or Heroku.
+        \Illuminate\Http\Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
+        \Illuminate\Http\Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
     ],
 ];


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Northstar's [TrustedProxy](https://www.github.com/fideloper/TrustedProxy) config to ignore `X-Forwarded` & `X-Forwarded-For` headers, which are not [set by Heroku's load balancer](https://devcenter.heroku.com/articles/getting-started-with-laravel#trusting-the-load-balancer). This addresses [these errors](https://rpm.newrelic.com/accounts/108038/applications/92216128/filterable_errors#/show/d117934c-f6d5-11e8-9f6f-0242ac110007_0_8062/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart) from last night.

#### How should this be reviewed?
Sanity-check that my changes make sense!

#### Relevant Tickets
References [this New Relic Alert & Slack conversation](https://dosomething.slack.com/archives/C02BBP0CU/p1543851697002000?thread_ts=1543821325.001600&cid=C02BBP0CU).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  