### PR TITLE
Make sure Facebook users get email fields set

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -99,6 +99,10 @@ class FacebookController extends Controller
             $fields['country'] = country_code();
             $fields['language'] = app()->getLocale();
 
+            // Add same email settings as traditional new members
+            $fields['email_subscription_status'] = true;
+            $fields['email_subscription_topics'] = ['community'];
+
             $northstarUser = $this->registrar->register($fields, null, function (User $user) {
                 $user->setSource(null, 'facebook');
             });

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -104,6 +104,8 @@ class FacebookTest extends BrowserKitTestCase
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
         $this->assertEquals($user->source_detail, 'facebook');
+        $this->assertEquals($user->email_subscription_status, true);
+        $this->assertEquals($user->email_subscription_topics, ['community']);
     }
 
     /**
@@ -122,6 +124,8 @@ class FacebookTest extends BrowserKitTestCase
         $this->assertEquals($user->first_name, 'Puppet');
         $this->assertEquals($user->last_name, 'Sloth');
         $this->assertEquals($user->facebook_id, '12345');
+        $this->assertEquals($user->email_subscription_status, true);
+        $this->assertEquals($user->email_subscription_topics, ['community']);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?

🤓 When a new user registers through Facebook, set `email_subscription_status` to `true` and `email_subscription_topics` to `['community']` just like non-Facebook web registrants. Tests have been updated to make sure these changes are working!

#### How should this be reviewed?
Are these the right values for these fields? Should all Facebook users get them?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165160711) which references [the list in this comment](https://github.com/orgs/DoSomething/teams/team-bleed/discussions/23?from_comment=20#discussion-23-comment-20).

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
