### PR TITLE
Rename "actions" to "community" email topic

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -65,7 +65,7 @@ class Registrar
             'sms_paused' => 'boolean',
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
-            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,actions',
+            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',
             'voter_registration_status' => 'in:uncertain,ineligible,confirmed,registration_complete',
         ];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -418,7 +418,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'created_at' => iso8601($this->created_at), // TODO: Update Blink to just accept timestamp.
             'news_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('news', $this->email_subscription_topics) : false,
             'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
-            'action_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('actions', $this->email_subscription_topics) : false,
+            'community_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('community', $this->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
         ];
 

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -40,7 +40,7 @@ class UserModelTest extends BrowserKitTestCase
             'created_at' => $user->created_at->toIso8601String(),
             'news_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('news', $user->email_subscription_topics) : false,
             'lifestyle_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('lifestyle', $user->email_subscription_topics) : false,
-            'action_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('actions', $user->email_subscription_topics) : false,
+            'community_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('community', $user->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('scholarships', $user->email_subscription_topics) : false,
         ]);
     }


### PR DESCRIPTION
#### What's this PR do?
Changes the `actions` email topic to be `community` instead.

#### How should this be reviewed?
Did I spell "community" right? Will this allow anyone to end up with a topic of "actions"? Can a user successfully have a topic of "community"?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/164714324)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
