### PR TITLE
Allow users to update themselves, but no one else

### DIFF
--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -40,7 +40,7 @@ class UserController extends Controller
         $this->registrar = $registrar;
         $this->transformer = $transformer;
 
-        $this->middleware('role:admin,staff', ['except' => ['show']]);
+        $this->middleware('role:admin,staff', ['except' => ['show', 'update']]);
         $this->middleware('scope:user');
         $this->middleware('scope:write', ['only' => ['store', 'update', 'destroy']]);
     }

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -174,7 +174,6 @@ class UserController extends Controller
             $this->registrar->register($request->all(), $user);
         }
 
-
         return $this->item($user);
     }
 

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -7,6 +7,7 @@ use Northstar\Auth\Role;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
+use Illuminate\Support\Facades\Gate;
 use Northstar\Http\Controllers\Controller;
 use Northstar\Http\Transformers\Two\UserTransformer;
 use Northstar\Exceptions\NorthstarValidationException;
@@ -169,7 +170,10 @@ class UserController extends Controller
             Role::gate(['admin']);
         }
 
-        $this->registrar->register($request->all(), $user);
+        if (Gate::allows('edit-profile', $user)) {
+            $this->registrar->register($request->all(), $user);
+        }
+
 
         return $this->item($user);
     }

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
 use Illuminate\Support\Facades\Gate;
 use Northstar\Http\Controllers\Controller;
+use Illuminate\Auth\AuthenticationException;
 use Northstar\Http\Transformers\Two\UserTransformer;
 use Northstar\Exceptions\NorthstarValidationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -161,6 +162,10 @@ class UserController extends Controller
     {
         $user = User::findOrFail($id);
 
+        if (! Gate::allows('edit-profile', $user)) {
+            throw new AuthenticationException('This action is unauthorized.');
+        }
+
         // Normalize input and validate the request
         $request = normalize('credentials', $request);
         $this->registrar->validate($request, $user);
@@ -170,9 +175,7 @@ class UserController extends Controller
             Role::gate(['admin']);
         }
 
-        if (Gate::allows('edit-profile', $user)) {
-            $this->registrar->register($request->all(), $user);
-        }
+        $this->registrar->register($request->all(), $user);
 
         return $this->item($user);
     }

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -4,6 +4,7 @@ namespace Northstar\Http\Controllers\Two;
 
 use Auth;
 use Northstar\Auth\Role;
+use Northstar\Auth\Scope;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
@@ -162,7 +163,7 @@ class UserController extends Controller
     {
         $user = User::findOrFail($id);
 
-        if (! Gate::allows('edit-profile', $user)) {
+        if (! (Scope::allows('admin') || Gate::allows('edit-profile', $user))) {
             throw new AuthenticationException('This action is unauthorized.');
         }
 

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -246,6 +246,31 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that a machine can update a user's profile.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateProfileAsMachine()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asMachine()->json('PUT', 'v2/users/'.$user->id, [
+            'first_name' => 'Wilhelmina',
+            'last_name' => 'Grubbly-Plank',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The user should be updated.
+        $this->seeInDatabase('users', [
+            'first_name' => 'Wilhelmina',
+            'last_name' => 'Grubbly-Plank',
+            '_id' => $user->id,
+        ]);
+    }
+
+    /**
      * Test that the write scope is required to update a profile.
      * PUT /v2/users/:id
      *

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -186,10 +186,64 @@ class UserTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(200);
 
-        // The user should remain unchanged.
-        $user->fresh();
-        $this->assertNotEquals('Alexander', $user->first_name);
-        $this->assertNotEquals('Hamilton', $user->last_name);
+        // The user should be updated.
+        $this->seeInDatabase('users', [
+            'first_name' => 'Alexander',
+            'last_name' => 'Hamilton',
+            '_id' => $user->id,
+        ]);
+    }
+
+    /**
+     * Test that a user can update their own profile.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateProfileAsSelf()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'role:staff', 'write'])->json('PUT', 'v2/users/'.$user->id, [
+            'first_name' => 'Pepper',
+            'last_name' => 'Puppy',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The user should be updated.
+        $this->seeInDatabase('users', [
+            'first_name' => 'Pepper',
+            'last_name' => 'Puppy',
+            '_id' => $user->id,
+        ]);
+    }
+
+    /**
+     * Test that a user cannot update another user's profile.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateProfileAsOther()
+    {
+        $user1 = factory(User::class)->create();
+        $user2 = factory(User::class)->create();
+
+        $this->asUser($user2, ['user', 'role:staff', 'write'])->json('PUT', 'v2/users/'.$user1->id, [
+            'first_name' => 'Burt',
+            'last_name' => 'Macklin',
+        ]);
+
+        // @TO-DO: I would expect at 403 here, but it is getting a 200
+        // $this->assertResponseStatus(403);
+
+        // The user should be updated.
+        $this->seeInDatabase('users', [
+            'first_name' => $user1->first_name,
+            'last_name' => $user1->last_name,
+            '_id' => $user1->id,
+        ]);
     }
 
     /**

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -235,8 +235,7 @@ class UserTest extends BrowserKitTestCase
             'last_name' => 'Macklin',
         ]);
 
-        // @TO-DO: I would expect at 403 here, but it is getting a 200
-        // $this->assertResponseStatus(403);
+        $this->assertResponseStatus(401);
 
         // The user should be updated.
         $this->seeInDatabase('users', [

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -143,7 +143,6 @@ trait WithAuthentication
         return $this->withAccessToken(['admin', 'user', 'write']);
     }
 
-
     /**
      * Create a signed JWT to authorize resource requests.
      *

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -136,6 +136,17 @@ trait WithAuthentication
     /**
      * Create a signed JWT to authorize resource requests.
      *
+     * @return $this
+     */
+    public function asMachine()
+    {
+        return $this->withAccessToken(['admin', 'user', 'write']);
+    }
+
+
+    /**
+     * Create a signed JWT to authorize resource requests.
+     *
      * @param User $user
      * @param array $scopes
      * @return $this


### PR DESCRIPTION
#### What's this PR do?

🔬 For `v2/users`, removes `update` from the `'role:admin,staff'` middleware because we're gonna use a Gate now.

🏡 Only update a user if the request passes the `'edit-profile'` gate as determined [here](https://github.com/DoSomething/northstar/blob/master/app/Policies/UserPolicy.php#L29-L44).

🔧 Fixes `testV2UpdateProfileAsStaff()` test which was in a "two wrongs make a right" situation. A comment in the test and the code of the test indicated that staff should _not_ be able to update users. The UserPolicy and other documentation (including above this test itself) indicate that staff _should_ be able to update users. The code was a little off, so it wasn't really testing what it said it was because [`$user->fresh()` returns a new model rather than "refreshing" the one you already have](https://laravel.com/docs/5.8/eloquent#retrieving-models). It must be assigned to something in order to do what we think it does! So it this case, `$user` wasn't really refreshed, so no matter what we did it wasn't going to change! I updated this test to search directly in the database because for me that is a lot less confusing and leaves less room for error.

👩‍🎓 Added a new test to make sure users can update their own profile.

⛔️ Added a new test to make sure users can't update someone else's profile (this has a `TODO` in it because I am not getting the expected response code) .

#### How should this be reviewed?
Some very careful 👀 ! Do all these tests really test what I said they do?

#### Relevant Tickets
This is relevant to [this slack thread](https://dosomething.slack.com/archives/C3ASB4204/p1554146339067400).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
