### PR TITLE
Silence noisy Facebook exceptions, Round 2.

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -2,7 +2,7 @@
 
 namespace Northstar\Http\Controllers\Web;
 
-use Socialite;
+use Laravel\Socialite\Facades\Socialite;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
@@ -58,10 +58,9 @@ class FacebookController extends Controller
      */
     public function handleProviderCallback()
     {
-        $requestUser = Socialite::driver('facebook')->user();
-
-        // Grab the user profile using their oauth token.
+        // Grab the user's profile using their Facebook OAuth token.
         try {
+            $requestUser = Socialite::driver('facebook')->user();
             $facebookUser = Socialite::driver('facebook')
                 ->fields(['email', 'first_name', 'last_name', 'birthday'])
                 ->userFromToken($requestUser->token);


### PR DESCRIPTION
#### What's this PR do?
These are still happening on QA! Gah! I think the `InvalidStateException` is actually getting thrown from the first `Socialite::driver('facebook')->user()` call, so moving that into the ol' try-catch.

#### How should this be reviewed?
⚠️ 👀 

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  