### PR TITLE
Pre-fill Submitted Value for Voter Registration Status Field

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -77,21 +77,21 @@
                 <label for="voter_registration_status" class="field-label height-auto">{{ "Are you registered to vote at your current address?"}}</label>
                 <div class="form-item -reduced">
                     <label class="option -radio">
-                      <input type="radio" name="voter_registration_status" value="confirmed">
+                      <input type="radio" name="voter_registration_status" value="confirmed" {{ old('voter_registration_status') === 'confirmed' ? 'checked' : '' }}>
                       <span class="option__indicator"></span>
                       <span>Yes</span>
                     </label>
                 </div>
                 <div class="form-item -reduced">
                     <label class="option -radio">
-                      <input type="radio" name="voter_registration_status" value="unregistered">
+                      <input type="radio" name="voter_registration_status" value="unregistered" {{ old('voter_registration_status') === 'unregistered' ? 'checked' : '' }}>
                       <span class="option__indicator"></span>
                       <span>No</span>
                     </label>
                 </div>
                 <div class="form-item -reduced">
                     <label class="option -radio">
-                      <input type="radio" name="voter_registration_status" value="uncertain">
+                      <input type="radio" name="voter_registration_status" value="uncertain" {{ old('voter_registration_status') === 'uncertain' ? 'checked' : '' }}>
                       <span class="option__indicator"></span>
                       <span>I'm not sure</span>
                     </label>


### PR DESCRIPTION
#### What's this PR do?
Auto-populates the voter registration status field in the registration form (based on old input) if the backend returns the form post-submission with validation errors.

#### How should this be reviewed?
Should be quite straightforward. Do you think a helper method would be worthwhile here? I started setting one up, but it sort of felt like more bloat then DRYness since this is somewhat specific, but do you think it would be worthwhile?

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/164023428

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
