### PR TITLE
Voter Registration Field Label Height - Bug Fix

### DIFF
--- a/resources/assets/scss/_components/_field-label.scss
+++ b/resources/assets/scss/_components/_field-label.scss
@@ -1,0 +1,5 @@
+
+// Overrides the static height definition for .field-label in Forge (https://git.io/fjl59)
+.field-label.height-auto {
+  height: auto;
+}

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -22,6 +22,7 @@
 @import "_components/_divider";
 @import "_components/_password-visibility";
 @import "_components/_text-field";
+@import "_components/_field-label";
 
 // Regions - complete sections of an interface
 @import "_regions/_chrome";

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -74,7 +74,7 @@
             </div>
 
             <div class="form-item">
-                <label for="voter_registration_status" class="field-label">{{ "Are you registered to vote at your current address?"}}</label>
+                <label for="voter_registration_status" class="field-label height-auto">{{ "Are you registered to vote at your current address?"}}</label>
                 <div class="form-item -reduced">
                     <label class="option -radio">
                       <input type="radio" name="voter_registration_status" value="confirmed">


### PR DESCRIPTION
#### What's this PR 
This PR fixes a lil bug that popped up with the Voter Registration Status field in the register form which would hide some overflow text on certain breakpoints.

It adds a new `.height-auto` field, which when applied to an element of `.field-label` persuasion, will set `height: auto` to override Forge's `height: 1.5em` applied to `.field-label`s.

#### How should this be reviewed?
Does the field not get hidden anymore as you adjust the viewport size?

I tried to conform to the style style, by adding a new `_field-label.scss` file within which to declare this new class. Was this correct?

#### Relevant Tickets
Subtask in https://www.pivotaltracker.com/story/show/165160297

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  

📸 

**Before**
![image](https://user-images.githubusercontent.com/12417657/57865788-3a7fd280-77cc-11e9-8526-f69120e21850.png)
**After**
![image](https://user-images.githubusercontent.com/12417657/57865833-4cfa0c00-77cc-11e9-8299-fa1207bb4a78.png)

