### PR TITLE
Avoid setting duplicates in `email_subscription_topics`

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -552,10 +552,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setEmailSubscriptionTopicsAttribute($value)
     {
-        // De-dupe given array
-        $topics = array_values(array_unique($value));
-
         // Set de-duped array as email_subscription_topics
-        $this->attributes['email_subscription_topics'] = $topics;
+        $this->attributes['email_subscription_topics'] = array_values(array_unique($value));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -542,7 +542,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function addEmailSubscriptionTopic($topic)
     {
         // Add the new topic to the existing array of topics
-        $this->email_subscription_topics = array_merge($this->email_subscription_topics, [$topic]);
+        $this->email_subscription_topics = array_merge($this->email_subscription_topics ?: [], [$topic]);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -537,23 +537,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     /**
      * Add the given topic to the user's array of topics if it is not already there.
      *
-     * @param string $status
+     * @param string $topic
      */
     public function addEmailSubscriptionTopic($topic)
     {
-        // Get current email topics
-        $topics = $this->email_subscription_topics ?: [];
-
-        // Don't add topic if it is already there
-        if (in_array($topic, $topics)) {
-            return;
-        }
-
-        // Add the new topic to our array
-        array_push($topics, $topic);
-
-        // Add the full array of topics to the user
-        $this->email_subscription_topics = $topics;
+        // Add the new topic to the existing array of topics
+        $this->email_subscription_topics = array_merge($this->email_subscription_topics, [$topic]);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -564,7 +564,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setEmailSubscriptionTopicsAttribute($value)
     {
         // De-dupe given array
-        $topics = array_unique($value);
+        $topics = array_values(array_unique($value));
 
         // Set de-duped array as email_subscription_topics
         $this->attributes['email_subscription_topics'] = $topics;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -555,4 +555,18 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         // Add the full array of topics to the user
         $this->email_subscription_topics = $topics;
     }
+
+    /**
+     * Mutator to ensure no duplicates in the email topics array.
+     *
+     * @param array $value
+     */
+    public function setEmailSubscriptionTopicsAttribute($value)
+    {
+        // De-dupe given array
+        $topics = array_unique($value);
+
+        // Set de-duped array as email_subscription_topics
+        $this->attributes['email_subscription_topics'] = $topics;
+    }
 }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -773,5 +773,4 @@ class UserTest extends BrowserKitTestCase
             'email_subscription_topics' => ['news'],
         ]);
     }
-
 }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -750,4 +750,28 @@ class UserTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(200);
     }
+
+    /**
+     * Test that an admin cannot add duplicates to email_subscription_topics.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateEmailSubscriptionTopicsWithNoDupesAsAdmin()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asAdminUser()->json('PUT', 'v2/users/'.$user->id, [
+            'email_subscription_topics' => ['news', 'news'],
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The email_subscription_topics should be updated with no duplicates
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'email_subscription_topics' => ['news'],
+        ]);
+    }
+
 }


### PR DESCRIPTION
#### What's this PR do?

Another application might be trying to add a value to a user's `email_subscription_topics` and it would be nice for that application or human to not have to worry about setting duplicates. See an example [here](https://github.com/DoSomething/chompy/pull/83#discussion_r271468629).

👯 Add `setEmailSubscriptionTopicsAttribute()` setter to de-dupe the array being set as `email_subscription_topics` and then use the de-duped array for that field.

✍️ Adds a test to make sure duplicates aren't set!

🦐 Simplifies the `addEmailSubscriptionTopic()` helper to be just one line! We don't need to check for duplicates anymore, so can just merge in the new topic directly with the existing ones.

#### How should this be reviewed?
Is there any way that a duplicate email topic could be added? Can you think of anything else to test? A test specifically for the `addEmailSubscriptionTopic()` helper?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165074676)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [X] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
