### PR TITLE
Only log about user updates if not running in console

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -113,4 +113,16 @@ class Model extends BaseModel
 
         return true;
     }
+
+    /**
+     * Get the attributes that have been changed.
+     *
+     * @return array
+     */
+    public function getChanged()
+    {
+        $changed = array_replace_keys($this->getDirty(), $this->getHidden(), '*****');
+
+        return $changed;
+    }
 }

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -115,7 +115,7 @@ class Model extends BaseModel
     }
 
     /**
-     * Get the attributes that have been changed.
+     * Get the attributes that have been changed, but redact any hidden fields.
      *
      * @return array
      */

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,7 +36,7 @@ class AppServiceProvider extends ServiceProvider
 
         User::updating(function (User $user) {
             // Write profile changes to the log, with redacted values for hidden fields.
-            $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
+            $changed = $user->getChanged();
 
             if (! app()->runningInConsole()) {
                 logger('updated user', ['id' => $user->id, 'changed' => $changed]);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,7 +38,9 @@ class AppServiceProvider extends ServiceProvider
             // Write profile changes to the log, with redacted values for hidden fields.
             $changed = array_replace_keys($user->getDirty(), $user->getHidden(), '*****');
 
-            logger('updated user', ['id' => $user->id, 'changed' => $changed]);
+            if (! app()->runningInConsole()) {
+                logger('updated user', ['id' => $user->id, 'changed' => $changed]);
+            }
         });
 
         User::updated(function (User $user) {

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -60,33 +60,16 @@ class UserModelTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function it_should_log_changes()
+    public function it_should_sanitize_changes()
     {
-        $logger = $this->spy('log');
         $user = User::create();
 
         $user->first_name = 'Caroline';
         $user->password = 'secret';
 
-        // Freeze time for testing audit info.
-        $time = $this->mockTime();
+        $changes = $user->getChanged();
 
-        $user->save();
-
-        // Setting up audit mock example for DRYness.
-        $auditMock = [
-            'source' => 'northstar',
-            'updated_at' => $time,
-        ];
-
-        $logger->shouldHaveReceived('debug')->once()->with('updated user', [
-            'id' => $user->id,
-            'changed' => [
-                'first_name' => 'Caroline',
-                'password' => '*****',
-                'audit' => '*****',
-            ],
-        ]);
+        $this->assertEquals(['first_name' => 'Caroline', 'password' => '*****', 'audit' => '*****'], $changes);
     }
 
     /** @test */


### PR DESCRIPTION
#### What's this PR do?

🍃 We don't need these logs if the app is running in console! These are also debug level logs that will not show up on prod or QA anyway! The hope here is that this will help the [Community backfill script](https://github.com/DoSomething/northstar/blob/master/app/Console/Commands/SetCommunityTopic.php) to not run out of memory so quickly.

🚁 Moves the logic that happened in the AppServiceProvider when a user was updating to sanitize the diff into a helper on Model. This way we can still test it even though we're not logging it. Test updated as well!

#### How should this be reviewed?
Will this still log when we want it to?

#### Relevant Tickets
🤠 [Card-ish](https://www.pivotaltracker.com/story/show/165087297)

#### Checklist
- [ ] Tests added for new features/bug fixes.
