### PR TITLE
Import email subscription status from cio

### DIFF
--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -34,8 +34,8 @@ class ImportSubStatusFromCio extends Command
         $query = (new User)->newQuery();
         $query = $query->where('email', 'exists', true);
 
-        $query->chunkById(200, function (Collection $users){
-            $users->each(function (User $user){
+        $query->chunkById(200, function (Collection $users) {
+            $users->each(function (User $user) {
                 $queue = config('queue.names.low');
 
                 dispatch(new GetEmailSubStatusFromCustomerIo($user))->onQueue($queue);

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -59,7 +59,7 @@ class ImportSubStatusFromCio extends Command
 
                     // Do not update this user if they were last updated after the specified date
                     if ($lastUpdated > $date) {
-                        continue;
+                        return false;
                     }
                 }
 

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Console\Commands;
 
-use Carbon\Carbon;
 use Northstar\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
@@ -14,15 +13,14 @@ class ImportSubStatusFromCio extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:importsub
-                            {--beforeDate= : Only pull updates for users whose status was last updated before this date.}';
+    protected $signature = 'northstar:importsub';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Grab email subscription status from Customer.io for users on which it is not already set.';
+    protected $description = 'For each user, kick off a job to grab email subscription status from Customer.io.';
 
     /**
      * Execute the console command.
@@ -31,59 +29,16 @@ class ImportSubStatusFromCio extends Command
      */
     public function handle()
     {
-        $this->line('Starting up...');
-
-        // Create a Guzzle Client to use with the Customer.io Beta API
-        $client = new \GuzzleHttp\Client([
-            'base_uri' => 'https://beta-api.customer.io',
-        ]);
-
-        // Customer.io authentication
-        $auth = [config('services.customerio.username'), config('services.customerio.password')];
-
-        // Create a query to grab users who have email addresses
         $query = (new User)->newQuery();
-        $query = $query->where('email', 'exists', true);
 
-        // See if the --beforeDate option was used and convert it from a string to a date
-        $date = $this->option('beforeDate');
-        $date = new Carbon($date);
+        $query->chunkById(200, function (Collection $users){
+            $users->each(function (User $user){
+                $queue = config('queue.names.backfill');
 
-        // Iterate through all the users and do the things!
-        $query->chunkById(200, function (Collection $users) use ($client, $auth, $date) {
-            $users->each(function (User $user) use ($client, $auth, $date) {
-                if ($date) {
-                    // Grab when the user's subscription status was last updated and convert from a string to a date
-                    $userUpdated = $user->audit['email_frequency']['updated_at']['date'];
-                    $lastUpdated = new Carbon($userUpdated);
-
-                    // Do not update this user if they were last updated after the specified date
-                    if ($lastUpdated > $date) {
-                        return false;
-                    }
-                }
-
-                // Make request to c.io to get that user's subscription status
-                $response = $client->get('/v1/api/customers/'.$user->id.'/attributes', ['auth' => $auth]);
-                $body = json_decode($response->getBody());
-                $unsubscribed = $body->customer->unsubscribed;
-
-                // Update subscription status on user
-                if ($unsubscribed) {
-                    $user->email_frequency = 'none';
-                }
-                if (! $unsubscribed) {
-                    $user->email_frequency = 'active';
-                }
-                $user->save();
-
-                $this->line('Updated user: '.$user->id);
-
-                // Make sure we don't go over 10 requests per second
-                sleep(.1);
+                dispatch(new GetEmailSubStatusFromCustomerIo($user))->onQueue($queue);
             });
         });
 
-        $this->line('Done!');
+        $this->info('Queued up a job to grab email status for each user!');
     }
 }

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -69,7 +69,12 @@ class ImportSubStatusFromCio extends Command
                 $unsubscribed = $body->customer->unsubscribed;
 
                 // Update subscription status on user
-                $user->email_frequency = !$unsubscribed;
+                if ($unsubscribed) {
+                    $user->email_frequency = 'none';
+                }
+                if (! $unsubscribed) {
+                    $user->email_frequency = 'active';
+                }
                 $user->save();
 
                 $this->line('Updated user: '.$user->id);

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -5,6 +5,7 @@ namespace Northstar\Console\Commands;
 use Northstar\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Northstar\Jobs\GetEmailSubStatusFromCustomerIo;
 
 class ImportSubStatusFromCio extends Command
 {
@@ -29,11 +30,13 @@ class ImportSubStatusFromCio extends Command
      */
     public function handle()
     {
+        // Grab users who have email addresses
         $query = (new User)->newQuery();
+        $query = $query->where('email', 'exists', true);
 
         $query->chunkById(200, function (Collection $users){
             $users->each(function (User $user){
-                $queue = config('queue.names.backfill');
+                $queue = config('queue.names.low');
 
                 dispatch(new GetEmailSubStatusFromCustomerIo($user))->onQueue($queue);
             });

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -81,7 +81,6 @@ class ImportSubStatusFromCio extends Command
 
                 // Make sure we don't go over 10 requests per second
                 sleep(.1);
-
             });
         });
 

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -64,7 +64,7 @@ class ImportSubStatusFromCio extends Command
                 }
 
                 // Make request to c.io to get that user's subscription status
-                $response = $client->get('/v1/api/customers/' . $user->id . '/attributes', ['auth' => $auth]);
+                $response = $client->get('/v1/api/customers/'.$user->id.'/attributes', ['auth' => $auth]);
                 $body = json_decode($response->getBody());
                 $unsubscribed = $body->customer->unsubscribed;
 

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class ImportSubStatusFromCio extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:importsub';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Grab email subscription status from Customer.io for users on which it is not already set.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->line('Starting up...');
+
+        // Create a Guzzle Client to use with the Customer.io Beta API
+        $client = new \GuzzleHttp\Client([
+            'base_uri' => 'https://beta-api.customer.io',
+        ]);
+
+        // Customer.io authentication
+        $auth = [config('services.customerio.username'), config('services.customerio.password')];
+
+        $query = (new User)->newQuery();
+        $query = $query->where('email', '!=', null);
+
+        $query->chunkById(200, function (Collection $users) use ($client, $auth) {
+            $users->each(function (User $user) use ($client, $auth) {
+                // Make request to c.io to get that user's subscription status
+                $response = $client->get('/v1/api/customers/' . $user->id . '/attributes', ['auth' => $auth]);
+                $body = json_decode($response->getBody());
+                $unsubscribed = $body->customer->unsubscribed;
+
+                // Update subscription status on user
+                $user->email_frequency = !$unsubscribed;
+                $user->save();
+
+                $this->line('Updated user: '.$user->id);
+
+                // Make sure we don't go over 10 requests per second
+                sleep(.1);
+
+            });
+        });
+
+        $this->line('Done!');
+    }
+}

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -56,5 +56,8 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
         $this->user->save();
 
         info('User '.$this->user->id.' email subscription status grabbed from Customer.io');
+
+        // Make sure we don't go over 10 requests/second
+        throttle(600);
     }
 }

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -62,6 +62,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             info('User '.$this->user->id.' email subscription status grabbed from Customer.io');
         }, function () {
             info('Unable to get email subscription status for '.$this->user->id.' at this time, job pushed back onto queue.');
+
             return $this->release(10);
         });
     }

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Northstar\Jobs;
+
+use Northstar\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class GetEmailSubStatusFromCustomerIo implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The serialized user model.
+     *
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Customer.io authentication
+        $auth = [config('services.customerio.username'), config('services.customerio.password')];
+
+        // Create a Guzzle Client to use with the Customer.io Beta API
+        $client = new \GuzzleHttp\Client([
+            'base_uri' => 'https://beta-api.customer.io',
+            'auth' => $auth,
+        ]);
+
+        // Make request to c.io to get that user's subscription status
+        $response = $client->get('/v1/api/customers/'.$this->user->id.'/attributes');
+        $body = json_decode($response->getBody());
+        $unsubscribed = $body->customer->unsubscribed;
+
+        // Update subscription status on user
+        $this->user->email_frequency = $unsubscribed ? 'none' : 'active';
+        $this->user->save();
+
+        info('User '.$this->user->id.' email subscription status grabbed from Customer.io');
+    }
+}

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -38,9 +38,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
      */
     public function handle()
     {
-        $key = 'GetEmailSubStatusFromCustomerIo-'.$this->user->id;
-
-        Redis::throttle($key)->allow(10)->every(1)->then(function () {
+        Redis::throttle('customerioemailsubstatus')->allow(10)->every(1)->then(function () {
             // Customer.io authentication
             $auth = [config('services.customerio.username'), config('services.customerio.password')];
 


### PR DESCRIPTION
#### What's this PR do?
- Script: The script grabs all of our users who have email addresses, and kicks off a `GetEmailSubStatusFromCustomerIo` job for each user. 
- Job: The `GetEmailSubStatusFromCustomerIo` job is passed one user. The job then grabs that user from [the Customer.io Beta API](https://customer.io/docs/api/#apibeta-apicustomerscustomers_get_attributes) and updates their `email_frequency` to `none` or `active` depending on if they are currently subscribed or not. These jobs will run on the low priority queue so nothing gets clogged up. The jobs are also limited to 10 per second as per the Customer.io Beta API requirements.

We will be able to kick of the script and just sit back as the queue processes through all the `GetEmailSubStatusFromCustomerIo` jobs. No further steps will need to be taken, yay!!! Huge shoutout to @DFurnes for his idea to use queue jobs in this way!!

#### How should this be reviewed?
Is this properly rate-limited? Will we end up having current email subscription status for all users?

#### Relevant Tickets
[Card 1](https://www.pivotaltracker.com/story/show/161428034)
[Card 2](https://www.pivotaltracker.com/story/show/160204038)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
