### PR TITLE
Update user update command to work with `email_subscription_topics`

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -68,6 +68,7 @@ class UpdateUserFieldsCommand extends Command
         $usersToUpdate = $usersCsv->getRecords();
 
         $this->line('northstar:update: Updating '.count($usersCsv).' users...');
+
         $fieldsToUpdate = $this->argument('fields');
 
         $this->totalCount = count($usersCsv);
@@ -95,7 +96,7 @@ class UpdateUserFieldsCommand extends Command
 
                         // Don't add topic if it is already there
                         if (in_array($userToUpdate[$field], $topics)) {
-                            return;
+                            continue;
                         }
 
                         // Add the new topic to our array

--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -88,7 +88,24 @@ class UpdateUserFieldsCommand extends Command
 
             foreach ($fieldsToUpdate as $field) {
                 if (! empty($userToUpdate[$field])) {
-                    $user->{$field} = $userToUpdate[$field];
+                    // Special instructions when working with array field
+                    if ($field === 'email_subscription_topics') {
+                        // Get current email topics
+                        $topics = $user->email_subscription_topics ? $user->email_subscription_topics : [];
+
+                        // Don't add topic if it is already there
+                        if (in_array($userToUpdate[$field], $topics)) {
+                            return;
+                        }
+
+                        // Add the new topic to our array
+                        array_push($topics, $userToUpdate[$field]);
+
+                        // Add the full array of topics to the user
+                        $user->email_subscription_topics = $topics;
+                    } else {
+                        $user->{$field} = $userToUpdate[$field];
+                    }
                 }
             }
 

--- a/tests/Console/UpdateUserFieldsCommandTest.php
+++ b/tests/Console/UpdateUserFieldsCommandTest.php
@@ -43,7 +43,7 @@ class UpdateUserFieldsCommandTest extends BrowserKitTestCase
         ]);
     }
 
-        /** @test */
+    /** @test */
     public function it_should_update_email_topics()
     {
         // Create the users given in the test csv

--- a/tests/Console/UpdateUserFieldsCommandTest.php
+++ b/tests/Console/UpdateUserFieldsCommandTest.php
@@ -42,4 +42,41 @@ class UpdateUserFieldsCommandTest extends BrowserKitTestCase
             'created_at' => Carbon::parse('2018-01-01 10:00:00'),
         ]);
     }
+
+        /** @test */
+    public function it_should_update_email_topics()
+    {
+        // Create the users given in the test csv
+        factory(User::class)->create(['_id' => '5acfbf609a89201c340543e2', 'email_subscription_topics' => []]);
+        factory(User::class)->create(['_id' => '5acfbf609a89201c340543e3', 'email_subscription_topics' => ['news', 'lifestyle']]);
+        factory(User::class)->create(['_id' => '5acfbf609a89201c340543e4', 'email_subscription_topics' => ['lifestyle']]);
+        $user = factory(User::class)->create(['_id' => '5acfbf609a89201c340543e5', 'email_subscription_topics' => ['lifestyle']]);
+
+        // Run the user update command.
+        $this->artisan('northstar:update', ['path' => 'tests/Console/example-topic-updates.csv', 'fields' => ['email_subscription_topics']]);
+
+        // Updating user with no email topics
+        $this->seeInDatabase('users', [
+            '_id' => '5acfbf609a89201c340543e2',
+            'email_subscription_topics' => ['lifestyle'],
+        ]);
+
+        // Updating user with 2 existing email topics
+        $this->seeInDatabase('users', [
+            '_id' => '5acfbf609a89201c340543e3',
+            'email_subscription_topics' => ['news', 'lifestyle', 'scholarships'],
+        ]);
+
+        // Updating user to make sure a topic isn't duplicated
+        $this->seeInDatabase('users', [
+            '_id' => '5acfbf609a89201c340543e4',
+            'email_subscription_topics' => ['lifestyle'],
+        ]);
+
+        // Updating user with 1 existing email topic
+        $this->seeInDatabase('users', [
+            '_id' => '5acfbf609a89201c340543e5',
+            'email_subscription_topics' => ['lifestyle', 'news'],
+        ]);
+    }
 }

--- a/tests/Console/example-topic-updates.csv
+++ b/tests/Console/example-topic-updates.csv
@@ -1,0 +1,5 @@
+northstar_id,email_subscription_topics
+5acfbf609a89201c340543e2,lifestyle
+5acfbf609a89201c340543e3,scholarships
+5acfbf609a89201c340543e4,lifestyle
+5acfbf609a89201c340543e5,news


### PR DESCRIPTION
#### What's this PR do?

🎩 Updates `northstar:update` to work with `email_subscription_topics`, which is an array value. We want to make sure that any topics added in through the csv are _added_ to the array and do not overwrite it! We also want to make sure that we don't add duplicate values to the array.

👩‍🎓 Adds a new test for this command for this work. Makes sure we can add `email_subscription_topics` to users who have no topics, have some existing topics, and makes sure we don't add duplicate topics.

#### How should this be reviewed?
Will this allow us to import the [csvs on this card](https://www.pivotaltracker.com/n/projects/2019429/stories/164216160)?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/164216160)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
