### PR TITLE
Referrer ID in Source Detail Field

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -85,6 +85,7 @@ class AuthController extends BaseController
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
                 'trafficSource' => request()->query('trafficSource'),
+                'referrerId' => request()->query('referrerId'),
             ]);
 
             return redirect()->guest($authorizationRoute);

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -221,10 +221,10 @@ class AuthController extends BaseController
                 $user->sms_status = 'active';
             }
 
-            // Set the traffic source as the `source_detail` if provided
-            $trafficSource = session()->pull('trafficSource');
-            if ($trafficSource) {
-                $user->source_detail = 'utm_medium:'.$trafficSource;
+            // Set source_detail, if applicable.
+            $sourceDetail = get_source_detail();
+            if ($sourceDetail) {
+                $user->source_detail = $sourceDetail;
             }
         });
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -291,3 +291,26 @@ function convert($experiment)
 
     return app(Sixpack::class)->convert($experiment);
 }
+
+/**
+ * Create a formatted source_detail string using session values.
+ *
+ * @return string
+ */
+function get_source_detail()
+{
+    $trafficSource = session()->pull('trafficSource');
+    $referrerId = session()->pull('referrerId');
+
+    $sourceDetail = [];
+
+    if ($trafficSource) {
+        array_push($sourceDetail, 'utm_medium:'.$trafficSource);
+    }
+
+    if ($referrerId) {
+        array_push($sourceDetail, 'referrer_id:'.$referrerId);
+    }
+
+    return implode($sourceDetail, ',');
+}


### PR DESCRIPTION
#### What's this PR do?
This PR allows us to store a new `referrer_id` value in a registering user's `source_detail` field based on values passed through from Phoenix (or whichever service). 

It adds a `get_source_detail` helper method to take care of properly formatting and generating this string. And makes use of this method in `AuthController#postRegister` to optionally assign the `source_detail` field.

#### How should this be reviewed?
- Click a signup button for a campaign, or take action as an unauthenticated user on a story page on Phoenix (adding a `?utm_medium=wtvr` to the URL)
- Complete registration
- You should see `source_detail => 'utm_medium=wtvr,referrer_id:[campaign/story page ID]'` in the newly created User's entry.

#### Relevant Tickets
[Pivotal ID#164935945](https://www.pivotaltracker.com/story/show/164935945)
https://github.com/DoSomething/phoenix-next/pull/1351

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
