### PR TITLE
Adds type param to userCallToActionEmail payload

### DIFF
--- a/app/Jobs/SendPasswordResetToCustomerIo.php
+++ b/app/Jobs/SendPasswordResetToCustomerIo.php
@@ -74,6 +74,7 @@ class SendPasswordResetToCustomerIo implements ShouldQueue
             $payload = PasswordResetType::getEmailVars($this->type);
             $payload['userId'] = $this->user->id;
             $payload['actionUrl'] = $this->getUrl();
+            $payload['type'] = $this->type;
 
             $shouldSendToCustomerIo = config('features.blink');
             if ($shouldSendToCustomerIo) {


### PR DESCRIPTION
#### What's this PR do?

Includes the password reset type as a `type` parameter.

#### How should this be reviewed?
Upon https://github.com/DoSomething/blink/pull/236 deploy, test triggering a Password Reset and verify the `type` parameter is included in the Customer.io `call_to_action_email` event created.

#### Relevant Tickets

Per https://github.com/orgs/DoSomething/teams/team-bleed/discussions/34, this allows us to define different event triggered campaigns in Customer.io for the various `call_to_action_email` events created by Forgot Password or Non-Traditional Member Activations in https://github.com/DoSomething/chompy/pull/65

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
