### PR TITLE
Adds more logging to job that pulls email subscription status from Customer.io

### DIFF
--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -52,7 +52,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             $response = $client->get('/v1/api/customers/'.$this->user->id.'/attributes');
             $body = json_decode($response->getBody());
             $unsubscribed = $body->customer->unsubscribed;
-            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got unsubscribed='.$unsubscribed);
+            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got subscribed='.!$unsubscribed);
 
             // Update subscription status on user
             $this->user->email_subscription_status = $unsubscribed ? false : true;

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -52,7 +52,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             $response = $client->get('/v1/api/customers/'.$this->user->id.'/attributes');
             $body = json_decode($response->getBody());
             $unsubscribed = $body->customer->unsubscribed;
-            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got subscribed='.!$unsubscribed);
+            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got subscribed='.! $unsubscribed);
 
             // Update subscription status on user
             $this->user->email_subscription_status = $unsubscribed ? false : true;

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -52,7 +52,7 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             $response = $client->get('/v1/api/customers/'.$this->user->id.'/attributes');
             $body = json_decode($response->getBody());
             $unsubscribed = $body->customer->unsubscribed;
-            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got subscribed='.! $unsubscribed);
+            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got unsubscribed='.$unsubscribed);
 
             // Update subscription status on user
             $this->user->email_subscription_status = $unsubscribed ? false : true;

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -52,12 +52,12 @@ class GetEmailSubStatusFromCustomerIo implements ShouldQueue
             $response = $client->get('/v1/api/customers/'.$this->user->id.'/attributes');
             $body = json_decode($response->getBody());
             $unsubscribed = $body->customer->unsubscribed;
+            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' got unsubscribed='.$unsubscribed);
 
             // Update subscription status on user
             $this->user->email_subscription_status = $unsubscribed ? false : true;
             $this->user->save();
-
-            info('User '.$this->user->id.' email subscription status grabbed from Customer.io');
+            info('[GetEmailSubStatusFromCustomerIo] For user '.$this->user->id.' set email_subscription_status='.$this->user->email_subscription_status);
         }, function () {
             info('Unable to get email subscription status for '.$this->user->id.' at this time, job pushed back onto queue.');
 


### PR DESCRIPTION
#### What's this PR do?

🍭 Adds a log of what we got when we pulled `unsubscribed` from c.io, except we log the opposite value so it is taken out of double negative land. Also adds what we set as `email_subscription_status`. These two values should be the same.

#### How should this be reviewed?
Should we log `unsubscribed` as it is and not flip it?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/163562051)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
