### PR TITLE
Silence some noisy Facebook authentication exceptions.

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -4,8 +4,9 @@ namespace Northstar\Http\Controllers\Web;
 
 use Socialite;
 use Illuminate\Contracts\Auth\Factory as Auth;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
-use DoSomething\StatHat\Client as StatHat;
+use Laravel\Socialite\Two\InvalidStateException;
 use Northstar\Auth\Registrar;
 use Northstar\Models\User;
 
@@ -73,8 +74,8 @@ class FacebookController extends Controller
             $facebookUser = Socialite::driver('facebook')
                 ->fields(['email', 'first_name', 'last_name', 'birthday'])
                 ->userFromToken($requestUser->token);
-        } catch (RequestException $e) {
-            $this->stathat->ezCount('facebook token mismatch');
+        } catch (RequestException | ClientException | InvalidStateException $e) {
+            logger()->warning('facebook token mismatch');
 
             return redirect('/register')->with('status', 'Unable to verify Facebook account.');
         }

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -27,25 +27,16 @@ class FacebookController extends Controller
     protected $registrar;
 
     /**
-     * The StatHat client.
-     *
-     * @var StatHat
-     */
-    protected $stathat;
-
-    /**
      * Make a new FacebookController, inject dependencies,
      * and set middleware for this controller's methods.
      *
      * @param Auth $auth
      * @param Registrar $registrar
-     * @param StatHat $stathat
      */
-    public function __construct(Auth $auth, Registrar $registrar, StatHat $stathat)
+    public function __construct(Auth $auth, Registrar $registrar)
     {
         $this->auth = $auth;
         $this->registrar = $registrar;
-        $this->stathat = $stathat;
     }
 
     /**
@@ -75,14 +66,14 @@ class FacebookController extends Controller
                 ->fields(['email', 'first_name', 'last_name', 'birthday'])
                 ->userFromToken($requestUser->token);
         } catch (RequestException | ClientException | InvalidStateException $e) {
-            logger()->warning('facebook token mismatch');
+            logger()->warning('facebook_token_mismatch');
 
             return redirect('/register')->with('status', 'Unable to verify Facebook account.');
         }
 
         // If we were denied access to read email, do not log them in.
         if (empty($facebookUser->email)) {
-            $this->stathat->ezCount('facebook email hidden');
+            logger()->info('facebook_email_hidden');
 
             return redirect('/register')->with('status', 'We need your email to contact you if you win a scholarship.');
         }
@@ -115,7 +106,7 @@ class FacebookController extends Controller
         }
 
         $this->auth->guard('web')->login($northstarUser, true);
-        $this->stathat->ezCount('facebook authentication');
+        logger()->info('facebook_authentication');
 
         return redirect()->intended('/');
     }


### PR DESCRIPTION
#### What's this PR do?
This pull request properly catches exceptions that occur as part of the Facebook authentication flow. These are fairly common and not truly "exceptional". Heck, we're even throwing exceptions when a user chooses to "deny" the login prompt! For example:

```
Mar 07 14:14:44 dosomething-northstar app/web.1: [07-Mar-2019 19:14:43 UTC] [2019-03-07 19:14:43] production.ERROR:  {"exception":"[object] (Laravel\\Socialite\\Two\\InvalidStateException(code: 0):  at /app/vendor/laravel/socialite/src/Two/AbstractProvider.php:209)"} {"user_id":"5c816c0c90828f009e485fb4","client_id":"phoenix-next","request_id":"cac9d067-ed9e-44f2-b897-f3aaa99af0d1"} 
Mar 07 14:14:44 fastly northstar: [07/Mar/2019:19:14:43 +0000] 'GET /facebook/verify?code=AQDAbpgiPmsNq7fhej4FrkIL3zPUE4eTBjqG781satebHjj_3CcwkenpBhrthN0VEb-PhRSU4JMOFdUeS1ro2JQMQS1jCt9ezsXoaAK1yjFDJ1Kd6a1bVF6HUi_bDut4KWX9pDLgs5uPi17V5fbAhnIIHmQygkdGiy_SRlXrHAN2PZ_pA1qe6j2Fv_bfpPoY4ZwS30U5JWxAjIscTJRHGCNjDt9tPiqO_p1gZKumgL8Nlg4tFp4-770tH88CEDITuD-C8WFp0ITLSigqukAiiYM4wJ0TpRatra_FH4ci_XmZsANJ8txS4pxlSzb_wMHD9ew1WV6TzmrZlmE9OBrnGE3v&state=uTfX9u5wi0iKDk6Q6n6RwLtR6WAbPhwRw9hA6fn1 HTTP/1.1' status=500 cache=MISS country=US bytes=6960 microseconds=131903
Mar 06 23:13:19 dosomething-northstar app/web.1: [07-Mar-2019 04:13:19 UTC] [2019-03-07 04:13:19] production.ERROR: Client error: `POST https://graph.facebook.com/v3.0/oauth/access_token` resulted in a `400 Bad Request` response: {"error":{"message":"Missing authorization code","type":"OAuthException","code":1,"fbtrace_id":"AugonnpALpq"}}  {"exception":"[object] (GuzzleHttp\\Exception\\ClientException(code: 400): Client error: `POST https://graph.facebook.com/v3.0/oauth/access_token` resulted in a `400 Bad Request` response:\n{\"error\":{\"message\":\"Missing authorization code\",\"type\":\"OAuthException\",\"code\":1,\"fbtrace_id\":\"AugonnpALpq\"}}\n at /app/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113)"} {"user_id":null,"client_id":"phoenix-next","request_id":"82bb3c07-a688-4593-8af4-6704cef39efe"} 
Mar 06 23:13:20 dosomething-northstar heroku/router: at=info method=GET path="/facebook/verify?error=access_denied&error_code=200&error_description=Permissions+error&error_reason=user_denied&state=nc3wuSRZ8OooAZGbfoMkFNHFiJyWQriLLdVFTJVN" host=identity.dosomething.org request_id=82bb3c07-a688-4593-8af4-6704cef39efe fwd="68.46.114.151, 68.46.114.151, 157.52.75.32,23.235.46.32" dyno=web.1 connect=0ms service=132ms status=500 bytes=7862 protocol=https 
```

Instead, these should gracefully redirect the user to the registration form & log a simple `facebook_token_mismatch` message that we can use to track these over time.

#### How should this be reviewed?
Tests pass! I'll smoke-test Facebook login on QA before pushing this to production.

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  