### PR TITLE
Add script to fix Drupal formatting weirdness.

### DIFF
--- a/app/Console/Commands/FixDrupalFields.php
+++ b/app/Console/Commands/FixDrupalFields.php
@@ -58,8 +58,8 @@ class FixDrupalFields extends Command
                 info('Sanitized object field.', [
                     'id' => $user->id,
                     'field' => $field,
-                    'is_array' => is_array($value),
-                    'parsable' => ! is_null($value),
+                    'before' => $value,
+                    'after' => $user->{$field},
                 ]);
             }
         });

--- a/app/Console/Commands/FixDrupalFields.php
+++ b/app/Console/Commands/FixDrupalFields.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class FixDrupalFields extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:dedrupal {field}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update fields that have nasty Drupal objects if possible.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $field = $this->argument('field');
+
+        // Get users where field is not a string:
+        $query = User::whereRaw([
+            $field => [
+                '$exists' => true,
+                '$not' => ['$type' => 'string'],
+            ],
+        ]);
+
+        $progressBar = $this->output->createProgressBar($query->count());
+        $query->chunkById(200, function (Collection $users) use ($field, $progressBar) {
+            foreach ($users as $user) {
+                $value = $user->{$field};
+
+                // If this is an object, it's likely Drupal gook.
+                if (is_array($value)) {
+                    $sanitized = array_get($value, 'value');
+                    $user->{$field} = $sanitized;
+                } else {
+                    $user->{$field} = null;
+                }
+
+                $progressBar->advance();
+                $user->save();
+
+                info('Sanitized object field.', [
+                    'id' => $user->id,
+                    'field' => $field,
+                    'is_array' => is_array($value),
+                    'parsable' => ! is_null($value),
+                ]);
+            }
+        });
+
+        $progressBar->finish();
+    }
+}

--- a/tests/Console/FixDrupalFieldsTest.php
+++ b/tests/Console/FixDrupalFieldsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Northstar\Models\User;
+
+class FixDrupalFieldsTest extends TestCase
+{
+    /** @test */
+    public function it_should_format_fields()
+    {
+        $invalidFormatQuery = [
+            '$exists' => true,
+            '$not' => ['$type' => 'string'],
+        ];
+
+        // Create some users with regular and borked fields.
+        factory(User::class, 5)->create();
+        $this->createMongoDocument('users', ['email' => 'dave@example.com', 'addr_street1' => '19 W 21st St']);
+        $this->createMongoDocument('users', ['email' => 'bob@example.com', 'addr_street1' => ['value' => '1 Main Street']]);
+        $this->createMongoDocument('users', ['email' => 'hackz@example.com', 'addr_street1' => ['lol' => 'nonsense']]);
+
+        // Make sure we have 2 borked users.
+        $borkedUsersCount = User::whereRaw(['addr_street1' => $invalidFormatQuery])->count();
+        $this->assertEquals(2, $borkedUsersCount);
+
+        // Run the de-drupalification command.
+        $this->artisan('northstar:dedrupal', ['field' => 'addr_street1']);
+
+        // Now, we should have 0 borked users!
+        $userWithValidField = User::where('email', 'dave@example.com')->first();
+        $userWithParsableField = User::where('email', 'bob@example.com')->first();
+        $userWithNonsenseField = User::where('email', 'hackz@example.com')->first();
+        $newBorkedUsersCount = User::whereRaw(['addr_street1' => $invalidFormatQuery])->count();
+
+        $this->assertEquals(0, $newBorkedUsersCount);
+        $this->assertEquals('19 W 21st St', $userWithValidField->addr_street1);
+        $this->assertEquals('1 Main Street', $userWithParsableField->addr_street1);
+        $this->assertEquals(null, $userWithNonsenseField->addr_street1);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `northstar:dedrupal` script, which can be used to parse fields that have awkward `['value' => 'actual value']` formatted contents into the expected `'actual value'`.

#### How should this be reviewed?
I added a test! Will run on QA before production. 🚥 

#### Relevant Tickets
[#165187491](https://www.pivotaltracker.com/story/show/165187491)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  