### PR TITLE
Add Category and Label to GTM Data Layer

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -38,7 +38,7 @@ function trackEvent(puck, event) {
   }
   // Push event to Google Tag Manager's data layer.
   window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push({ event: eventName });
+  window.dataLayer.push({ category, event: eventName, label });
 }
 
 function init() {


### PR DESCRIPTION
#### What's this PR do?
Adds the event 'category' and 'label' to the object pushed to the Google Tag Manager `dataLayer` for each tracked analytics event.

This is part of the analytics quest to be able to have GTM push directly to GA removing that level of effort from the application itself.

#### How should this be reviewed?
👁

#### Relevant Tickets
N/A

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
