### PR TITLE
Remove birthdates that are unreasonably far in the past.

### DIFF
--- a/app/Console/Commands/RemoveOldBirthdates.php
+++ b/app/Console/Commands/RemoveOldBirthdates.php
@@ -30,7 +30,7 @@ class RemoveOldBirthdates extends Command
      */
     public function handle()
     {
-        // Get users where field is not a string:
+        // Get any users where 'birthdate' is before 1900... a.k.a way too old:
         $query = User::whereRaw([
             'birthdate' => [
                 '$lt' => new UTCDateTime(strtotime('1900-01-01 00:00:00')),

--- a/app/Console/Commands/RemoveOldBirthdates.php
+++ b/app/Console/Commands/RemoveOldBirthdates.php
@@ -2,7 +2,6 @@
 
 namespace Northstar\Console\Commands;
 
-use Carbon\Carbon;
 use Northstar\Models\User;
 use MongoDB\BSON\UTCDateTime;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/RemoveOldBirthdates.php
+++ b/app/Console/Commands/RemoveOldBirthdates.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+use MongoDB\BSON\UTCDateTime;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class RemoveOldBirthdates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:olds';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove birthdates that are way too old.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Get users where field is not a string:
+        $query = User::whereRaw([
+            'birthdate' => [
+                '$lt' => new UTCDateTime(strtotime('1900-01-01 00:00:00')),
+            ],
+        ]);
+
+        $progressBar = $this->output->createProgressBar($query->count());
+        $query->chunkById(200, function (Collection $users) use ($progressBar) {
+            foreach ($users as $user) {
+                $birthdate = $user->birthdate;
+                $user->birthdate = null;
+                $user->save();
+
+                $progressBar->advance();
+
+                info('Removed invalid birthdate.', [
+                    'id' => $user->id,
+                    'birthdate' => $birthdate,
+                ]);
+            }
+        });
+
+        $progressBar->finish();
+    }
+}

--- a/tests/Console/RemoveOldBirthdatesTest.php
+++ b/tests/Console/RemoveOldBirthdatesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+
+class StandardizeBirthdatesTest extends TestCase
+{
+    /** @test */
+    public function it_should_fix_birthdates()
+    {
+        // Create some normal and *really* old users:
+        $normalUsers = factory(User::class, 5)->create();
+        $ancientOnes = factory(User::class, 3)->create(['birthdate' => new Carbon('0001-01-01 00:00:00')]);
+
+        // Run the script!
+        $this->artisan('northstar:olds');
+
+        // Make sure we have 0 borked users
+        foreach ($normalUsers as $user) {
+            $attributes = $user->fresh()->getAttributes();
+            $this->assertArrayHasKey('birthdate', $user->fresh()->getAttributes(), 'Valid birthdates should not be removed.');
+        }
+
+        foreach ($ancientOnes as $user) {
+            $attributes = $user->fresh()->getAttributes();
+            $this->assertArrayNotHasKey('birthdate', $attributes, 'Invalid birthdates should be removed.');
+        }
+    }
+}

--- a/tests/Console/RemoveOldBirthdatesTest.php
+++ b/tests/Console/RemoveOldBirthdatesTest.php
@@ -3,7 +3,7 @@
 use Carbon\Carbon;
 use Northstar\Models\User;
 
-class StandardizeBirthdatesTest extends TestCase
+class RemoveOldBirthdatesTest extends TestCase
 {
     /** @test */
     public function it_should_fix_birthdates()


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a script which removes any birthdates that are before the year 1900, because chances are we don't have users over 119 years old. And certainly very few users that are over two thousand years old, as indicated in the ticket.

#### How should this be reviewed?
I added a test! 🚥

#### Relevant Tickets
[#165190368](https://www.pivotaltracker.com/story/show/165190368)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  