### PR TITLE
Accept additional UTM parameters and store on new registrations.

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -84,8 +84,12 @@ class AuthController extends BaseController
                 'title' => request()->query('title', trans('auth.get_started.create_account')),
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
-                'trafficSource' => request()->query('trafficSource'),
-                'referrerId' => request()->query('referrerId'),
+                'source_detail' => array_filter([
+                    'contentful_id' => request()->query('contentful_id'),
+                    'utm_source' => request()->query('utm_source'),
+                    'utm_medium' => request()->query('utm_medium'),
+                    'utm_campaign' => request()->query('utm_campaign'),
+                ]),
             ]);
 
             return redirect()->guest($authorizationRoute);
@@ -215,9 +219,9 @@ class AuthController extends BaseController
             }
 
             // Set source_detail, if applicable.
-            $sourceDetail = get_source_detail();
+            $sourceDetail = session('source_detail');
             if ($sourceDetail) {
-                $user->source_detail = $sourceDetail;
+                $user->source_detail = stringify_object($sourceDetail);
             }
         });
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -293,24 +293,13 @@ function convert($experiment)
 }
 
 /**
- * Create a formatted source_detail string using session values.
+ * Create a formatted key-value string, like for source_detail.
  *
+ * @param object $object
  * @return string
  */
-function get_source_detail()
+function stringify_object($object)
 {
-    $trafficSource = session()->pull('trafficSource');
-    $referrerId = session()->pull('referrerId');
-
-    $sourceDetail = [];
-
-    if ($trafficSource) {
-        array_push($sourceDetail, 'utm_medium:'.$trafficSource);
-    }
-
-    if ($referrerId) {
-        array_push($sourceDetail, 'referrer_id:'.$referrerId);
-    }
-
-    return implode($sourceDetail, ',');
+    // e.g. utm_source:test,utm_medium:internet,utm_campaign:uconn_lady_huskies
+    return str_replace('=', ':', http_build_query($object, '', ','));
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for storing `utm_source` and  `utm_campaign` in a user's `source_detail` field when they're registering [via Phoenix](https://github.com/DoSomething/phoenix-next/blob/a34848047cb3868e105f74e01819f37f6388f4f1/resources/assets/selectors/index.js#L14-L18). I've also changed `referrer_id` to `contentful_id` for clarity & consistency with how the same data is tracked on signups & posts in Rogue.

#### How should this be reviewed?
👀

#### Relevant Tickets
[#166250944](https://www.pivotaltracker.com/story/show/166250944)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
