### PR TITLE
Update nav bar to link to Phoenix not Ashes

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -4,13 +4,13 @@
     <div class="navigation__menu">
         <ul class="navigation__primary">
             <li>
-                <a href="{{ config('services.drupal.url') }}/campaigns">
+                <a href="{{ config('services.phoenix.url') }}/campaigns">
                   <strong class="navigation__title">Explore Campaigns</strong>
                   <span class="navigation__subtitle">Find ways to take action both online and off.</span>
                 </a>
             </li>
             <li>
-                <a href="{{ config('services.drupal.url') }}/about/who-we-are">
+                <a href="{{ config('services.phoenix.url') }}/about/who-we-are">
                   <strong class="navigation__title">What Is DoSomething.org?</strong>
                   <span class="navigation__subtitle">A global movement for good. </span>
                 </a>


### PR DESCRIPTION
#### What's this PR do?
Fixes these links:

![image](https://user-images.githubusercontent.com/4240292/52002618-59ee2c00-2477-11e9-929e-4820a31d43ea.png)

Which were trying to link to `services.drupal.url` which doesn't exist anymore! Update those links to reference `services.phoenix.url`.

#### How should this be reviewed?
Do the links work now and send to the right pages?

#### Relevant Tickets
[Slack](https://dosomething.slack.com/archives/C02BBRN5A/p1548867070120600) - this was super quick so I decided to just fix it cc: @mendelB 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
