### PR TITLE
Subscribe new web users to "community"

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -211,8 +211,9 @@ class AuthController extends BaseController
             // Set language based on locale (either 'en', 'es-mx')
             $user->language = app()->getLocale();
 
-            // Sign the user up for email messaging.
+            // Sign the user up for email messaging & give them the "community" topic.
             $user->email_subscription_status = true;
+            $user->email_subscription_topics = ["community"];
 
             // Set sms_status, if applicable
             if ($user->mobile) {

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -213,7 +213,7 @@ class AuthController extends BaseController
 
             // Sign the user up for email messaging & give them the "community" topic.
             $user->email_subscription_status = true;
-            $user->email_subscription_topics = ["community"];
+            $user->email_subscription_topics = ['community'];
 
             // Set sms_status, if applicable
             if ($user->mobile) {

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -190,7 +190,7 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         // The user should be signed up for email messaging.
         $this->assertEquals(true, $user->email_subscription_status);
-        $this->assertEquals(["community"], $user->email_subscription_topics);
+        $this->assertEquals(['community'], $user->email_subscription_topics);
     }
 
     /**

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -190,6 +190,7 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         // The user should be signed up for email messaging.
         $this->assertEquals(true, $user->email_subscription_status);
+        $this->assertEquals(["community"], $user->email_subscription_topics);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?
When a new users registers via the web form, give them `email_subscription_topics` = `['community']`.

#### How should this be reviewed?
Is it okay to set `email_subscription_topics` this way? It would overwrite any other topics, but at this point there shouldn't be any others set yet anyway! Is the test sufficient?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/164714334)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
