### PR TITLE
Add last name to registration form

### DIFF
--- a/resources/assets/js/validators/auth.js
+++ b/resources/assets/js/validators/auth.js
@@ -54,6 +54,15 @@ Validation.registerValidationFunction('first_name', function(string, done) {
   );
 });
 
+// ## Last Name
+// Makes sure the user submits a last name.
+Validation.registerValidationFunction('last_name', function(string, done) {
+  validateNotBlank(string, done,
+    'Last Name',
+    'We need your last name.'
+  );
+});
+
 // ## Birthday
 // Validates correct date input, reasonable birthdate, and says a nice message.
 Validation.registerValidationFunction('birthday', function(string, done) {

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -30,7 +30,8 @@ return [
             'password_length' => 'Must be 6+ characters',
         ],
         'placeholder' => [
-            'call_you' => 'What do we call you?',
+            'first_name' => 'First Name',
+            'last_name' => 'Last Name',
             'birthday' => 'MM/DD/YYYY',
             'password' => '6+ characters... make it tricky!',
             'double_checking' => 'Just double checking!',
@@ -41,6 +42,7 @@ return [
         'mobile' => 'Cell Number',
         'email_or_mobile' => 'Email address or cell number',
         'first_name' => 'First Name',
+        'last_name' => 'Last Name',
         'birthday' => 'Birthday',
         'password' => 'Password',
         'confirm_password' => 'Confirm Password',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -34,13 +34,20 @@
             <div>
                 <div class="form-item -reduced">
                     <label for="first_name" class="field-label">{{ trans('auth.fields.first_name') }}</label>
-                    <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.call_you') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
+                    <input name="first_name" type="text" id="first_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.first_name') }}" value="{{ old('first_name') }}" autofocus data-validate="first_name" data-validate-required />
                 </div>
 
                 <div class="form-item -reduced">
-                    <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
-                    <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
+                    <label for="last_name" class="field-label">{{ trans('auth.fields.last_name') }}</label>
+                    <input name="last_name" type="text" id="last_name" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.last_name') }}" value="{{ old('last_name') }}" autofocus data-validate="last_name" data-validate-required />
                 </div>
+
+
+            </div>
+
+            <div class="form-item">
+                <label for="birthdate" class="field-label">{{ trans('auth.fields.birthday') }}</label>
+                <input name="birthdate" type="text" id="birthdate" class="text-field required js-validate" placeholder="{{ trans('auth.validation.placeholder.birthday') }}" value="{{ old('birthdate') }}" data-validate="birthday" data-validate-required />
             </div>
 
             <div class="form-item">


### PR DESCRIPTION
#### What's this PR do?

🌗 Adds last name field to the registration form.

Try to submit with no last name:
![last_name_mandatory](https://user-images.githubusercontent.com/4240292/56158360-a88b6c80-5f76-11e9-8c21-8f7f4ea0b14c.gif)

Success with a last name:
![success_last_name](https://user-images.githubusercontent.com/4240292/56158662-880fe200-5f77-11e9-9135-21714f940f2a.gif)

#### How should this be reviewed?
Will this require last name on the registration form and store it on the user?

After this is merged, the following Ghost Inspector tests will need to be updated:
QA: 
[[User Flow] Campaign Signup + Registration + Photo Reportback
](https://app.ghostinspector.com/tests/5c49f1dd638e692a231ece5f)
[[User Flow] Registration + Homepage
](https://app.ghostinspector.com/tests/5c4a2353638e692a2320a494)

Prod:
[[User Flow] Campaign Signup + Registration + Photo Reportback](https://app.ghostinspector.com/tests/5c4a1efd638e692a23208132)

[[User Flow] Registration + Homepage](https://app.ghostinspector.com/tests/5c4a28fa638e692a2320bf21)


#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165160823)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
