### PR TITLE
Set `source_detail` based on traffic source

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -84,6 +84,7 @@ class AuthController extends BaseController
                 'title' => request()->query('title', trans('auth.get_started.create_account')),
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
+                'trafficSource' => request()->query('trafficSource'),
             ]);
 
             return redirect()->guest($authorizationRoute);
@@ -213,6 +214,12 @@ class AuthController extends BaseController
             // Set sms_status, if applicable
             if ($user->mobile) {
                 $user->sms_status = 'active';
+            }
+
+            // Set the traffic source as the `source_detail` if provided
+            $trafficSource = session()->pull('trafficSource');
+            if ($trafficSource) {
+                $user->source_detail = $trafficSource;
             }
         });
 


### PR DESCRIPTION
#### What's this PR do?

[Phoenix now sends `trafficSource`](https://github.com/DoSomething/phoenix-next/pull/1245) when it redirects to the registration page. This update is to grab that value and save it as `source_detail`.

#### How should this be reviewed?
Is this how we want to save this value?

#### Relevant Tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/163123198)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
