### PR TITLE
Experimental: Add support for implicit grant.

### DIFF
--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -55,6 +55,12 @@ class ClientRepository implements ClientRepositoryInterface
             return in_array($client->allowed_grant, ['password', 'authorization_code']);
         }
 
+        // HACK: For now, treat implicit grant as 'auth code' grant so that
+        // we don't need to do a bunch of extra work for an experiment.
+        if ($grantType === 'implicit') {
+            $grantType = 'authorization_code';
+        }
+
         // Otherwise, the client must always match the grant being used.
         return $client->allowed_grant === $grantType;
     }

--- a/app/Http/Controllers/DiscoveryController.php
+++ b/app/Http/Controllers/DiscoveryController.php
@@ -21,6 +21,8 @@ class DiscoveryController extends Controller
             'token_endpoint' => url($url.'/v2/auth/token'),
             'userinfo_endpoint' => url($url.'/v2/userinfo'),
             'jwks_uri' => url($url.'/v2/keys'),
+            'end_session_endpoint' => url($url.'/logout'),
+
 
             'response_types_supported' => ['code'],
             'subject_types_supported' => ['public'],

--- a/app/Providers/OAuthServiceProvider.php
+++ b/app/Providers/OAuthServiceProvider.php
@@ -12,6 +12,7 @@ use League\OAuth2\Server\ResourceServer;
 use Northstar\Auth\NorthstarUserProvider;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
+use League\OAuth2\Server\Grant\ImplicitGrant;
 use League\OAuth2\Server\AuthorizationServer;
 use Northstar\Auth\Repositories\KeyRepository;
 use Northstar\Auth\Repositories\UserRepository;
@@ -93,10 +94,15 @@ class OAuthServiceProvider extends ServiceProvider
                 $grants[] = PasswordGrant::class;
             }
 
+
             // Enable each grant w/ an access token TTL of 1 hour.
+            $accessTokenTtl = new DateInterval('PT1H');
             foreach ($grants as $grant) {
-                $server->enableGrantType(app($grant), new DateInterval('PT1H'));
+                $server->enableGrantType(app($grant), $accessTokenTtl);
             }
+
+            // TEMPORARY: Enable the implict grant to test out improved SPA auth.
+            $server->enableGrantType(new ImplicitGrant($accessTokenTtl), $accessTokenTtl);
 
             // Rate limit failed client authentication attempts.
             // @see: OAuthController::createToken

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -23,8 +23,7 @@ class ClientTableSeeder extends Seeder
             'client_id' => 'dev-oauth',
             'client_secret' => 'secret1',
             'scope' => collect(Scope::all())->except('admin')->keys()->toArray(),
-            // @NOTE: We're omitting 'redirect_uri' here for easy local dev.
-            'redirect_uri' => null,
+            'redirect_uri' => ['http://localhost:3000/', 'http://northstar.test/callback'],
         ]);
 
         // ..and one for machine authentication:


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for the [Implicit Grant](https://oauth2.thephpleague.com/authorization-server/implicit-grant/), allowing users to log into client-side apps (like our [GraphQL Playground](https://graphql.dosomething.org)) without requiring a server process to maintain a traditional HTTP session.

(Longer-term, we'd probably want to use the [authorization code grant with PKCE](https://oauth.net/2/grant-types/implicit/) which [can be conditionally supported for particular clients](https://git.io/fhNZK) in the upcoming 8.x release of `league/oauth2-server`).

#### How should this be reviewed?
As a proof-of-concept, this is implemented client-side in DoSomething/graphql#66.

#### Relevant Tickets
See DoSomething/northstar#840.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  