### PR TITLE
Update Puck Analytics Event Naming

### DIFF
--- a/resources/assets/js/utilities/Puck.js
+++ b/resources/assets/js/utilities/Puck.js
@@ -11,15 +11,15 @@ function init() {
 
   $(document).ready(() => {
     $('.facebook-login').on('click', () => (
-      puck.trackEvent('clicked facebook auth')
+      puck.trackEvent('northstar_clicked_login_facebook')
     ));
 
     $('#register-submit').on('click', () => (
-      puck.trackEvent('clicked register-submit')
+      puck.trackEvent('northstar_submitted_register')
     ));
 
     $('#login-submit').on('click', () => (
-      puck.trackEvent('clicked login-submit')
+      puck.trackEvent('northstar_submitted_login')
     ));
 
     const $validationErrors = $('.validation-error');


### PR DESCRIPTION
#### What's this PR do?
Updates our tracked Puck events to use the [established naming conventions](https://github.com/orgs/DoSomething/teams/tech-leads/discussions/3)

#### How should this be reviewed?
🕶 

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/162418632

(We're currently in the process of a massive analytics overhaul over on Phoenix, which includes updating all the legacy naming to the established conventions.)
