### PR TITLE
`feature_flags` field on users

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -198,19 +198,6 @@ class Registrar
             $customizer($user);
         }
 
-        // If the badges test is running, put half of users in badges group and half in control group
-        if (config('features.badges')) {
-            $feature_flags = $user->feature_flags;
-
-            if (rand(0, 1) === 1) {
-                $feature_flags['badges'] = true;
-            } else {
-                $feature_flags['badges'] = false;
-            }
-
-            $user->feature_flags = $feature_flags;
-        }
-
         $user->save();
 
         return $user;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -202,7 +202,7 @@ class Registrar
         if (config('features.badges')) {
             $feature_flags = $user->feature_flags;
 
-            if (rand(0,1) === 1) {
+            if (rand(0, 1) === 1) {
                 $feature_flags['badges'] = true;
             } else {
                 $feature_flags['badges'] = false;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -198,6 +198,19 @@ class Registrar
             $customizer($user);
         }
 
+        // If the badges test is running, put half of users in badges group and half in control group
+        if (config('features.badges')) {
+            $feature_flags = $user->feature_flags;
+
+            if (rand(0,1) === 1) {
+                $feature_flags['badges'] = true;
+            } else {
+                $feature_flags['badges'] = false;
+            }
+
+            $user->feature_flags = $feature_flags;
+        }
+
         $user->save();
 
         return $user;

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -221,6 +221,15 @@ class AuthController extends BaseController
             }
         });
 
+        // If the badges test is running, put half of users in badges group and half in control group
+        if (config('features.badges')) {
+            $feature_flags = $user->feature_flags;
+
+            $feature_flags['badges'] = (bool) rand(0, 1);
+
+            $user->feature_flags = $feature_flags;
+        }
+
         $this->auth->guard('web')->login($user, true);
 
         return redirect()->intended('/');

--- a/app/Http/Transformers/Two/UserTransformer.php
+++ b/app/Http/Transformers/Two/UserTransformer.php
@@ -57,6 +57,9 @@ class UserTransformer extends TransformerAbstract
 
             // Voting Plan Status
             $response['voting_plan_status'] = $user->voting_plan_status;
+
+            // Feature Flags
+            $response['feature_flags'] = $user->feature_flags;
         }
 
         // Make a Voting Plan fields to be rendered in messaging

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -436,7 +436,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         if (isset($this->feature_flags)) {
             if (array_key_exists('badges', $this->feature_flags)) {
-                $payload['badges'] = $this->feature_flags['badges'];
+                $payload['badges_feature_flag'] = $this->feature_flags['badges'];
             }
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -67,6 +67,9 @@ use Northstar\Jobs\SendPasswordResetToCustomerIo;
  * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
  * @property Carbon $created_at
  * @property Carbon $updated_at
+ *
+ * The feature flags this user has
+ * @property Object $feature_flags
  */
 class User extends Model implements AuthenticatableContract, AuthorizableContract, ResetPasswordContract
 {
@@ -102,6 +105,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // Voting Plan:
         'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',
+
+        // Feature flags:
+        'feature_flags'
     ];
 
     /**
@@ -113,7 +119,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public static $internal = [
         'drupal_id', 'role', 'facebook_id',
         'mobilecommons_id', 'mobilecommons_status', 'sms_status', 'sms_paused',
-        'last_messaged_at',
+        'last_messaged_at', 'feature_flags'
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -434,6 +434,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             $payload['unsubscribed'] = (! $this->email_subscription_status);
         }
 
+        if (isset($this->feature_flags)) {
+            if (array_key_exists('badges', $this->feature_flags)) {
+                $payload['badges'] = $this->feature_flags['badges'];
+            }
+        }
+
         return $payload;
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,7 +69,7 @@ use Northstar\Jobs\SendPasswordResetToCustomerIo;
  * @property Carbon $updated_at
  *
  * The feature flags this user has
- * @property Object $feature_flags
+ * @property object $feature_flags
  */
 class User extends Model implements AuthenticatableContract, AuthorizableContract, ResetPasswordContract
 {
@@ -107,7 +107,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',
 
         // Feature flags:
-        'feature_flags'
+        'feature_flags',
     ];
 
     /**
@@ -119,7 +119,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public static $internal = [
         'drupal_id', 'role', 'facebook_id',
         'mobilecommons_id', 'mobilecommons_status', 'sms_status', 'sms_paused',
-        'last_messaged_at', 'feature_flags'
+        'last_messaged_at', 'feature_flags',
     ];
 
     /**

--- a/config/features.php
+++ b/config/features.php
@@ -18,4 +18,6 @@ return [
 
     'rate-limiting' => env('DS_ENABLE_RATE_LIMITING'),
 
+    'badges' => env('DS_BADGES_TEST', false),
+
 ];

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -242,8 +242,6 @@ class UserTest extends BrowserKitTestCase
         // Should not see the badges feature flag.
         $user->refresh();
         $this->assertNull($user->feature_flags);
-
-
     }
 
     /**

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -204,7 +204,7 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asUser($user, ['user', 'role:staff', 'write'])->json('PUT', 'v2/users/'.$user->id, [
+        $this->asUser($user, ['user', 'write'])->json('PUT', 'v2/users/'.$user->id, [
             'first_name' => 'Pepper',
             'last_name' => 'Puppy',
         ]);
@@ -217,6 +217,33 @@ class UserTest extends BrowserKitTestCase
             'last_name' => 'Puppy',
             '_id' => $user->id,
         ]);
+    }
+
+    /**
+     * Test that an update does not add the "badges" feature flag.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateShouldNotAddBadgesFlag()
+    {
+        // Turn on the badge test feature flag
+        config(['features.badges' => true]);
+
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'write'])->json('PUT', 'v2/users/'.$user->id, [
+            'first_name' => 'Pepper',
+            'last_name' => 'Puppy',
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // Should not see the badges feature flag.
+        $user->refresh();
+        $this->assertNull($user->feature_flags);
+
+
     }
 
     /**

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -194,6 +194,50 @@ class WebAuthenticationTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that users get a feature_flags 'badges' value when the test is on.
+     */
+    public function testRegisterWithBadgeTest()
+    {
+        // Turn on the badge test feature flag
+        config(['features.badges' => true]);
+
+        $this->withHeader('X-Fastly-Country-Code', 'US')
+            ->register();
+
+        $this->seeIsAuthenticated('web');
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        // The user should have a value set for 'badges'
+        $this->assertEquals(true, array_key_exists('badges', $user->feature_flags));
+    }
+
+
+    /**
+     * Test that users do not get feature flags set when the badges test is off.
+     */
+    public function testRegisterWithoutBadgeTest()
+    {
+        // Turn off the badge test feature flag
+        config(['features.badges' => false]);
+
+        $this->withHeader('X-Fastly-Country-Code', 'US')
+            ->register();
+
+        $this->seeIsAuthenticated('web');
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        $this->assertEquals('US', $user->country);
+        $this->assertEquals('en', $user->language);
+
+        // The user should not have any `feature_flags`.
+        $this->assertEquals(true, is_null($user->feature_flags));
+    }
+
+    /**
      * Test that users can't enter invalid profile info.
      */
     public function testRegisterInvalid()

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -213,7 +213,6 @@ class WebAuthenticationTest extends BrowserKitTestCase
         $this->assertEquals(true, array_key_exists('badges', $user->feature_flags));
     }
 
-
     /**
      * Test that users do not get feature flags set when the badges test is off.
      */

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -210,7 +210,7 @@ class WebAuthenticationTest extends BrowserKitTestCase
         $user = auth()->user();
 
         // The user should have a value set for 'badges'
-        $this->assertEquals(true, array_key_exists('badges', $user->feature_flags));
+        $this->assertArrayHasKey('badges', $user->feature_flags);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?

🎏 New feature flag `DS_BADGES_TEST` which defaults to `false` for whether or not we should be opting folks into the badges test.

🇺🇸 New field on users called `feature_flags`.

📨 For new registrants, give half the feature flag for badges `true` and give half `false`. Only do this if we are currently running the badges test. Example below!

👚 Expose the `feature_flags` attribute in the `v2` user transformer to admins or the user whose account it is.

👩‍🎓 Added tests to make sure `feature_flags['badges']` is assigned appropriately.

🏰 Add `badges` to Customer.io payload if the user is in one of the test groups. ⚠️ ⚠️ ⚠️ _This brings our Customer.io payload up to 29 attributes and we cannot send more than 30_


**Example**
I created a new user who has `feature_flags` as follows:
```
     feature_flags: [
       "badges" => false,
     ],
```

#### How should this be reviewed?
Will this allow us to run the badges test how we want to? Can other services access the `feature_flags` information as they need to?

⚠️ ⚠️ ⚠️ _Please double check my counting and make sure in no cases are we sending more than 30 attributes to Customer.io_

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165718950)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
