### PR TITLE
Mock any API calls to Customer.io in tests.

### DIFF
--- a/app/Jobs/SendPasswordUpdatedToCustomerIo.php
+++ b/app/Jobs/SendPasswordUpdatedToCustomerIo.php
@@ -47,12 +47,11 @@ class SendPasswordUpdatedToCustomerIo implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(CustomerIo $customerIo)
     {
         // Rate limit Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
-        $throttler->then(function () {
-            $customerIo = new CustomerIo;
+        $throttler->then(function () use ($customerIo) {
             $response = $customerIo->trackEvent($this->user, 'password_updated', [
                 'updated_via' => $this->updatedVia,
             ]);

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -16,6 +16,13 @@ trait CreatesApplication
     protected $blinkMock;
 
     /**
+     * The Customer.io API client mock.
+     *
+     * @var \Mockery\MockInterface
+     */
+    protected $customerIoMock;
+
+    /**
      * The Faker generator, for creating test data.
      *
      * @var \Faker\Generator
@@ -37,6 +44,10 @@ trait CreatesApplication
         $this->blinkMock = $this->mock(Blink::class);
         $this->blinkMock->shouldReceive('userCreate')->andReturn(true);
         $this->blinkMock->shouldReceive('userCallToActionEmail')->andReturn(true);
+
+        // Configure a mock for any Customer.io API calls.
+        $this->customerIoMock = $this->mock(\Northstar\Services\CustomerIo::class);
+        $this->customerIoMock->shouldReceive('trackEvent');
 
         return $app;
     }


### PR DESCRIPTION
#### What's this PR do?
This baffled me for way longer than it probably should have. The `testActivateAccountResetFlow` was failing on my local because it was trying to send real (😱) events to Customer.io each time I ran the test suite.

This pull request configures a global mock for `CustomerIo`, like we do for equivalent Blink events.

#### How should this be reviewed?
I've also removed the `CUSTOMERIO_USERNAME` and `CUSTOMERIO_PASSWORD` that were allowing these to function on Wercker, since we don't want our automated tests to be making any side-effects in other systems!

#### Relevant Tickets
N/A. References DoSomething/communal-docs#24.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  