### PR TITLE
Rename `email_frequency` to `email_subscription_status`

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -64,7 +64,7 @@ class Registrar
             'sms_status' => 'in:active,less,stop,undeliverable,unknown,pending',
             'sms_paused' => 'boolean',
             'last_messaged_at' => 'date',
-            'email_frequency' => 'in:active,none',
+            'email_subscription_status' => 'boolean',
             'voter_registration_status' => 'in:uncertain,ineligible,confirmed,registration_complete',
         ];
 

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -49,7 +49,7 @@ class UserTransformer extends TransformerAbstract
             $response['slack_id'] = null;
 
             // Email subscription status
-            $response['email_frequency'] = $user->email_frequency;
+            $response['email_subscription_status'] = $user->email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -57,7 +57,7 @@ class UserTransformer extends TransformerAbstract
             $response['parse_installation_ids'] = $user->parse_installation_ids;
 
             // Email subscription status
-            $response['email_frequency'] = $user->email_frequency;
+            $response['email_subscription_status'] = $user->email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -54,7 +54,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             $unsubscribed = $body->customer->unsubscribed;
 
             // Update subscription status on user
-            $this->user->email_subscription_status = $unsubscribed ? 'none' : 'active';
+            $this->user->email_subscription_status = $unsubscribed ? false : true;
             $this->user->save();
 
             info('User '.$this->user->id.' email subscription status grabbed from Customer.io');

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -54,7 +54,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             $unsubscribed = $body->customer->unsubscribed;
 
             // Update subscription status on user
-            $this->user->email_frequency = $unsubscribed ? 'none' : 'active';
+            $this->user->email_subscription_status = $unsubscribed ? 'none' : 'active';
             $this->user->save();
 
             info('User '.$this->user->id.' email subscription status grabbed from Customer.io');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,7 +51,7 @@ use Northstar\Auth\Role;
  * Messaging subscription status:
  * @property string $sms_status
  * @property bool   $sms_paused
- * @property string $email_frequency
+ * @property string $email_subscription_status
  *
  * Fields for Make a Voting Plan
  * @property string $voting_plan_status
@@ -95,7 +95,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id',
-        'sms_status', 'sms_paused', 'email_frequency', 'last_messaged_at',
+        'sms_status', 'sms_paused', 'email_subscription_status', 'last_messaged_at',
 
         // Voting Plan:
         'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -418,9 +418,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         ];
 
         // Only include email subscription status if we have that information
-        if ($this->email_frequency) {
-            $payload['email_frequency'] = $this->email_frequency;
-            $payload['unsubscribed'] = ($this->email_frequency === 'stop');
+        if ($this->email_subscription_status) {
+            $payload['email_subscription_status'] = $this->email_subscription_status;
+            $payload['unsubscribed'] = (! $this->email_subscription_status);
         }
 
         return $payload;

--- a/database/migrations/2019_01_10_180904_RenameEmailFrequencyToEmailSubscriptionStatus.php
+++ b/database/migrations/2019_01_10_180904_RenameEmailFrequencyToEmailSubscriptionStatus.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameEmailFrequencyToEmailSubscriptionStatus extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->renameField('users', 'email_frequency', 'email_subscription_status');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->renameField('users', 'email_subscription_status', 'email_frequency');
+    }
+
+     /**
+     * Rename the given field on any documents in the collection.
+     *
+     * @param string $collection
+     * @param string $old
+     * @param string $new
+     */
+    public function renameField($collection, $old, $new)
+    {
+        /** @var \Jenssegers\Mongodb\Connection $connection */
+        $connection = app('db')->connection('mongodb');
+
+        $connection->collection($collection)
+            ->whereRaw([$old => ['$exists' => true]])
+            ->update(['$rename' => [$old => $new]]);
+    }
+}

--- a/database/migrations/2019_01_10_180904_RenameEmailFrequencyToEmailSubscriptionStatus.php
+++ b/database/migrations/2019_01_10_180904_RenameEmailFrequencyToEmailSubscriptionStatus.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class RenameEmailFrequencyToEmailSubscriptionStatus extends Migration
@@ -26,7 +24,7 @@ class RenameEmailFrequencyToEmailSubscriptionStatus extends Migration
         $this->renameField('users', 'email_subscription_status', 'email_frequency');
     }
 
-     /**
+    /**
      * Rename the given field on any documents in the collection.
      *
      * @param string $collection


### PR DESCRIPTION
#### What's this PR do?
It's deja vu all over again: https://github.com/DoSomething/northstar/pull/742

✍️ Changes all references to `email_frequency` to `email_subscription_status` instead. We also now expect `email_subscription_status` to be a boolean so there is a validation update and a logic update to reflect that.

🐦 Includes a migration file to update the name of this attribute in the database which uses our existing `renameField` function.

#### How should this be reviewed?
Did I miss any references? Does this migration work as expected?

#### Relevant Tickets
Related to this work: https://www.pivotaltracker.com/story/show/161428034
[Slack discussion](https://dosomething.slack.com/archives/C02BBRN5A/p1547055755030600)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
