### PR TITLE
Update to cast email_subscription_status to a bool

### DIFF
--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -49,7 +49,7 @@ class UserTransformer extends TransformerAbstract
             $response['slack_id'] = null;
 
             // Email subscription status
-            $response['email_subscription_status'] = $user->email_subscription_status;
+            $response['email_subscription_status'] = (bool) $user->email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -57,7 +57,7 @@ class UserTransformer extends TransformerAbstract
             $response['parse_installation_ids'] = $user->parse_installation_ids;
 
             // Email subscription status
-            $response['email_subscription_status'] = $user->email_subscription_status;
+            $response['email_subscription_status'] = (bool) $user->email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,7 +51,7 @@ use Northstar\Auth\Role;
  * Messaging subscription status:
  * @property string $sms_status
  * @property bool   $sms_paused
- * @property string $email_subscription_status
+ * @property bool $email_subscription_status
  *
  * Fields for Make a Voting Plan
  * @property string $voting_plan_status
@@ -166,6 +166,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $casts = [
         'birthdate' => 'date',
         'sms_paused' => 'boolean',
+        'email_subscription_status' => 'boolean',
     ];
 
     /**

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -1,9 +1,10 @@
 # User Endpoints
+
 The `write` scope is required for create/update/delete endpoints.
 
 ## Retrieve All Users
-Get data for all users in a paginated format. This requires the `user` scope and either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
+Get data for all users in a paginated format. This requires the `user` scope and either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```
 GET /v1/users
@@ -11,11 +12,11 @@ GET /v1/users
 
 **Additional Query Parameters:**
 
-- `pagination`: __[Experimental]__ Either "standard" or "cursor". Cursor pagination is _significantly_ faster, but does not provide any information on the total number of results (only whether another page exists).
+- `pagination`: **[Experimental]** Either "standard" or "cursor". Cursor pagination is _significantly_ faster, but does not provide any information on the total number of results (only whether another page exists).
 - `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
-- `before`: Filter the collection to include _only_ users with timestamps before the given date or datetime. For example, `/v1/users?before[created_at]=1/1/2015`. 
-- `after`: Filter the collection to include _only_ users with timestamps after the given date or datetime. For example, `/v1/users?after[created_at]=1/1/2015`. 
+- `before`: Filter the collection to include _only_ users with timestamps before the given date or datetime. For example, `/v1/users?before[created_at]=1/1/2015`.
+- `after`: Filter the collection to include _only_ users with timestamps after the given date or datetime. For example, `/v1/users?after[created_at]=1/1/2015`.
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v1/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.
 - `search`: Search the collection for users with fields whose value match the query. You can search by `id`, `drupal_id`, `email`, and `mobile`. For example, you can search with or without specifying an indexed column: `/v1/users?search[email]=test@example.org` or `v1/users?search=clee@dosomething.org`. Both ways are now supported.
 
@@ -52,7 +53,7 @@ curl -X GET \
             "per_page": 15,
             "current_page": 1,
             "total_pages": 5,
-            "links": {            
+            "links": {
                 "next": "https://northstar.dosomething.org/v1/users?page=2",
             }
         ]
@@ -103,6 +104,7 @@ curl -X GET \
 </details>
 
 ## Create a User
+
 Create a new user. This is performed as an "[upsert](https://docs.mongodb.org/v2.6/reference/glossary/#term-upsert)" by default,
 so if a user with a matching identifier is found, new/changed properties will be merged into the existing document. This means
 making the same request multiple times will _not_ create duplicate accounts.
@@ -120,56 +122,57 @@ POST /v1/users
 **Request Parameters:**
 
 Either a mobile number or email is required.
+
 ```js
 // Content-Type: application/json
 
 {
   // Required if 'mobile' or 'facebook_id' is not provided
-  email: String
+  email: String;
 
   // Required if 'email' or 'facebook_id' is not provided
-  mobile: String
+  mobile: String;
 
   // Required if 'email' or 'mobile' is not provided
-  facebook_id: Number
+  facebook_id: Number;
 
   // Optional, but required for user to be able to log in!
-  password: String
+  password: String;
 
   // Optional:
-  birthdate: Date
-  first_name: String
-  last_name: String
-  addr_street1: String
-  addr_street2: String
-  addr_city: String
-  addr_state: String
-  addr_zip: String
-  country: String // two character country code
-  language: String
-  agg_id: Number
-  cgg_id: Number
-  drupal_id: String
-  slack_id: String
-  parse_installation_ids: String // CSV values or array will be appended to existing interests
-  interests: String, Array // CSV values or array will be appended to existing interests
-  sms_status: String // Either 'active', 'stop', 'less', 'undeliverable', 'pending', or 'unknown'
-  sms_paused: Boolean // Whether a user is in a support conversation.
-  source: String // Immutable. Will only be set on new records.
-  source_detail: String // Only accepted alongside a valid 'source'.
-  created_at: Number // timestamp
+  birthdate: Date;
+  first_name: String;
+  last_name: String;
+  addr_street1: String;
+  addr_street2: String;
+  addr_city: String;
+  addr_state: String;
+  addr_zip: String;
+  country: String; // two character country code
+  language: String;
+  agg_id: Number;
+  cgg_id: Number;
+  drupal_id: String;
+  slack_id: String;
+  parse_installation_ids: String; // CSV values or array will be appended to existing interests
+  interests: String, Array; // CSV values or array will be appended to existing interests
+  sms_status: String; // Either 'active', 'stop', 'less', 'undeliverable', 'pending', or 'unknown'
+  sms_paused: Boolean; // Whether a user is in a support conversation.
+  source: String; // Immutable. Will only be set on new records.
+  source_detail: String; // Only accepted alongside a valid 'source'.
+  created_at: Number; // timestamp
 
   // Hidden fields (optional):
-  race: String
-  religion: String
-  college_name: String
-  degree_type: String
-  major_name: String
-  hs_gradyear: String
-  hs_name: String
-  sat_math: Number
-  sat_verbal: Number
-  sat_writing: Number
+  race: String;
+  religion: String;
+  college_name: String;
+  degree_type: String;
+  major_name: String;
+  hs_gradyear: String;
+  hs_name: String;
+  sat_math: Number;
+  sat_verbal: Number;
+  sat_writing: Number;
 }
 ```
 
@@ -218,6 +221,7 @@ curl -X POST \
 </details>
 
 ## Retrieve a User
+
 Get profile data for a specific user. This can be retrieved with either the user's Northstar ID (which is automatically
 generated when a new database record is created), a mobile phone number, an email address, a Facebook ID or the user's Drupal ID.
 
@@ -274,6 +278,7 @@ curl -X GET \
 </details>
 
 ## Update a User
+
 Update a user resource. This can be retrieved with the user's Northstar ID or the source ID (`drupal_id`). This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```
@@ -287,41 +292,42 @@ PUT /v1/users/drupal_id/<drupal_id>
 // Content-Type: application/json
 
 {
-  email: String
-  mobile: String
-  facebook_id: Number
-  password: String
-  birthdate: Date
-  first_name: String
-  last_name: String
-  addr_street1: String
-  addr_street2: String
-  addr_city: String
-  addr_state: String
-  addr_zip: String
-  country: String // two character country code
-  language: String
-  agg_id: Number
-  cgg_id: Number
-  drupal_id: String
-  slack_id: String
-  parse_installation_ids: String // CSV values or array will be appended to existing interests
-  interests: String, Array // CSV values or array will be appended to existing interests
-  role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
-  sms_status: String // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
-  sms_paused: Boolean // Whether a user is in a support conversation.
+  email: String;
+  mobile: String;
+  facebook_id: Number;
+  password: String;
+  birthdate: Date;
+  first_name: String;
+  last_name: String;
+  addr_street1: String;
+  addr_street2: String;
+  addr_city: String;
+  addr_state: String;
+  addr_zip: String;
+  country: String; // two character country code
+  language: String;
+  agg_id: Number;
+  cgg_id: Number;
+  drupal_id: String;
+  slack_id: String;
+  parse_installation_ids: String; // CSV values or array will be appended to existing interests
+  interests: String, Array; // CSV values or array will be appended to existing interests
+  role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
+  sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
+  sms_paused: Boolean; // Whether a user is in a support conversation.
+  email_subscription_status: Boolean; // Whether a user can recieve emails or not.
 
   // Hidden fields (optional):
-  race: String
-  religion: String
-  college_name: String
-  degree_type: String
-  major_name: String
-  hs_gradyear: String
-  hs_name: String
-  sat_math: Number
-  sat_verbal: Number
-  sat_writing: Number
+  race: String;
+  religion: String;
+  college_name: String;
+  degree_type: String;
+  major_name: String;
+  hs_gradyear: String;
+  hs_name: String;
+  sat_math: Number;
+  sat_verbal: Number;
+  sat_writing: Number;
 }
 ```
 
@@ -355,6 +361,7 @@ curl -X PUT \
 </details>
 
 ## Delete a User
+
 Destroy a user resource. The `user_id` property of the user to delete must be provided in the URL path, and refers to the user's Northstar ID. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```
@@ -389,9 +396,10 @@ curl -X DELETE \
 </details>
 
 ## Merge User Accounts
+
 Merge two user accounts. The `id` of the "target" user must be provided in the URL path, and the "duplicate" ID should be provided in the body. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
-:warning: __[Experimental]__ This is an experimental endpoint and isn't thoroughly tested.
+:warning: **[Experimental]** This is an experimental endpoint and isn't thoroughly tested.
 
 ```
 POST /v1/users/:user_id/merge
@@ -402,13 +410,14 @@ POST /v1/users/:user_id/merge
 - `pretend`: Return the result of merging the given accounts, but do not save.
 
 **Request Parameters:**
+
 ```js
 // Content-Type: application/json
 // Accept: application/json
 
 {
   /* Required, duplicate account */
-  id: String
+  id: String;
 }
 ```
 

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -1,7 +1,8 @@
 # User Endpoints
-## Retrieve All Users
-Get data for all users in a paginated format. This requires the `user` scope and either the `admin` scope, or "admin" or "staff" role with the appropriate scope. The `write` scope is required for create/update/delete endpoints.
 
+## Retrieve All Users
+
+Get data for all users in a paginated format. This requires the `user` scope and either the `admin` scope, or "admin" or "staff" role with the appropriate scope. The `write` scope is required for create/update/delete endpoints.
 
 ```
 GET /v2/users
@@ -9,11 +10,11 @@ GET /v2/users
 
 **Additional Query Parameters:**
 
-- `pagination`: __[Experimental]__ Either "standard" or "cursor". Cursor pagination is _significantly_ faster, but does not provide any information on the total number of results (only whether another page exists).
+- `pagination`: **[Experimental]** Either "standard" or "cursor". Cursor pagination is _significantly_ faster, but does not provide any information on the total number of results (only whether another page exists).
 - `limit`: Set the number of results to include per page. Default is 20. Maximum is 100.
 - `page`: Set the page number to get results from.
-- `before`: Filter the collection to include _only_ users with timestamps before the given date or datetime. For example, `/v2/users?before[created_at]=1/1/2015`. 
-- `after`: Filter the collection to include _only_ users with timestamps after the given date or datetime. For example, `/v2/users?after[created_at]=1/1/2015`. 
+- `before`: Filter the collection to include _only_ users with timestamps before the given date or datetime. For example, `/v2/users?before[created_at]=1/1/2015`.
+- `after`: Filter the collection to include _only_ users with timestamps after the given date or datetime. For example, `/v2/users?after[created_at]=1/1/2015`.
 - `filter`: Filter the collection to include _only_ users matching the following comma-separated values. For example, `/v2/users?filter[drupal_id]=10123,10124,10125` would return users whose Drupal ID is either 10123, 10124, or 10125. You can filter by one or more indexed fields.
 - `search`: Search the collection for users with fields whose value match the query. You can search by `id`, `drupal_id`, `email`, and `mobile`. For example, you can search with or without specifying an indexed column: `/v2/users?search[email]=test@example.org` or `v2/users?search=clee@dosomething.org`. Both ways are now supported.
 
@@ -50,7 +51,7 @@ curl -X GET \
             "per_page": 15,
             "current_page": 1,
             "total_pages": 5,
-            "links": {            
+            "links": {
                 "next": "https://northstar.dosomething.org/v2/users?page=2",
             }
         ]
@@ -101,7 +102,8 @@ curl -X GET \
 </details>
 
 ## Create a User
-Create a new user. If a user already exists, an exception error (`A record matching one of the given indexes already exists.` will be returned) and will not create a duplicate account. 
+
+Create a new user. If a user already exists, an exception error (`A record matching one of the given indexes already exists.` will be returned) and will not create a duplicate account.
 
 An "[upsert](https://docs.mongodb.org/v2.6/reference/glossary/#term-upsert)" will only occur if using the `upsert=true` param. If this is present and a user with a matching identifier is found, new/changed properties will be merged into the existing document. This means
 making the same request multiple times will _not_ create duplicate accounts.
@@ -119,54 +121,56 @@ POST /v2/users
 **Request Parameters:**
 
 Either a mobile number or email is required.
+
 ```js
 // Content-Type: application/json
 
 {
   // Required if 'mobile' or 'facebook_id' is not provided
-  email: String
+  email: String;
 
   // Required if 'email' or 'facebook_id' is not provided
-  mobile: String
+  mobile: String;
 
   // Required if 'email' or 'mobile' is not provided
-  facebook_id: Number
+  facebook_id: Number;
 
   // Optional, but required for user to be able to log in!
-  password: String
+  password: String;
 
   // Optional:
-  birthdate: Date
-  first_name: String
-  last_name: String
-  addr_street1: String
-  addr_street2: String
-  addr_city: String
-  addr_state: String
-  addr_zip: String
-  country: String // two character country code
-  language: String
-  agg_id: Number
-  cgg_id: Number
-  slack_id: String
-  interests: String, Array // CSV values or array will be appended to existing interests
-  sms_status: String // Either 'active', 'stop', 'less', 'undeliverable', 'pending', or 'unknown'
-  sms_paused: Boolean // Whether a user is in a support conversation.
-  source: String // Immutable. Will only be set on new records.
-  source_detail: String // Only accepted alongside a valid 'source'.
-  created_at: Number // timestamp
+  birthdate: Date;
+  first_name: String;
+  last_name: String;
+  addr_street1: String;
+  addr_street2: String;
+  addr_city: String;
+  addr_state: String;
+  addr_zip: String;
+  country: String; // two character country code
+  language: String;
+  agg_id: Number;
+  cgg_id: Number;
+  slack_id: String;
+  interests: String, Array; // CSV values or array will be appended to existing interests
+  sms_status: String; // Either 'active', 'stop', 'less', 'undeliverable', 'pending', or 'unknown'
+  sms_paused: Boolean; // Whether a user is in a support conversation.
+  email_subscription_status: Boolean; // Whether a user can recieve emails or not.
+  source: String; // Immutable. Will only be set on new records.
+  source_detail: String; // Only accepted alongside a valid 'source'.
+  created_at: Number; // timestamp
 
   // Hidden fields (optional):
-  race: String
-  religion: String
-  college_name: String
-  degree_type: String
-  major_name: String
-  hs_gradyear: String
-  hs_name: String
-  sat_math: Number
-  sat_verbal: Number
-  sat_writing: Number
+  race: String;
+  religion: String;
+  college_name: String;
+  degree_type: String;
+  major_name: String;
+  hs_gradyear: String;
+  hs_name: String;
+  sat_math: Number;
+  sat_verbal: Number;
+  sat_writing: Number;
 }
 ```
 
@@ -214,6 +218,7 @@ curl -X POST \
 </details>
 
 ## Retrieve a User
+
 Get profile data for a specific user by the user's Northstar ID.
 
 Fetching a user requires either the `admin` scope, or an "admin" or "staff" role with the appropriate scope.
@@ -262,6 +267,7 @@ curl -X GET \
 ```
 
 ## Retrieve a User By Mobile
+
 Get profile data for a specific user by the user's mobile number.
 
 Fetching a user requires either the `admin` scope, or an "admin" or "staff" role with the appropriate scope.
@@ -309,6 +315,7 @@ curl -X GET \
 ```
 
 ## Retrieve a User By Email
+
 Get profile data for a specific user by the user's email address.
 
 Fetching a user requires either the `admin` scope, or an "admin" or "staff" role with the appropriate scope.
@@ -358,6 +365,7 @@ curl -X GET \
 </details>
 
 ## Update a User
+
 Update a user resource, retrieved with the user's Northstar ID. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```
@@ -370,39 +378,39 @@ PUT /v2/users/:user_id
 // Content-Type: application/json
 
 {
-  email: String
-  mobile: String
-  facebook_id: Number
-  password: String
-  birthdate: Date
-  first_name: String
-  last_name: String
-  addr_street1: String
-  addr_street2: String
-  addr_city: String
-  addr_state: String
-  addr_zip: String
-  country: String // two character country code
-  language: String
-  agg_id: Number
-  cgg_id: Number
-  slack_id: String
-  interests: String, Array // CSV values or array will be appended to existing interests
-  role: String // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
-  sms_status: String // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
-  sms_paused: Boolean // Whether a user is in a support conversation.
+  email: String;
+  mobile: String;
+  facebook_id: Number;
+  password: String;
+  birthdate: Date;
+  first_name: String;
+  last_name: String;
+  addr_street1: String;
+  addr_street2: String;
+  addr_city: String;
+  addr_state: String;
+  addr_zip: String;
+  country: String; // two character country code
+  language: String;
+  agg_id: Number;
+  cgg_id: Number;
+  slack_id: String;
+  interests: String, Array; // CSV values or array will be appended to existing interests
+  role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
+  sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
+  sms_paused: Boolean; // Whether a user is in a support conversation.
 
   // Hidden fields (optional):
-  race: String
-  religion: String
-  college_name: String
-  degree_type: String
-  major_name: String
-  hs_gradyear: String
-  hs_name: String
-  sat_math: Number
-  sat_verbal: Number
-  sat_writing: Number
+  race: String;
+  religion: String;
+  college_name: String;
+  degree_type: String;
+  major_name: String;
+  hs_gradyear: String;
+  hs_name: String;
+  sat_math: Number;
+  sat_verbal: Number;
+  sat_writing: Number;
 }
 ```
 
@@ -436,6 +444,7 @@ curl -X PUT \
 </details>
 
 ## Delete a User
+
 Destroy a user resource. The `user_id` property of the user to delete must be provided in the URL path, and refers to the user's Northstar ID. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
 ```


### PR DESCRIPTION
#### What's this PR do?
1️⃣ Some updates so that `email_subscription_status` is always returned as a boolean.

✍️ Updates to the docs to add `email_subscription_status`. When I saved the documentation files a whole bunch of other updates happened automatically.

#### How should this be reviewed?
Will this accept and return boolean values only for `email_subscription_status`? Do the docs look okay?

#### Relevant Tickets
None!

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
