### PR TITLE
Community backfill command

### DIFF
--- a/app/Console/Commands/SetCommunityTopic.php
+++ b/app/Console/Commands/SetCommunityTopic.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class SetCommunityTopic extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:community';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add "community" to the email topics for each user who is subscribed.';
+
+    /**
+     * The number of users updated so far.
+     *
+     * @var string
+     */
+    protected $currentCount = 0;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Grab users who have email addresses
+        $query = (new User)->newQuery();
+        $query = $query->where('email_subscription_status', true);
+        $query = $query->whereNotIn('email_subscription_topics', ['community']);
+
+        $totalCount = $query->count();
+
+        if ($totalCount === 0) {
+            $this->line('northstar:community - No users need updating!');
+            return;
+        }
+
+        $query->chunkById(200, function (Collection $users) use ($totalCount) {
+            $users->each(function (User $user) use ($totalCount) {
+                // Add "community" for each user here
+                $user->addEmailSubscriptionTopic('community');
+                $user->save();
+
+                $this->line('northstar:community - User '.$user->id.' given community topic');
+            });
+
+            // Logging to track progress (may read over 100% at the end when there are less than 200 users in the last chunk)
+            $this->currentCount += 200;
+            $percentDone = ($this->currentCount / $totalCount) * 100;
+            $this->line('northstar:community - status update - '.$this->currentCount.'/'.$totalCount.' - '.$percentDone.'% done');
+        });
+
+        $this->line('northstar:community - Added "community" to each appropriate user!');
+    }
+}

--- a/app/Console/Commands/SetCommunityTopic.php
+++ b/app/Console/Commands/SetCommunityTopic.php
@@ -55,6 +55,7 @@ class SetCommunityTopic extends Command
 
         if ($totalCount === 0) {
             $this->line('northstar:community - No users need updating!');
+
             return;
         }
 

--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -94,19 +94,7 @@ class UpdateUserFieldsCommand extends Command
                 if (! empty($userToUpdate[$field])) {
                     // Special instructions when working with array field
                     if ($field === 'email_subscription_topics') {
-                        // Get current email topics
-                        $topics = $user->email_subscription_topics ? $user->email_subscription_topics : [];
-
-                        // Don't add topic if it is already there
-                        if (in_array($userToUpdate[$field], $topics)) {
-                            continue;
-                        }
-
-                        // Add the new topic to our array
-                        array_push($topics, $userToUpdate[$field]);
-
-                        // Add the full array of topics to the user
-                        $user->email_subscription_topics = $topics;
+                        $user->addEmailSubscriptionTopic($userToUpdate[$field]);
                     } else {
                         $user->{$field} = $userToUpdate[$field];
                     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -533,4 +533,27 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         $this->attributes['voter_registration_status'] = $status;
     }
+
+
+    /**
+     * Add the given topic to the user's array of topics if it is not already there.
+     *
+     * @param string $status
+     */
+    public function addEmailSubscriptionTopic($topic)
+    {
+        // Get current email topics
+        $topics = $this->email_subscription_topics ?: [];
+
+        // Don't add topic if it is already there
+        if (in_array($topic, $topics)) {
+            return;
+        }
+
+        // Add the new topic to our array
+        array_push($topics, $topic);
+
+        // Add the full array of topics to the user
+        $this->email_subscription_topics = $topics;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -534,7 +534,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         $this->attributes['voter_registration_status'] = $status;
     }
 
-
     /**
      * Add the given topic to the user's array of topics if it is not already there.
      *

--- a/tests/Console/CommunityTopicBackfillTest.php
+++ b/tests/Console/CommunityTopicBackfillTest.php
@@ -39,7 +39,7 @@ class CommunityTopicBackfillTest extends BrowserKitTestCase
     /** @test */
     public function it_should_add_community_to_subscribed_users()
     {
-        $user = factory(User::class)->create(['email_subscription_status' => true]);
+        $user = factory(User::class)->create(['email_subscription_status' => true, 'email_subscription_topics' => []]);
 
         // Run the community backfill command.
         $this->artisan('northstar:community');

--- a/tests/Console/CommunityTopicBackfillTest.php
+++ b/tests/Console/CommunityTopicBackfillTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Northstar\Models\User;
+
+class CommunityTopicBackfillTest extends BrowserKitTestCase
+{
+    /** @test */
+    public function it_should_not_assign_community_to_unsubscribed_users()
+    {
+        $user = factory(User::class)->create(['email_subscription_status' => false, 'email_subscription_topics' => []]);
+
+        // Run the community backfill command.
+        $this->artisan('northstar:community');
+
+        // Make sure no updates were made to this user
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'email_subscription_status' => false,
+            'email_subscription_topics' => null,
+        ]);
+    }
+
+    /** @test */
+    public function it_should_not_duplicate_community_topic()
+    {
+        $user = factory(User::class)->create(['email_subscription_status' => true, 'email_subscription_topics' => ['community']]);
+
+        // Run the community backfill command.
+        $this->artisan('northstar:community');
+
+        // Make sure no updates were made to this user
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['community'],
+        ]);
+    }
+
+    /** @test */
+    public function it_should_add_community_to_subscribed_users()
+    {
+        $user = factory(User::class)->create(['email_subscription_status' => true]);
+
+        // Run the community backfill command.
+        $this->artisan('northstar:community');
+
+        // Make sure community was added to this user
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['community'],
+        ]);
+    }
+
+    /** @test */
+    public function it_should_ignore_other_topics()
+    {
+        $user1 = factory(User::class)->create(['email_subscription_status' => true, 'email_subscription_topics' => ['news']]);
+        $user2 = factory(User::class)->create(['email_subscription_status' => true, 'email_subscription_topics' => ['news', 'scholarships']]);
+        $user3 = factory(User::class)->create(['email_subscription_status' => true, 'email_subscription_topics' => ['news', 'scholarships', 'lifestyle']]);
+
+        // Run the community backfill command.
+        $this->artisan('northstar:community');
+
+        // Make sure the updates were made
+        $this->seeInDatabase('users', [
+            '_id' => $user1->id,
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['news','community'],
+        ]);
+
+        $this->seeInDatabase('users', [
+            '_id' => $user2->id,
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['news', 'scholarships', 'community'],
+        ]);
+
+        $this->seeInDatabase('users', [
+            '_id' => $user3->id,
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['news', 'scholarships', 'lifestyle', 'community'],
+        ]);
+    }
+}

--- a/tests/Console/CommunityTopicBackfillTest.php
+++ b/tests/Console/CommunityTopicBackfillTest.php
@@ -66,7 +66,7 @@ class CommunityTopicBackfillTest extends BrowserKitTestCase
         $this->seeInDatabase('users', [
             '_id' => $user1->id,
             'email_subscription_status' => true,
-            'email_subscription_topics' => ['news','community'],
+            'email_subscription_topics' => ['news', 'community'],
         ]);
 
         $this->seeInDatabase('users', [


### PR DESCRIPTION
#### What's this PR do?

🆘 Adds a helper to easily add a topic to a user's `email_subscription_topics` which takes care of not duplicating a topic.

💬 Adds `northstar:community` command to take all users who have `email_subscription_status` = `true` and who also do not already have `community` in their topics and add `community` to their topics.

🍮 Update the update users command to use the new `addEmailSubscriptionTopic()` helper.

#### How should this be reviewed?
Biggest area of concern: Does the logic in the command update the correct users? Maybe I should add a test for this command!

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/164216160)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
