### PR TITLE
Use low priority queue for user update command

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -55,6 +55,9 @@ class UpdateUserFieldsCommand extends Command
      */
     public function handle()
     {
+        // Use low priority queue for these updates
+        config(['queue.jobs.users' => 'low']);
+
         // Make a local copy of the CSV
         $path = $this->argument('path');
         $this->line('northstar:update: Loading in csv from '.$path);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,7 +25,9 @@ class AppServiceProvider extends ServiceProvider
 
         User::created(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            SendUserToCustomerIo::dispatch($user);
+            $queueLevel = config('queue.jobs.users');
+            $queue = config('queue.names.'.$queueLevel);
+            SendUserToCustomerIo::dispatch($user)->onQueue($queue);
 
             // Send metrics to StatHat.
             app('stathat')->ezCount('user created');
@@ -41,7 +43,9 @@ class AppServiceProvider extends ServiceProvider
 
         User::updated(function (User $user) {
             // Send payload to Blink for Customer.io profile.
-            SendUserToCustomerIo::dispatch($user);
+            $queueLevel = config('queue.jobs.users');
+            $queue = config('queue.names.'.$queueLevel);
+            SendUserToCustomerIo::dispatch($user)->onQueue($queue);
 
             // Purge Fastly cache of user
             $fastly = new Fastly;

--- a/config/queue.php
+++ b/config/queue.php
@@ -103,4 +103,18 @@ return [
         'table' => 'failed_jobs',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Jobs For Updating/Creating Users
+    |--------------------------------------------------------------------------
+    |
+    | This option configures which queue is used when a job is triggered by
+    | updating or creating a user.
+    |
+    */
+
+    'jobs' => [
+        'users' => 'high',
+    ],
+
 ];


### PR DESCRIPTION
#### What's this PR do?
- Adds new `config('queue.jobs.users')` which defaults to `high`
- Changes the value of that to `low` in the `northstar:update` command
- Pushes `SendUserToCustomerIo` onto the appropriate queue when it is called

#### How should this be reviewed?
Will this solve our queue woes?

#### Relevant Tickets
[Slack thread](https://dosomething.slack.com/archives/C02BBRN5A/p1553019070076300)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
