### PR TITLE
Adds support for Activate Account password resets

### DIFF
--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -2,6 +2,7 @@
 
 namespace Northstar\Http\Controllers\Web;
 
+use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Support\Facades\Auth;
@@ -47,6 +48,45 @@ class ResetPasswordController extends Controller
         event(new PasswordReset($user));
 
         $this->guard()->login($user);
+    }
+
+    /**
+     * Display the password reset view for the given token.
+     *
+     * If no token is present, display the link request form.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string|null  $token
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function showResetForm(Request $request, $token = null)
+    {
+        $data = [
+            'title' => 'Forgot Password',
+            'header' => trans('auth.forgot_password.header'),
+            'instructions' => trans('auth.forgot_password.instructions'),
+            'new_password_field' => trans('auth.fields.new_password'),
+            'confirm_new_password_field' => trans('auth.fields.confirm_new_password'),
+            'new_password_submit' => trans('auth.forgot_password.submit_new_password'),
+            'display_footer' => true,
+        ];
+
+        if (str_contains(request()->input('type'), 'activate-account')) {
+            $data = [
+                'title' => 'Activate Account',
+                'header' => trans('auth.activate_account.header'),
+                'instructions' => trans('auth.activate_account.instructions'),
+                'new_password_field' => trans('auth.fields.password'),
+                'confirm_new_password_field' => trans('auth.fields.confirm_password'),
+                'new_password_submit' => trans('auth.activate_account.submit_new_password'),
+                'display_footer' => false,
+            ];
+        }
+
+        $data['token'] = $token;
+        $data['email'] = $request->email;
+
+        return view('auth.passwords.reset')->with($data);
     }
 
     /**

--- a/documentation/endpoints/resets.md
+++ b/documentation/endpoints/resets.md
@@ -4,7 +4,7 @@ The `write` scope is required for the create endpoint.
 
 ## Send a Password Reset Email
 
-Sends a password reset email to the user with provided user ID. This requires admin privileges.
+Generates a valid password reset URL for the provided user ID, and sends it to user by posting a [`call_to_action_email` event to Customer.io](http://docs.dosomething.org/customer-io#call-to-action-email) with the provided reset `type`. This requires admin privileges.
 
 ```
 POST /v2/resets
@@ -17,7 +17,11 @@ POST /v2/resets
   /* The user id to send a password reset email to. */
   id: String
 
-  /* The type of password reset email to send. Valid types are 'forgot-password', 'rock-the-vote-activate-account' */
+  /* The type of password reset email to send.
+   * Valid types:
+   * - 'forgot-password'
+   * - 'rock-the-vote-activate-account' 
+   */
   type: String
 }
 ```

--- a/documentation/endpoints/resets.md
+++ b/documentation/endpoints/resets.md
@@ -1,4 +1,5 @@
 # Reset Endpoints
+
 The `write` scope is required for the create endpoint.
 
 ## Send a Password Reset Email
@@ -7,6 +8,18 @@ Sends a password reset email to the user with provided user ID. This requires ad
 
 ```
 POST /v2/resets
+```
+
+**Request Parameters:**
+
+```js
+{
+  /* The user id to send a password reset email to. */
+  id: String
+
+  /* The type of password reset email to send. Valid types are 'forgot-password', 'rock-the-vote-activate-account' */
+  type: String
+}
 ```
 
 <details>

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -51,11 +51,17 @@ return [
         'header' => 'Forgot your password?',
         'instructions' => 'We\'ve all been there. Reset by entering your email.',
         'request' => 'Request New Password',
+        'submit_new_password' => 'Reset Password',
     ],
     'footnote' => [
         'create' => 'Creating an account means you agree to our',
         'terms_of_service' => 'Terms of Service',
         'privacy_policy' => 'Privacy Policy',
         'messaging' => 'and to receive our weekly update. Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.',
+    ],
+    'activate_account' => [
+        'header' => 'Welcome to your DoSomething.org account!',
+        'instructions' => 'Create a password to join a movement of young people dedicated to making their communities a better place for everyone.',
+        'submit_new_password' => 'Activate Account',
     ],
 ];

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -50,7 +50,7 @@ return [
     'forgot_password' => [
         'header' => 'Forgot your password?',
         'instructions' => 'We\'ve all been there. Reset by entering your email.',
-        'request' => 'Request New Password',
+        'submit_forgot_password' => 'Request New Password',
         'submit_new_password' => 'Reset Password',
     ],
     'footnote' => [

--- a/resources/lang/es-mx/auth.php
+++ b/resources/lang/es-mx/auth.php
@@ -49,7 +49,7 @@ return [
     'forgot_password' => [
         'header' => '¿Olvidaste la contraseña?',
         'instructions' => 'A todos nos ha pasado. Ingresa tu cuenta de correo para restablecer tu contraseña.',
-        'request' => 'Request New Password',
+        'submit_forgot_password' => 'Request New Password',
     ],
     'footnote' => [
         'create' => 'Crear una cuenta significa que aceptas nuestros',

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -30,7 +30,7 @@
                     </div>
 
                     <div class="form-actions -padded">
-                        <input id="request-reset" type="submit" class="button" value="{{ trans('auth.forgot_password.request') }}">
+                        <input id="request-reset" type="submit" class="button" value="{{ trans('auth.forgot_password.submit_forgot_password') }}">
                     </div>
                 </form>
             </div>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,13 +1,13 @@
 @extends('layouts.app')
 
-@section('title', 'Forgot Password | DoSomething.org')
+@section('title', $title. ' | DoSomething.org')
 
 @section('content')
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block -centered">
-                <h1>{{ trans('auth.forgot_password.header') }}</h1>
-                <h3>{{ trans('auth.forgot_password.instructions') }}</h3>
+                <h1>{{ $header }}</h1>
+                <h3>{{ $instructions }}</h3>
             </div>
             <div class="container__block -centered">
                 @if (count($errors) > 0)
@@ -32,26 +32,28 @@
                     </div>
 
                     <div class="form-item">
-                        <label for="password" class="field-label">{{ trans('auth.fields.new_password') }}</label>
+                        <label for="password" class="field-label">{{ $new_password_field }}</label>
                         <input name="password" type="password" class="text-field" placeholder="••••••">
                     </div>
 
                     <div class="form-item">
-                        <label for="password_confirmation" class="field-label">{{ trans('auth.fields.confirm_new_password') }}</label>
+                        <label for="password_confirmation" class="field-label">{{ $confirm_new_password_field }}</label>
                         <input name="password_confirmation" type="password" class="text-field" placeholder="••••••">
                     </div>
 
                     <div class="form-actions -padded">
-                        <input id="reset-password" type="submit" class="button" value="Reset Password">
+                        <input id="reset-password" type="submit" class="button" value="{{ $new_password_submit }}">
                     </div>
                 </form>
             </div>
-            <div class="container__block -centered">
-                <ul>
-                    <li><a href="{{ url('login') }}" class="login-link">{{ trans('auth.log_in.existing') }}</a></li>
-                    <li><a href="{{ url('register') }}" class="register-link">{{ trans('auth.log_in.create') }}</a></li>
-                </ul>
-            </div>
+            @if ($display_footer)
+                <div class="container__block -centered">
+                    <ul>
+                        <li><a href="{{ url('login') }}" class="login-link">{{ trans('auth.log_in.existing') }}</a></li>
+                        <li><a href="{{ url('register') }}" class="register-link">{{ trans('auth.log_in.create') }}</a></li>
+                    </ul>
+                </div>
+            @endif
         </div>
     </div>
 @stop

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -19,7 +19,7 @@ class PasswordResetTest extends BrowserKitTestCase
     /**
      * Test that the homepage redirects to login page.
      */
-    public function testPasswordResetFlow()
+    public function testForgotPasswordResetFlow()
     {
         Bus::fake();
 
@@ -29,6 +29,7 @@ class PasswordResetTest extends BrowserKitTestCase
         // The user should be able to request a new password by entering their email.
         $this->visit('/password/reset');
         $this->see('Forgot your password?');
+        $this->see('We\'ve all been there. Reset by entering your email.');
         $this->submitForm('Request New Password', [
             'email' => 'forgetful@example.com',
         ]);
@@ -39,6 +40,7 @@ class PasswordResetTest extends BrowserKitTestCase
 
             return true;
         });
+        info('testForgotPasswordResetFlow '.$resetPasswordUrl);
 
         // The user should visit the link that was sent via email & set a new password.
         $this->visit($resetPasswordUrl);
@@ -78,5 +80,50 @@ class PasswordResetTest extends BrowserKitTestCase
         ]);
 
         $this->see('Too many attempts.');
+    }
+
+    /**
+     * Test that the Reset Password form displays Activate Account per type query parameter.
+     */
+    public function testActivateAccountResetFlow()
+    {
+        Bus::fake();
+
+        $user = factory(User::class)->create();
+        $passwordResetUrl = '';
+
+        /*
+        $this->asAdminUser()->post('v2/resets', [
+            'id' => $user->id,
+            'type' => 'rock-the-vote-activate-account',
+        ]);
+        $this->assertResponseStatus(200);
+        $this->seeJsonStructure(['success']);
+        // We'll assert that the event was created & take note of reset URL for the next step.
+        Bus::assertDispatched(SendPasswordResetToCustomerIo::class, function ($job) use (&$resetPasswordUrl) {
+            $passwordResetUrl = $job->getUrl();
+
+            return true;
+        });
+        */
+
+        $resetPasswordUrl = 'password/reset/f4da1d2ab8ba48ac992518933653beb7a59d57dc5a45275b083ec2b02a1528dc?email=kdeckow%40example.com&type=rock-the-vote-activate-account';
+
+        $this->visit($resetPasswordUrl);
+        $this->see('Welcome to your DoSomething.org account!');
+        $this->see('Create a password to join a movement of young people dedicated to making their communities a better place for everyone.');
+        /*
+        $this->postForm('Activate Account', [
+            'password' => 'top_secret',
+            'password_confirmation' => 'top_secret',
+        ]);
+
+        // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
+        $this->seeIsAuthenticatedAs($user, 'web');
+        $this->assertRedirectedTo('https://www-dev.dosomething.org/next/login');
+
+        // And their account should be updated with their new password.
+        $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));
+        */
     }
 }

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -90,29 +90,29 @@ class PasswordResetTest extends BrowserKitTestCase
         Bus::fake();
 
         $user = factory(User::class)->create();
-        $resetPasswordUrl = '';
-        /*
+        $resetPasswordUrl = null;
+
         $this->asAdminUser()->post('v2/resets', [
             'id' => $user->id,
             'type' => 'rock-the-vote-activate-account',
         ]);
+
         $this->assertResponseStatus(200);
         $this->seeJsonStructure(['success']);
+
         // We'll assert that the event was created & take note of reset URL for the next step.
         Bus::assertDispatched(SendPasswordResetToCustomerIo::class, function ($job) use (&$resetPasswordUrl) {
             $resetPasswordUrl = $job->getUrl();
 
             return true;
         });
-        info('test 2 '.$resetPasswordUrl);
-        */
 
-        $resetPasswordUrl = 'http://localhost/password/reset/15f5b5dbead3e0455e10955febd0458948d088f153016c51f166740bb2d37bfd?email=davon11%40example.org&type=rock-the-vote-activate-account';
+        $this->refreshApplication();
 
         $this->visit($resetPasswordUrl);
         $this->see('Welcome to your DoSomething.org account!');
         $this->see('Create a password to join a movement of young people dedicated to making their communities a better place for everyone.');
-        /*
+
         $this->postForm('Activate Account', [
             'password' => 'top_secret',
             'password_confirmation' => 'top_secret',
@@ -124,6 +124,5 @@ class PasswordResetTest extends BrowserKitTestCase
 
         // And their account should be updated with their new password.
         $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));
-        */
     }
 }

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -90,8 +90,7 @@ class PasswordResetTest extends BrowserKitTestCase
         Bus::fake();
 
         $user = factory(User::class)->create();
-        $passwordResetUrl = '';
-
+        $resetPasswordUrl = '';
         /*
         $this->asAdminUser()->post('v2/resets', [
             'id' => $user->id,
@@ -101,13 +100,14 @@ class PasswordResetTest extends BrowserKitTestCase
         $this->seeJsonStructure(['success']);
         // We'll assert that the event was created & take note of reset URL for the next step.
         Bus::assertDispatched(SendPasswordResetToCustomerIo::class, function ($job) use (&$resetPasswordUrl) {
-            $passwordResetUrl = $job->getUrl();
+            $resetPasswordUrl = $job->getUrl();
 
             return true;
         });
+        info('test 2 '.$resetPasswordUrl);
         */
 
-        $resetPasswordUrl = 'password/reset/f4da1d2ab8ba48ac992518933653beb7a59d57dc5a45275b083ec2b02a1528dc?email=kdeckow%40example.com&type=rock-the-vote-activate-account';
+        $resetPasswordUrl = 'http://localhost/password/reset/15f5b5dbead3e0455e10955febd0458948d088f153016c51f166740bb2d37bfd?email=davon11%40example.org&type=rock-the-vote-activate-account';
 
         $this->visit($resetPasswordUrl);
         $this->see('Welcome to your DoSomething.org account!');


### PR DESCRIPTION
#### What's this PR do?

Adds [`showResetForm`](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/Auth/ResetsPasswords.php#L25) to the `ResetPasswordController` to customize the Reset Password form when `type` query parameter includes `activate-account`.

#### How should this be reviewed?

Verify expected content for Forgot Password forms at `/password/reset`, as well as overrides for when the `type` query parameter includes `activate-account`.

<img src="https://user-images.githubusercontent.com/1236811/54788729-59f3e800-4bed-11e9-84db-5194172f8cc2.png" width="600">


#### Relevant Tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/164780588

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
