### PR TITLE
Use low priority queue for community backfill script

### DIFF
--- a/app/Console/Commands/SetCommunityTopic.php
+++ b/app/Console/Commands/SetCommunityTopic.php
@@ -46,6 +46,9 @@ class SetCommunityTopic extends Command
      */
     public function handle()
     {
+        // Use low priority queue for these updates
+        config(['queue.jobs.users' => 'low']);
+
         // Grab users who have email addresses
         $query = (new User)->newQuery();
         $query = $query->where('email_subscription_status', true);


### PR DESCRIPTION
#### What's this PR do?
This should have been included in https://github.com/DoSomething/northstar/pull/857! This script will be updating around 4.3 million users and we do not want them clogging up the high priority queue. 

#### How should this be reviewed?
Compare to how this is done [here](https://github.com/DoSomething/northstar/blob/master/app/Console/Commands/UpdateUserFieldsCommand.php#L59) in the update users command.

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165087297)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
