### PR TITLE
Show payload for debugging

### DIFF
--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -175,7 +175,6 @@ class UserController extends Controller
         $request = normalize('credentials', $request);
         $this->registrar->validate($request, $user);
 
-
         // Only admins can change the role field.
         if ($request->has('role') && $request->input('role') !== 'user') {
             Role::gate(['admin']);

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -8,6 +8,7 @@ use Northstar\Auth\Scope;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Gate;
 use Northstar\Http\Controllers\Controller;
 use Illuminate\Auth\AuthenticationException;
@@ -170,6 +171,9 @@ class UserController extends Controller
         // Normalize input and validate the request
         $request = normalize('credentials', $request);
         $this->registrar->validate($request, $user);
+
+        // Debug level log to show the payload received
+        Log::debug('received update user payload', $request->all());
 
         // Only admins can change the role field.
         if ($request->has('role') && $request->input('role') !== 'user') {

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -168,12 +168,13 @@ class UserController extends Controller
             throw new AuthenticationException('This action is unauthorized.');
         }
 
+        // Debug level log to show the payload received
+        Log::debug('received update user payload', $request->all());
+
         // Normalize input and validate the request
         $request = normalize('credentials', $request);
         $this->registrar->validate($request, $user);
 
-        // Debug level log to show the payload received
-        Log::debug('received update user payload', $request->all());
 
         // Only admins can change the role field.
         if ($request->has('role') && $request->input('role') !== 'user') {

--- a/app/Http/Controllers/Two/UserController.php
+++ b/app/Http/Controllers/Two/UserController.php
@@ -169,7 +169,7 @@ class UserController extends Controller
         }
 
         // Debug level log to show the payload received
-        Log::debug('received update user payload', $request->all());
+        Log::debug('received update user payload for user '.$user->id, $request->all());
 
         // Normalize input and validate the request
         $request = normalize('credentials', $request);


### PR DESCRIPTION
#### What's this PR do?

👻 When trying to figure out the unsubscribed spookiness, we have been able to verify that a request is made to Northstar from Blink, but we haven't been able to figure out why the user's `email_subscription_status` is not set. I think the next step is to see the exact payload that Northstar is receiving so we can verify that it works locally (or not!) and try to step through what exactly is happening in Northstar.

Example log:
`
[2019-04-24 15:15:37] local.DEBUG: received update user payload for user 5cacef40fdce271a65654f12 {"first_name":"Katie","email_subscription_status":false} {"user_id":null,"client_id":"dev-machine","request_id":null}
`

#### How should this be reviewed?
Good next step?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165160711)
