### PR TITLE
Removes hardcoded email content

### DIFF
--- a/app/Jobs/SendPasswordResetToCustomerIo.php
+++ b/app/Jobs/SendPasswordResetToCustomerIo.php
@@ -3,7 +3,6 @@
 namespace Northstar\Jobs;
 
 use Northstar\Models\User;
-use Northstar\PasswordResetType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Queue\SerializesModels;
@@ -71,10 +70,11 @@ class SendPasswordResetToCustomerIo implements ShouldQueue
         // Rate limit Blink/Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
         $throttler->then(function () {
-            $payload = PasswordResetType::getEmailVars($this->type);
-            $payload['userId'] = $this->user->id;
-            $payload['actionUrl'] = $this->getUrl();
-            $payload['type'] = $this->type;
+            $payload = [
+                'actionUrl' => $this->getUrl(),
+                'type' => $this->type,
+                'userId' => $this->user->id,
+            ];
 
             $shouldSendToCustomerIo = config('features.blink');
             if ($shouldSendToCustomerIo) {

--- a/app/PasswordResetType.php
+++ b/app/PasswordResetType.php
@@ -27,31 +27,4 @@ class PasswordResetType
     {
         return [self::$forgotPassword, self::$rockTheVoteActivateAccount];
     }
-
-    /**
-     * Returns Call To Action Email parameters for a given Password Reset Type.
-     *
-     * @param string $type
-     * @return array
-     */
-    public static function getEmailVars($type)
-    {
-        if ($type === self::$rockTheVoteActivateAccount) {
-            return [
-                'actionText' =>'Set Password',
-                'greeting' => 'Hello!',
-                'intro' => 'You are receiving this email because you need to set a password to activate your DoSomething.org account. Here is the link to set your password:',
-                'outro' => 'This link will expire in 24 hours. Once you click the button above, you will be asked to reset your password on the page.<br /><br />If you have further questions, please reach out to help@dosomething.org.',
-                'subject' => 'Activate your DoSomething.org Account',
-            ];
-        }
-
-        return [
-            'actionText' => 'Reset Password',
-            'greeting' => 'Hello!',
-            'intro' => 'You are receiving this email because we received a password reset request for your DoSomething.org account. Here is the link to reset your password:',
-            'outro' => 'This link will expire in 24 hours. Once you click the button above, you will be asked to reset your password on the page. If you did not request a password reset, you can ignore this email. Your password will not change and your account is safe.<br /><br />If you have further questions, please reach out to help@dosomething.org.',
-            'subject' => 'Reset Password',
-        ];
-    }
 }


### PR DESCRIPTION
#### What's this PR do?
Removes the parameters no longer used in Customer.io to send Forgot Password and RTV Activate Account emails. We've set up separate event triggered campaigns for each `type` of `call_to_action_email` event created by a password reset request, and manage the content for each email within corresponding the Workflow step (refs https://github.com/orgs/DoSomething/teams/team-bleed/discussions/34).

#### How should this be reviewed?
Test on Customer.io staging and verify that email content is sent for both types (can easily test this via Aurora)


#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
