### PR TITLE
Web registrations should be subscribed to email messaging.

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -210,6 +210,9 @@ class AuthController extends BaseController
             // Set language based on locale (either 'en', 'es-mx')
             $user->language = app()->getLocale();
 
+            // Sign the user up for email messaging.
+            $user->email_subscription_status = true;
+
             // Set sms_status, if applicable
             if ($user->mobile) {
                 $user->sms_status = 'active';

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -187,6 +187,9 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         $this->assertEquals('US', $user->country);
         $this->assertEquals('en', $user->language);
+
+        // The user should be signed up for email messaging.
+        $this->assertEquals(true, $user->email_subscription_status);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Northstar so that new web registrations have their `email_subscription_status` field checked. This opts them into messaging with the ✨ source of truth ✨ being Northstar, rather than Customer.io!

#### How should this be reviewed?
👀 

#### Relevant Tickets
References [#160204056](https://www.pivotaltracker.com/story/show/160204056)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  