### PR TITLE
Change Password form

### DIFF
--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -4,6 +4,8 @@ namespace Northstar\Http\Controllers\Web;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Northstar\Auth\Registrar;
 use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -100,5 +102,38 @@ class UserController extends BaseController
         $user->fill($values)->save();
 
         return redirect('/');
+    }
+
+    public function showChangePasswordForm(){
+        return view('auth.passwords.change');
+    }
+
+    public function changePassword(Request $request){
+        $user = Auth::user();
+
+        $this->registrar->validate($request, $user, [
+            'current_password' => 'required',
+            'new_password' => 'nullable|min:6|max:512|confirmed',
+            'new_password_confirmation' => 'required|same:new_password'
+        ]);
+        info('test 1');
+        /*
+        if (!(Hash::check($request->get('current_password'), $user->password))) {
+            info('password does not match', ['password' => $user->password]);
+            $this->registrar->errors()->add('current_password', 'Your current password does not matches with the password you provided. Please try again.');
+        }
+        info('test 2');
+        if (str_is($request->get('current_password'), $request->get('new_password'))) {
+            return redirect()->back()->with("error", "New Password cannot be same as your current password. Please choose a different password.");
+        }
+        info('test 3');
+        */
+
+        //Change Password
+        $user->password = bcrypt($request->get('new_password'));
+        $user->save();
+        info('test 3');
+
+        return redirect('/')->with("success", "Password changed successfully !");
     }
 }

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -46,6 +46,10 @@ return [
         'confirm_password' => 'Confirm Password',
         'new_password' => 'New Password',
         'confirm_new_password' => 'Confirm New Password',
+        'current_password' => 'Current Password',
+    ],
+    'change_password' => [
+        'submit_change_password' => 'Submit',
     ],
     'forgot_password' => [
         'header' => 'Forgot your password?',

--- a/resources/views/auth/passwords/change.blade.php
+++ b/resources/views/auth/passwords/change.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts.app')
+
+@section('title', 'Change Password | DoSomething.org')
+
+@section('content')
+    <div class="container -padded">
+        <div class="container__block -centered">
+          <h2 class="heading -alpha">Change password</h2>
+        </div>
+        <div class="wrapper">
+            <div class="container__block -centered">
+                @if (count($errors) > 0)
+                    <div class="validation-error fade-in-up">
+                        <h4>{{ trans('auth.validation.issues') }}</h4>
+                        <ul class="list -compacted">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                <form id="change-password-form" role="form" method="POST" action="{{ url('/password/change') }}">
+                    {{ csrf_field() }}
+
+                    <div class="form-item">
+                        <label for="current_password" class="field-label">{{ trans('auth.fields.current_password') }}</label>
+                        <input name="current_password" type="password" class="text-field" placeholder="••••••">
+                    </div>
+
+                    <div class="form-item">
+                        <label for="new_password" class="field-label">{{ trans('auth.fields.new_password') }}</label>
+                        <input name="new_password" type="password" class="text-field" placeholder="••••••">
+                    </div>
+
+                    <div class="form-item">
+                        <label for="new_password_confirmation" class="field-label">{{ trans('auth.fields.confirm_new_password') }}</label>
+                        <input name="new_password_confirmation" type="password" class="text-field" placeholder="••••••">
+                    </div>
+
+                    <div class="form-actions -padded">
+                        <input id="reset-password" type="submit" class="button" value="{{ trans('auth.change_password.submit_change_password') }}">
+                    </div>
+                </form>
+            </div>
+            <div class="container__block -centered">
+                <div class="form-actions">
+                    <a href="{{ url('password/reset') }}">{{ trans('auth.forgot_password.header') }}</a>
+                </div>
+                <div class="form-actions">
+                    <a href="/">Cancel</a>
+                </ul>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -42,5 +42,8 @@
         <div class="form-actions">
             <a href="{{ route('users.edit', $user->id) }}" class="button -secondary">Edit Profile</a>
         </div>
+        <div class="form-actions">
+            <a href="/password/change" class="button -secondary">Change Password</a>
+        </div>
     </div>
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,3 +41,5 @@ $router->get('password/reset', 'ForgotPasswordController@showLinkRequestForm');
 $router->post('password/email', 'ForgotPasswordController@sendResetLinkEmail');
 $router->get('password/reset/{token}', ['as' => 'password.reset', 'uses' => 'ResetPasswordController@showResetForm']);
 $router->post('password/reset', 'ResetPasswordController@reset');
+$router->get('password/change', 'UserController@showChangePasswordForm');
+$router->post('password/change', 'UserController@changePassword');


### PR DESCRIPTION
#### What's this PR do?

Starts on a separate very non-functional Change Password form, inspired by tracking `password_updated` events per profile changes in #854 - which (re)discovered bug of #855 

#### How should this be reviewed?
Still working through validating... wondering whether confirming current password should be added into a [custom validation rule](https://laravel.com/docs/5.8/validation#custom-validation-rules) or how it added as a closure in Laravel 5.5

#### Relevant Tickets
#855, #482 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
