### PR TITLE
Remove Mandetory Voter Reg Status Sixpack AB Test

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -175,10 +175,6 @@ class AuthController extends BaseController
      */
     public function getRegister()
     {
-        // Mandatory voter reg question experiment
-        $mandatoryVoterStatus = participate('voter-status-mandatory', ['normal_form', 'mandatory_voter_form']);
-        session(['ab_voter_status_mandatory' => $mandatoryVoterStatus]);
-
         return view('auth.register');
     }
 
@@ -191,16 +187,13 @@ class AuthController extends BaseController
      */
     public function postRegister(Request $request)
     {
-        // Grab alternative for this user again (it will be the same)
-        $mandatoryVoterStatus = session('ab_voter_status_mandatory') === 'mandatory_voter_form' ? true : false;
-
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',
             'birthdate' => 'required|date|before:now',
             'email' => 'required|email|unique:users',
             'mobile' => 'mobile|nullable|unique:users',
             'password' => 'required|min:6|max:512',
-            'voter_registration_status' => $mandatoryVoterStatus ? 'required' : '',
+            'voter_registration_status' => 'required',
         ]);
 
         // Register and login the user.
@@ -227,8 +220,6 @@ class AuthController extends BaseController
                 $user->source_detail = $sourceDetail;
             }
         });
-
-        convert('voter-status-mandatory');
 
         $this->auth->guard('web')->login($user, true);
 

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -100,6 +100,7 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
             'email' => $this->faker->unique->email,
             'birthdate' => $this->faker->date('m/d/Y', '5 years ago'),
             'password' => 'secret',
+            'voter_registration_status' => 'confirmed',
         ]);
     }
 }

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -51,7 +51,7 @@ class PasswordResetTest extends BrowserKitTestCase
 
         // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
         $this->seeIsAuthenticatedAs($user, 'web');
-        $this->assertRedirectedTo('https://www-dev.dosomething.org/next/login');
+        $this->assertRedirectedTo(config('services.phoenix.url').'/next/login');
 
         // And their account should be updated with their new password.
         $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));
@@ -120,7 +120,7 @@ class PasswordResetTest extends BrowserKitTestCase
 
         // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
         $this->seeIsAuthenticatedAs($user, 'web');
-        $this->assertRedirectedTo('https://www-dev.dosomething.org/next/login');
+        $this->assertRedirectedTo(config('services.phoenix.url').'/next/login');
 
         // And their account should be updated with their new password.
         $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -210,6 +210,7 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         $this->see('The first name may not be greater than 50 characters');
         $this->see('The birthdate must be a date before now');
+        $this->see('The voter registration status field is required');
 
         $this->dontSeeIsAuthenticated('web');
     }


### PR DESCRIPTION
#### What's this PR do?
This PR removes the - long running 😅- Sixpack A/B test determining the effectiveness and safety of making the Voter Registration Status field mandatory.

We've selected a winner -- mandatory! 

https://github.com/DoSomething/northstar/pull/872/commits/6d4c96dce581e9a87cae02d4f650a0240da24555 updates the `BrowserKitTestCase#register` method to fill out the -now mandatory- `voter_registration_status_field`. And https://github.com/DoSomething/northstar/pull/872/commits/f9331b25dd19a7a1f7bbf4f743de4d81464c6ad2 expects the voter reg validation message to display for an invalid registration.

 I was getting a local test failure because I hadn't set the `PHOENIX_URL` env variable, causing some reset password flow tests to cry. I figured it might be nice to remove the hardcoded `www-dev` value in favor of pulling the `PHOENIX_URL` in  https://github.com/DoSomething/northstar/pull/872/commits/46d429fceccb97124d4a7ff80bc30eb525035eb4, since that's what's used to determine this URL in the reset password flow https://github.com/DoSomething/northstar/blob/46d429fceccb97124d4a7ff80bc30eb525035eb4/app/Http/Controllers/Web/ResetPasswordController.php#L122

#### How should this be reviewed?
Does the form still work? Did I just break the site?

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/165160297

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
