### PR TITLE
Add email subscription type attributes to users

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -65,10 +65,7 @@ class Registrar
             'sms_paused' => 'boolean',
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
-            'news_email_subscription_status' => 'boolean',
-            'lifestyle_email_subscription_status' => 'boolean',
-            'action_email_subscription_status' => 'boolean',
-            'scholarship_email_subscription_status'  => 'boolean',
+            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,actions',
             'voter_registration_status' => 'in:uncertain,ineligible,confirmed,registration_complete',
         ];
 

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -65,6 +65,10 @@ class Registrar
             'sms_paused' => 'boolean',
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
+            'news_email_subscription_status' => 'boolean',
+            'lifestyle_email_subscription_status' => 'boolean',
+            'action_email_subscription_status' => 'boolean',
+            'scholarship_email_subscription_status'  => 'boolean',
             'voter_registration_status' => 'in:uncertain,ineligible,confirmed,registration_complete',
         ];
 

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -53,7 +53,7 @@ class UserTransformer extends TransformerAbstract
             $response['news_email_subscription_status'] = (bool) $user->news_email_subscription_status;
             $response['lifestyle_email_subscription_status'] = (bool) $user->lifestyle_email_subscription_status;
             $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
-            $response['scholarship_email_subscription_status']  = (bool) $user->scholarship_email_subscription_status;
+            $response['scholarship_email_subscription_status'] = (bool) $user->scholarship_email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -55,7 +55,6 @@ class UserTransformer extends TransformerAbstract
             $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
             $response['scholarship_email_subscription_status']  = (bool) $user->scholarship_email_subscription_status;
 
-
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;
 

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -48,8 +48,13 @@ class UserTransformer extends TransformerAbstract
             // Internal & third-party service IDs:
             $response['slack_id'] = null;
 
-            // Email subscription status
+            // Email subscription statuses
             $response['email_subscription_status'] = (bool) $user->email_subscription_status;
+            $response['news_email_subscription_status'] = (bool) $user->news_email_subscription_status;
+            $response['lifestyle_email_subscription_status'] = (bool) $user->lifestyle_email_subscription_status;
+            $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
+            $response['scholarship_email_subscription_status']  = (bool) $user->scholarship_email_subscription_status;
+
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -50,10 +50,7 @@ class UserTransformer extends TransformerAbstract
 
             // Email subscription statuses
             $response['email_subscription_status'] = (bool) $user->email_subscription_status;
-            $response['news_email_subscription_status'] = (bool) $user->news_email_subscription_status;
-            $response['lifestyle_email_subscription_status'] = (bool) $user->lifestyle_email_subscription_status;
-            $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
-            $response['scholarship_email_subscription_status'] = (bool) $user->scholarship_email_subscription_status;
+            $response['email_subscription_topics'] = $user->email_subscription_topics;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -56,8 +56,12 @@ class UserTransformer extends TransformerAbstract
             $response['mobilecommons_status'] = $user->sms_status; // @DEPRECATED: Will be removed.
             $response['parse_installation_ids'] = $user->parse_installation_ids;
 
-            // Email subscription status
+            // Email subscription statuses
             $response['email_subscription_status'] = (bool) $user->email_subscription_status;
+            $response['news_email_subscription_status'] = (bool) $user->news_email_subscription_status;
+            $response['lifestyle_email_subscription_status'] = (bool) $user->lifestyle_email_subscription_status;
+            $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
+            $response['scholarship_email_subscription_status']  = (bool) $user->scholarship_email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -61,7 +61,7 @@ class UserTransformer extends TransformerAbstract
             $response['news_email_subscription_status'] = (bool) $user->news_email_subscription_status;
             $response['lifestyle_email_subscription_status'] = (bool) $user->lifestyle_email_subscription_status;
             $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
-            $response['scholarship_email_subscription_status']  = (bool) $user->scholarship_email_subscription_status;
+            $response['scholarship_email_subscription_status'] = (bool) $user->scholarship_email_subscription_status;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -58,10 +58,7 @@ class UserTransformer extends TransformerAbstract
 
             // Email subscription statuses
             $response['email_subscription_status'] = (bool) $user->email_subscription_status;
-            $response['news_email_subscription_status'] = (bool) $user->news_email_subscription_status;
-            $response['lifestyle_email_subscription_status'] = (bool) $user->lifestyle_email_subscription_status;
-            $response['action_email_subscription_status'] = (bool) $user->action_email_subscription_status;
-            $response['scholarship_email_subscription_status'] = (bool) $user->scholarship_email_subscription_status;
+            $response['email_subscription_topics'] = $user->email_subscription_topics;
 
             // Voter registration status
             $response['voter_registration_status'] = $user->voter_registration_status;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,6 +52,11 @@ use Northstar\Auth\Role;
  * @property string $sms_status
  * @property bool   $sms_paused
  * @property bool $email_subscription_status
+ * @property bool $news_email_subscription_status
+ * @property bool $lifestyle_email_subscription_status
+ * @property bool $action_email_subscription_status
+ * @property bool $scholarship_email_subscription_status
+ *
  *
  * Fields for Make a Voting Plan
  * @property string $voting_plan_status
@@ -95,7 +100,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id',
-        'sms_status', 'sms_paused', 'email_subscription_status', 'last_messaged_at',
+        'sms_status', 'sms_paused', 'email_subscription_status',  'news_email_subscription_status', 'lifestyle_email_subscription_status', 'action_email_subscription_status', 'scholarship_email_subscription_status', 'last_messaged_at',
 
         // Voting Plan:
         'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',
@@ -167,6 +172,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'birthdate' => 'date',
         'sms_paused' => 'boolean',
         'email_subscription_status' => 'boolean',
+        'news_email_subscription_status' => 'boolean',
+        'lifestyle_email_subscription_status' => 'boolean',
+        'action_email_subscription_status' => 'boolean',
+        'scholarship_email_subscription_status'  => 'boolean',
     ];
 
     /**
@@ -416,6 +425,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'voting_plan_method_of_transport' => $this->voting_plan_method_of_transport,
             'voting_plan_time_of_day' => $this->voting_plan_time_of_day,
             'voting_plan_attending_with' => $this->voting_plan_attending_with,
+            'news_email_subscription_status' => $this->news_email_subscription_status,
+            'lifestyle_email_subscription_status' => $this->lifestyle_email_subscription_status,
+            'action_email_subscription_status' => $this->action_email_subscription_status,
+            'scholarship_email_subscription_status' => $this->scholarship_email_subscription_status,
         ];
 
         // Only include email subscription status if we have that information

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,10 +52,7 @@ use Northstar\Auth\Role;
  * @property string $sms_status
  * @property bool   $sms_paused
  * @property bool $email_subscription_status
- * @property bool $news_email_subscription_status
- * @property bool $lifestyle_email_subscription_status
- * @property bool $action_email_subscription_status
- * @property bool $scholarship_email_subscription_status
+ * @property array $email_subscription_topics
  *
  *
  * Fields for Make a Voting Plan
@@ -100,7 +97,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id',
-        'sms_status', 'sms_paused', 'email_subscription_status',  'news_email_subscription_status', 'lifestyle_email_subscription_status', 'action_email_subscription_status', 'scholarship_email_subscription_status', 'last_messaged_at',
+        'sms_status', 'sms_paused', 'email_subscription_status', 'email_subscription_topics', 'last_messaged_at',
 
         // Voting Plan:
         'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',
@@ -172,10 +169,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'birthdate' => 'date',
         'sms_paused' => 'boolean',
         'email_subscription_status' => 'boolean',
-        'news_email_subscription_status' => 'boolean',
-        'lifestyle_email_subscription_status' => 'boolean',
-        'action_email_subscription_status' => 'boolean',
-        'scholarship_email_subscription_status'  => 'boolean',
     ];
 
     /**
@@ -425,10 +418,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'voting_plan_method_of_transport' => $this->voting_plan_method_of_transport,
             'voting_plan_time_of_day' => $this->voting_plan_time_of_day,
             'voting_plan_attending_with' => $this->voting_plan_attending_with,
-            'news_email_subscription_status' => $this->news_email_subscription_status,
-            'lifestyle_email_subscription_status' => $this->lifestyle_email_subscription_status,
-            'action_email_subscription_status' => $this->action_email_subscription_status,
-            'scholarship_email_subscription_status' => $this->scholarship_email_subscription_status,
+            'news_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('news', $this->email_subscription_topics) : false,
+            'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
+            'action_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('actions', $this->email_subscription_topics) : false,
+            'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
         ];
 
         // Only include email subscription status if we have that information

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -27,7 +27,7 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'country' => $faker->countryCode,
         'language' => $faker->languageCode,
         'source' => 'factory',
-        'email_subscription_topics' => $faker->randomElements(['news', 'lifestyle', 'actions', 'scholarships'], $faker->numberBetween(0, 3)),
+        'email_subscription_topics' => $faker->randomElements(['news', 'lifestyle', 'actions', 'scholarships'], $faker->numberBetween(0, 4)),
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -27,6 +27,7 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'country' => $faker->countryCode,
         'language' => $faker->languageCode,
         'source' => 'factory',
+        'email_subscription_topics' => $faker->randomElements(['news', 'lifestyle', 'actions', 'scholarships'], $faker->numberBetween(0, 3)),
     ];
 });
 

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -42,6 +42,10 @@ class UserModelTest extends BrowserKitTestCase
             'voting_plan_method_of_transport' => null,
             'voting_plan_time_of_day' => null,
             'voting_plan_attending_with' => null,
+            'news_email_subscription_status' => null,
+            'lifestyle_email_subscription_status' => null,
+            'action_email_subscription_status' => null,
+            'scholarship_email_subscription_status' => null,
         ]);
     }
 

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -42,10 +42,10 @@ class UserModelTest extends BrowserKitTestCase
             'voting_plan_method_of_transport' => null,
             'voting_plan_time_of_day' => null,
             'voting_plan_attending_with' => null,
-            'news_email_subscription_status' => null,
-            'lifestyle_email_subscription_status' => null,
-            'action_email_subscription_status' => null,
-            'scholarship_email_subscription_status' => null,
+            'news_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('news', $this->email_subscription_topics) : false,
+            'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
+            'action_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('actions', $this->email_subscription_topics) : false,
+            'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
         ]);
     }
 

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -42,10 +42,10 @@ class UserModelTest extends BrowserKitTestCase
             'voting_plan_method_of_transport' => null,
             'voting_plan_time_of_day' => null,
             'voting_plan_attending_with' => null,
-            'news_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('news', $this->email_subscription_topics) : false,
-            'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
-            'action_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('actions', $this->email_subscription_topics) : false,
-            'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
+            'news_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('news', $user->email_subscription_topics) : false,
+            'lifestyle_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('lifestyle', $user->email_subscription_topics) : false,
+            'action_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('actions', $user->email_subscription_topics) : false,
+            'scholarship_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('scholarships', $user->email_subscription_topics) : false,
         ]);
     }
 


### PR DESCRIPTION
#### What's this PR do?

🔍 Added four new subscription type fields: 
- `news_email_subscription_status`
- `lifestyle_email_subscription_status`
- `action_email_subscription_status`
- `scholarship_email_subscription_status`

🍹 Validates that these fields are `boolean`.

📨 Included these fields in `v1` and `v2` user transformers, with the values cast as booleans.

🗄 Added these fields to the `fillable` array on users.

🎣 Cast these fields as `boolean`.

#### How should this be reviewed?
How are the names? Should I include any tests?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/163779556)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
