### PR TITLE
Fixes email subscription status Customer.io sync

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -24,7 +24,7 @@ class Model extends BaseModel
     {
         parent::setAttribute($key, $value);
 
-        // Empty strings should be saved as `null` when our attribute is a string.
+        // Empty string values should be saved as `null` if attribute is not boolean.
         $booleanFields = ['email_subscription_status', 'sms_paused'];
         if (empty($this->attributes[$key]) && ! in_array($key, $booleanFields)) {
             $this->attributes[$key] = null;

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -25,7 +25,7 @@ class Model extends BaseModel
         parent::setAttribute($key, $value);
 
         // Empty string values should be saved as `null` if attribute is not boolean.
-        $booleanFields = ['email_subscription_status', 'sms_paused'];
+        $booleanFields = array_keys($this->casts, 'boolean');
         if (empty($this->attributes[$key]) && ! in_array($key, $booleanFields)) {
             $this->attributes[$key] = null;
         }

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -24,8 +24,9 @@ class Model extends BaseModel
     {
         parent::setAttribute($key, $value);
 
-        // Empty strings should be saved as `null`.
-        if (empty($this->attributes[$key])) {
+        // Empty strings should be saved as `null` when our attribute is a string.
+        $booleanFields = ['email_subscription_status', 'sms_paused'];
+        if (empty($this->attributes[$key]) && ! in_array($key, $booleanFields)) {
             $this->attributes[$key] = null;
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -422,8 +422,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
         ];
 
-        // Only include email subscription status if we have that information
-        if ($this->email_subscription_status) {
+        // Only include email subscription status when a value exists.
+        if (isset($this->email_subscription_status)) {
             $payload['email_subscription_status'] = $this->email_subscription_status;
             $payload['unsubscribed'] = (! $this->email_subscription_status);
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -422,7 +422,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
         ];
 
-        // Only include email subscription status when a value exists.
+        // Only include email subscription status if we have that information.
         if (isset($this->email_subscription_status)) {
             $payload['email_subscription_status'] = $this->email_subscription_status;
             $payload['unsubscribed'] = (! $this->email_subscription_status);

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -101,4 +101,39 @@ class UserModelTest extends BrowserKitTestCase
 
         $this->assertEquals($result, route('password.reset', [$token, 'email' => $email, 'type' => $type]));
     }
+
+    /** @test */
+    public function it_should_include_email_subscription_status_in_customerio_payload_if_set()
+    {
+        $subscribedStatusUser = factory(User::class)->create([
+            'email' => 'subscribed@example.com',
+            'email_subscription_status' => true,
+        ]);
+        $result = $subscribedStatusUser->toCustomerIoPayload();
+
+        $this->assertTrue($result['email_subscription_status']);
+        $this->assertFalse($result['unsubscribed']);
+
+        $unsubscribedStatusUser = factory(User::class)->create([
+            'email' => 'unsubscribed@example.com',
+            'email_subscription_status' => false,
+        ]);
+        $result = $unsubscribedStatusUser->toCustomerIoPayload();
+
+        // TODO: These tests fail because of https://www.pivotaltracker.com/story/show/164346648
+        // $this->assertFalse($result['email_subscription_status']);
+        // $this->assertTrue($result['unsubscribed']);
+    }
+
+    /** @test */
+    public function it_should_exclude_email_subscription_status_in_customerio_payload_if_not_set()
+    {
+        $unknownStatusUser = factory(User::class)->create([
+            'email' => 'unknown@example.com',
+        ]);
+        $result = $unknownStatusUser->toCustomerIoPayload();
+
+        $this->assertFalse(isset($result['email_subscription_status']));
+        $this->assertFalse(isset($result['unsubscribed']));
+    }
 }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -120,9 +120,8 @@ class UserModelTest extends BrowserKitTestCase
         ]);
         $result = $unsubscribedStatusUser->toCustomerIoPayload();
 
-        // TODO: These tests fail because of https://www.pivotaltracker.com/story/show/164346648
-        // $this->assertFalse($result['email_subscription_status']);
-        // $this->assertTrue($result['unsubscribed']);
+        $this->assertFalse($result['email_subscription_status']);
+        $this->assertTrue($result['unsubscribed']);
     }
 
     /** @test */

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -106,7 +106,6 @@ class UserModelTest extends BrowserKitTestCase
     public function it_should_include_unsubscribed_false_in_customerio_payload_if_email_subscription_status_true()
     {
         $subscribedStatusUser = factory(User::class)->create([
-            'email' => 'subscribed@example.com',
             'email_subscription_status' => true,
         ]);
         $result = $subscribedStatusUser->toCustomerIoPayload();
@@ -119,7 +118,6 @@ class UserModelTest extends BrowserKitTestCase
     public function it_should_include_unsubscribed_true_in_customerio_payload_if_email_subscription_status_false()
     {
         $unsubscribedStatusUser = factory(User::class)->create([
-            'email' => 'unsubscribed@example.com',
             'email_subscription_status' => false,
         ]);
         $result = $unsubscribedStatusUser->toCustomerIoPayload();
@@ -131,9 +129,7 @@ class UserModelTest extends BrowserKitTestCase
     /** @test */
     public function it_should_exclude_unsubscribed_in_customerio_payload_if_email_subscription_status_not_set()
     {
-        $unknownStatusUser = factory(User::class)->create([
-            'email' => 'unknown@example.com',
-        ]);
+        $unknownStatusUser = factory(User::class)->create();
         $result = $unknownStatusUser->toCustomerIoPayload();
 
         $this->assertFalse(isset($result['email_subscription_status']));

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -103,7 +103,7 @@ class UserModelTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function it_should_include_email_subscription_status_in_customerio_payload_if_set()
+    public function it_should_include_unsubscribed_false_in_customerio_payload_if_email_subscription_status_true()
     {
         $subscribedStatusUser = factory(User::class)->create([
             'email' => 'subscribed@example.com',
@@ -113,7 +113,11 @@ class UserModelTest extends BrowserKitTestCase
 
         $this->assertTrue($result['email_subscription_status']);
         $this->assertFalse($result['unsubscribed']);
+    }
 
+    /** @test */
+    public function it_should_include_unsubscribed_true_in_customerio_payload_if_email_subscription_status_false()
+    {
         $unsubscribedStatusUser = factory(User::class)->create([
             'email' => 'unsubscribed@example.com',
             'email_subscription_status' => false,
@@ -125,7 +129,7 @@ class UserModelTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function it_should_exclude_email_subscription_status_in_customerio_payload_if_not_set()
+    public function it_should_exclude_unsubscribed_in_customerio_payload_if_email_subscription_status_not_set()
     {
         $unknownStatusUser = factory(User::class)->create([
             'email' => 'unknown@example.com',


### PR DESCRIPTION
#### What's this PR do?

Modifies `Model.setAttribute` to avoid overriding `false` boolean values with `null`, which unblocks fixing updating `email_subscription_status` in Customer.io by checking whether a `email_subscription_status` value is set (vs whether it's truthy)

#### How should this be reviewed?

I've been testing by locally updating my user via API, but also within Aurora to verify all data looks as expected.

#### Relevant Tickets
* Fixes https://www.pivotaltracker.com/story/show/164346693, https://www.pivotaltracker.com/story/show/164346648

#### Checklist
- [x] Tests added for new features/bug fixes.
