### PR TITLE
Adding Snowplow Analytics (& general analytics updates)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,6 @@ SIXPACK_COOKIE_PREFIX=null
 SIXPACK_TIMEOUT=null
 
 # Google Analytics:
-GOOGLE_ANALYTICS_ID=
 GOOGLE_TAG_MANAGER_ID=
 
 # Snowplow Analytics

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -254,6 +254,7 @@ function get_client_environment_vars()
 {
     return [
         'PUCK_URL' => config('services.puck.url'),
+        'PHOENIX_URL' => config('services.phoenix.url'),
     ];
 }
 

--- a/config/services.php
+++ b/config/services.php
@@ -15,7 +15,6 @@ return [
     */
 
     'analytics' => [
-        'id' => env('GOOGLE_ANALYTICS_ID'),
         'google_tag_manager_id' => env('GOOGLE_TAG_MANAGER_ID'),
         'snowplow_url' => env('SNOWPLOW_URL'),
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2439,8 +2439,7 @@
         "core-js": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-          "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
-          "dev": true
+          "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
         },
         "semver": {
           "version": "6.1.1",
@@ -2634,8 +2633,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -3481,7 +3479,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3502,12 +3501,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3522,17 +3523,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3649,7 +3653,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3661,6 +3666,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3675,6 +3681,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3682,12 +3689,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3706,6 +3715,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3786,7 +3796,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3798,6 +3809,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3883,7 +3895,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3919,6 +3932,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3938,6 +3952,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3981,12 +3996,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5679,6 +5696,25 @@
         "prepend-http": "^2.0.0",
         "query-string": "^5.0.1",
         "sort-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "dev": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
       }
     },
     "npm-run-path": {
@@ -6343,14 +6379,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.7.0.tgz",
+      "integrity": "sha512-oQ01H1jrgDRbPq5SjtJF470S418GOrKkds+fpvAt6DQatHXl7bmkaJulHbTIM+QNGtoPpa8f5k9W3Zk50zXRPQ==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -7236,6 +7271,11 @@
       "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7353,10 +7393,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -961,11 +961,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@dosomething/analytics": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dosomething/analytics/-/analytics-1.0.2.tgz",
-      "integrity": "sha1-AlzFowkAazGCrZI8zMJBwxq28jQ="
-    },
     "@dosomething/babel-preset": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@dosomething/babel-preset/-/babel-preset-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@dosomething/analytics": "^1.0.2",
     "@dosomething/forge": "^6.9.1",
     "@dosomething/puck-client": "^1.6.0",
     "core-js": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "graphql-tag": "^2.10.1",
     "jquery": "^3.4.0",
     "lodash": "^4.17.11",
-    "mailcheck": "^1.1.1"
+    "mailcheck": "^1.1.1",
+    "query-string": "^6.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -135,8 +135,8 @@ export function analyzeWithPuck(name, data) {
  * @return {void}
  */
 export function analyzeWithGoogle(name, category, action, label, data) {
-  if (!category || !action) {
-    console.error('The Category or Action is missing!');
+  if (!name || !category || !action || !label) {
+    console.error('Some expected data is missing!');
     return;
   }
 

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -118,6 +118,10 @@ export function analyzeWithGoogle(name, category, action, label, data) {
 
   const flattenedData = stringifyNestedObjects(data);
 
+  if (window.NORTHSTAR_ID) {
+    flattenedData.userId = window.NORTHSTAR_ID;
+  }
+
   const analyticsEvent = {
     event: name,
     eventAction: startCase(action),

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -5,7 +5,7 @@ const Validation = require('dosomething-validation');
 const { Engine } = require('@dosomething/puck-client');
 const {
   flattenDeep,
-  isNul,
+  isNil,
   isObjectLike,
   mapValues,
   omitBy,

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -196,7 +196,13 @@ export function trackAnalyticsEvent({ metadata, context = {}, service }) {
 
   const name = formatEventName(verb, noun, adjective);
 
-  const data = withoutValueless(context);
+  const data = withoutValueless({
+    ...context,
+    utmSource: query('utm_source'),
+    utmMedium: query('utm_medium'),
+    utmCampaign: query('utm_campaign'),
+  });
+
   const action = snakeCase(`${target}_${verb}`);
 
   sendToServices(name, category, action, label, data, service);

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -270,9 +270,21 @@ function init() {
     puckClient = puckClientInit();
   }
 
-  // If available, set User ID for Snowplow analytics.
-  if (typeof window.snowplow === 'function' && window.NORTHSTAR_ID) {
-    window.snowplow('setUserId', window.NORTHSTAR_ID);
+  if (typeof window.snowplow === 'function') {
+    // If available, set User ID for Snowplow analytics.
+    if (window.NORTHSTAR_ID) {
+      window.snowplow('setUserId', window.NORTHSTAR_ID);
+    }
+
+    // Track page view to Snowplow analytics.
+    window.snowplow('trackPageView', null, [
+      {
+        schema: `${window.ENV.PHOENIX_URL}/snowplow_schema.json`,
+        data: {
+          payload: JSON.stringify(withoutValueless(getAdditionalContext())),
+        },
+      },
+    ]);
   }
 
   // Validation Events for the Register form.

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -63,18 +63,13 @@ export function analyzeWithPuck(name, data) {
  * @param  {Object} data
  * @return {void}
  */
-export function analyzeWithGoogleAnalytics(
-  name,
-  category,
-  action,
-  label,
-  data,
-) {
+export function analyzeWithGoogle(name, category, action, label, data) {
   if (!category || !action) {
     console.error('The Category or Action is missing!');
     return;
   }
 
+  // @DEPRECATE
   Analytics.analyze(category, action, label);
 
   // Push event action to Google Tag Manager's data layer.
@@ -100,7 +95,7 @@ export function analyzeWithGoogleAnalytics(
 const sendToServices = (name, category, action, label, data, service) => {
   switch (service) {
     case 'ga':
-      analyzeWithGoogleAnalytics(name, category, action, label, data);
+      analyzeWithGoogle(name, category, action, label, data);
       break;
 
     case 'puck':
@@ -108,7 +103,7 @@ const sendToServices = (name, category, action, label, data, service) => {
       break;
 
     default:
-      analyzeWithGoogleAnalytics(name, category, action, label, data);
+      analyzeWithGoogle(name, category, action, label, data);
       analyzeWithPuck(name, data);
   }
 };

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -10,7 +10,7 @@ const {
   omitBy,
   snakeCase,
   startCase,
-} = require("lodash");
+} = require('lodash');
 
 // App name prefix used for analytics event naming.
 const APP_PREFIX = 'northstar';

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -270,6 +270,11 @@ function init() {
     puckClient = puckClientInit();
   }
 
+  // If available, set User ID for Snowplow analytics.
+  if (typeof window.snowplow === 'function' && window.NORTHSTAR_ID) {
+    window.snowplow('setUserId', window.NORTHSTAR_ID);
+  }
+
   // Validation Events for the Register form.
   Validation.Events.subscribe('Validation:InlineError', (topic, args) => {
     // Tracks each individual inline error.

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -116,15 +116,19 @@ export function analyzeWithGoogle(name, category, action, label, data) {
   // @DEPRECATE
   Analytics.analyze(category, action, label);
 
-  // Push event action to Google Tag Manager's data layer.
-  window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push({
+  const flattenedData = stringifyNestedObjects(data);
+
+  const analyticsEvent = {
     event: name,
     eventAction: startCase(action),
     eventCategory: startCase(category),
     eventLabel: startCase(label),
-    eventContext: data,
-  });
+    ...flattenedData,
+  }
+
+  // Push event action to Google Tag Manager's data layer.
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(analyticsEvent);
 }
 
 /**

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -181,9 +181,10 @@ export function trackAnalyticsEvent({ metadata, context = {}, service }) {
 
   const name = formatEventName(verb, noun, adjective);
 
+  const data = withoutValueless(context);
   const action = snakeCase(`${target}_${verb}`);
 
-  sendToServices(name, category, action, label, context, service);
+  sendToServices(name, category, action, label, data, service);
 }
 
 // Helper method to track field focus analytics events.

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -1,14 +1,58 @@
 const $ = require('jquery');
-const { flattenDeep, snakeCase, startCase } = require('lodash');
 const Analytics = require('@dosomething/analytics');
 const Validation = require('dosomething-validation');
 const { Engine } = require('@dosomething/puck-client');
+const {
+  flattenDeep,
+  isNul,
+  isObjectLike,
+  mapValues,
+  omitBy,
+  snakeCase,
+  startCase,
+} = require("lodash");
 
 // App name prefix used for analytics event naming.
 const APP_PREFIX = 'northstar';
 
 // Variable that stores the instance of PuckClient.
 let puckClient = null;
+
+/**
+ * Stringify all properties on an object whose value is object with properties.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function stringifyNestedObjects(data) {
+  return mapValues(data, value => {
+    if (isObjectLike(value)) {
+      return JSON.stringify(value);
+    }
+
+    return value;
+  });
+}
+
+/**
+ * Return a boolean indicating whether the provided argument is a string.
+ *
+ * @param  {Mixed}  string
+ * @return {Boolean}
+ */
+export function isEmptyString(string) {
+  return string === '';
+}
+
+/**
+ * Remove items from object with null, undefined, or empty string values.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutValueless(data) {
+  return omitBy(omitBy(data, isNil), isEmptyString);
+}
 
 /**
  * Parse analytics event name parameters into a snake cased string.

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -70,6 +70,19 @@ export function withoutValueless(data) {
 }
 
 /**
+ * Get additional context data.
+ *
+ * @return {Object}
+ */
+export function getAdditionalContext() {
+  return {
+    utmSource: query('utm_source'),
+    utmMedium: query('utm_medium'),
+    utmCampaign: query('utm_campaign'),
+  };
+}
+
+/**
  * Parse analytics event name parameters into a snake cased string.
  *
  * @param  {String}      verb
@@ -198,9 +211,7 @@ export function trackAnalyticsEvent({ metadata, context = {}, service }) {
 
   const data = withoutValueless({
     ...context,
-    utmSource: query('utm_source'),
-    utmMedium: query('utm_medium'),
-    utmCampaign: query('utm_campaign'),
+    ...getAdditionalContext(),
   });
 
   const action = snakeCase(`${target}_${verb}`);

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -1,4 +1,5 @@
 const $ = require('jquery');
+const queryString = require('query-string');
 const Analytics = require('@dosomething/analytics');
 const Validation = require('dosomething-validation');
 const { Engine } = require('@dosomething/puck-client');
@@ -17,6 +18,20 @@ const APP_PREFIX = 'northstar';
 
 // Variable that stores the instance of PuckClient.
 let puckClient = null;
+
+/**
+ * Get the query-string value at the given key.
+ *
+ * @param  {String}   key
+ * @param  {URL|Location}   url
+ * @return {String|Undefined}
+ */
+export function query(key, url = window.location) {
+  // Ensure we have a URL object from the location.
+  const search = queryString.parse(url.search);
+
+  return search[key];
+}
 
 /**
  * Stringify all properties on an object whose value is object with properties.

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -164,6 +164,31 @@ export function analyzeWithGoogle(name, category, action, label, data) {
 }
 
 /**
+ * Send event to analyze with Snowplow.
+ *
+ * @param  {String} name
+ * @param  {String} category
+ * @param  {String} action
+ * @param  {String} label
+ * @param  {Object} data
+ * @return {void}
+ */
+export function analyzeWithSnowplow(name, category, action, label, data) {
+  if (!window.snowplow) {
+    return;
+  }
+
+  window.snowplow('trackStructEvent', category, action, label, name, null, [
+    {
+      schema: `${window.ENV.PHOENIX_URL}/snowplow_schema.json`,
+      data: {
+        payload: JSON.stringify(data),
+      },
+    },
+  ]);
+}
+
+/**
  * Dispatch analytics event to specified service, or all services by default.
  *
  * @param  {String}      category
@@ -185,6 +210,7 @@ const sendToServices = (name, category, action, label, data, service) => {
     default:
       analyzeWithGoogle(name, category, action, label, data);
       analyzeWithPuck(name, data);
+      analyzeWithSnowplow(name, category, action, label, data);
   }
 };
 

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -1,6 +1,5 @@
 const $ = require('jquery');
 const queryString = require('query-string');
-const Analytics = require('@dosomething/analytics');
 const Validation = require('dosomething-validation');
 const { Engine } = require('@dosomething/puck-client');
 const {
@@ -141,9 +140,6 @@ export function analyzeWithGoogle(name, category, action, label, data) {
     return;
   }
 
-  // @DEPRECATE
-  Analytics.analyze(category, action, label);
-
   const flattenedData = stringifyNestedObjects(data);
 
   if (window.NORTHSTAR_ID) {
@@ -264,8 +260,6 @@ function trackInputFocus(inputName) {
 }
 
 function init() {
-  Analytics.init();
-
   if (!puckClient) {
     puckClient = puckClientInit();
   }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,7 +12,6 @@
     <link rel="shortcut icon" href="{{ asset('favicon.ico') }}">
     <link rel="apple-touch-icon-precomposed" href="{{ asset('apple-touch-icon-precomposed.png') }}">
 
-    @include('layouts.google_analytics')
     @include('layouts.google_tag_manager')
     @include('layouts.snowplow')
 

--- a/resources/views/layouts/google_analytics.blade.php
+++ b/resources/views/layouts/google_analytics.blade.php
@@ -1,7 +1,0 @@
-@if (config('services.analytics.id'))
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', '{{ config('services.analytics.id') }}', 'auto');ga('send', 'pageview');
-    </script>
-@endif
-

--- a/resources/views/layouts/snowplow.blade.php
+++ b/resources/views/layouts/snowplow.blade.php
@@ -4,12 +4,51 @@
           p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
           };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
           n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,'script','//d1fc8wv8zag5ca.cloudfront.net/2.5.3/sp.js','snowplow'));
+
           window.snowplow('newTracker', 'cf', '{{config('services.analytics.snowplow_url')}}', {
             appId: 'northstar',
             cookieDomain: null,
             discoverRootDomain: true
         });
+    </script>
+@else
+    {{-- Custom script for logging Snowplow events to the console when no ENV variable provided. --}}
+    <script type='text/javascript'>
+        window.snowplow = function () {
+            console.groupCollapsed(
+                '%c SNOWPLOW: %c %c %s %c@%c %s %c',
+                'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
+                'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
+                'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
+                'Function Name',
+                'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
+                'color: black; font-weight: bold;',
+                arguments[0],
+                'background-color: rgba(105,157,215,0.5);',
+            );
 
-        window.snowplow('trackPageView');
+            switch (arguments[0]) {
+                case 'setUserId':
+                    console.log('User ID:', arguments[1]);
+                    break;
+
+                case 'trackStructEvent':
+                    console.log('Category: ', arguments[1]);
+                    console.log('Action: ', arguments[2]);
+                    console.log('Label: ', arguments[3]);
+                    console.log('Name: ', arguments[4]);
+                    // arguments[5] is always null
+                    console.log('Context: ', JSON.parse(arguments[6][0]['data']['payload']));
+                    break;
+
+                case 'trackPageView':
+                    console.log('Context: ', JSON.parse(arguments[2][0]['data']['payload']));
+                    break;
+
+                default:
+                    console.log(arguments);
+            }
+            console.groupEnd();
+        };
     </script>
 @endif

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -109,7 +109,7 @@
                 <input type="submit" class="button" value="Save">
             </div>
             <ul class="form-actions">
-                <li><a href="{{ url('users/'.$user->id) }}" data-track-category="Profile Edit" data-track-action="Clicked" data-track-label="Cancel">Cancel</a></li>
+                <li><a href="{{ url('users/'.$user->id) }}">Cancel</a></li>
             </ul>
         </div>
     </form>


### PR DESCRIPTION
#### What's this PR do?
This PR puts our analytics up to speed with the current implementation on Phoenix.

Most notably:
- adds Snowplow analytics tracking (page views, all other events...)
- updates the data decorating & formatting. (removing empty values, appending UTMs and User ID....)
- removes Google Analytics and the @dosomething/analytics package.

#### How should this be reviewed?
There's quite barely anything novel happening on top of the current Phoenix implementation. I'd recommend going through this commit-by-commit, and referencing Phoenix (primarily the [`analytics` helper file](https://github.com/DoSomething/phoenix-next/blob/d2e6f4b5e75e27d5bb82563cae8f86e558c1b633/resources/assets/helpers/analytics.js) if necessary.)

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/166546346

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
