### PR TITLE
Manually setting Snowplow cookie domain to ds root domain.

### DIFF
--- a/resources/views/layouts/snowplow.blade.php
+++ b/resources/views/layouts/snowplow.blade.php
@@ -7,8 +7,7 @@
 
           window.snowplow('newTracker', 'cf', '{{config('services.analytics.snowplow_url')}}', {
             appId: 'northstar',
-            cookieDomain: null,
-            discoverRootDomain: true
+            cookieDomain: '.dosomething.org'
         });
     </script>
 @else


### PR DESCRIPTION
#### What's this PR do?
@mendelB Tracked down that the version of the Snowplow Tracker we use from Fivetran doesn't support the `discoverRootDomain` functionality, and this was validated by Megha in Quasar that we're not seeing cross-domain sessions and `domain_userid` between Northstar and Phoenix. 😡 

It is possible to set the cookie domain for cross-domain tracking in Snowplow Tracker version 2.5.3 as noted [here](https://github.com/snowplow/snowplow/wiki/1-General-parameters-for-the-Javascript-tracker-v2.5#223-configuring-the-cookie-domain). 

This PR removes the root domain discovery and manually sets the domain to be wildcard as [described](https://github.com/snowplow/snowplow/wiki/1-General-parameters-for-the-Javascript-tracker-v2.5#223-configuring-the-cookie-domain) in the 2.5.3 documentation.

#### How should this be reviewed?
Unfortunately only way to test this is to get web-data, and lots of it to validate cross-domain functionality.

#### Relevant Tickets
https://dosomething.slack.com/archives/CJU7WCQG4/p1561414915100800

[Corollary Phoenix PR](https://github.com/DoSomething/phoenix-next/pull/1474).