### PR TITLE
Prefix source_detail from utm_medium with `utm_medium:`

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -222,7 +222,7 @@ class AuthController extends BaseController
             // Set the traffic source as the `source_detail` if provided
             $trafficSource = session()->pull('trafficSource');
             if ($trafficSource) {
-                $user->source_detail = $trafficSource;
+                $user->source_detail = 'utm_medium:'.$trafficSource;
             }
         });
 


### PR DESCRIPTION
#### What's this PR do?

⏮ When we save a `source_detail` from `utm_medium:` we're going to prefix it so that it's saved as `source_detail:"utm_medium:testtesttest"`. We do this with some of the other `source_detail` values and it seems like a good way to not end up confused later.

#### How should this be reviewed?
Does this follow the convention used elsewhere?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/163123198)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
