### PR TITLE
Fix issue where we'd delete all birthdates before 1969!

### DIFF
--- a/app/Console/Commands/RemoveOldBirthdates.php
+++ b/app/Console/Commands/RemoveOldBirthdates.php
@@ -30,10 +30,12 @@ class RemoveOldBirthdates extends Command
      */
     public function handle()
     {
-        // Get any users where 'birthdate' is before 1900... a.k.a way too old:
+        // Get any users where 'birthdate' is before 1900. Note that strtotime gives
+        // us a traditional UNIX timestamp (in seconds), but UTCDateTime wants a
+        // JavaScript-style timestamp (in milliseconds).
         $query = User::whereRaw([
             'birthdate' => [
-                '$lt' => new UTCDateTime(strtotime('1900-01-01 00:00:00')),
+                '$lt' => new UTCDateTime(strtotime('1900-01-01 00:00:00') * 1000),
             ],
         ]);
 

--- a/tests/Console/RemoveOldBirthdatesTest.php
+++ b/tests/Console/RemoveOldBirthdatesTest.php
@@ -9,7 +9,7 @@ class RemoveOldBirthdatesTest extends TestCase
     public function it_should_fix_birthdates()
     {
         // Create some normal and *really* old users:
-        $normalUsers = factory(User::class, 5)->create();
+        $normalUsers = factory(User::class, 5)->create(['birthdate' => $this->faker->dateTimeBetween('1/1/1901', 'now')]);
         $ancientOnes = factory(User::class, 3)->create(['birthdate' => new Carbon('0001-01-01 00:00:00')]);
 
         // Run the script!


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes a funny issue from #868, where `1900-01-01 00:00:00` was getting parsed into `1969-12-06 10:23:31` by [`strtotime`](https://www.php.net/manual/en/function.strtotime.php) (because different timestamp formats), and so we'd clear birthdates for far younger people than we intended to.

#### How should this be reviewed?
I added a failing test in 9ce2c17 and the fix in d947298.

#### Relevant Tickets
[#165190368](https://www.pivotaltracker.com/story/show/165190368)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  