### PR TITLE
Use 70/30 split for badges

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -230,7 +230,7 @@ class AuthController extends BaseController
             $feature_flags = $user->feature_flags;
 
             // Give 70% users the badges flag (1-7), 30% in control (8-10)
-            $feature_flags['badges'] = ( rand(1, 10) < 8);
+            $feature_flags['badges'] = (rand(1, 10) < 8);
 
             $user->feature_flags = $feature_flags;
         }

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -225,11 +225,12 @@ class AuthController extends BaseController
             }
         });
 
-        // If the badges test is running, put half of users in badges group and half in control group
+        // If the badges test is running, sort users into badges group control group
         if (config('features.badges')) {
             $feature_flags = $user->feature_flags;
 
-            $feature_flags['badges'] = (bool) rand(0, 1);
+            // Give 70% users the badges flag (1-7), 30% in control (8-10)
+            $feature_flags['badges'] = ( rand(1, 10) < 8);
 
             $user->feature_flags = $feature_flags;
         }


### PR DESCRIPTION
#### What's this PR do?
Update the badges feature_flag work to use a 70/30 split (70% receive badge experience) instead of 50/50.

#### How should this be reviewed?
Will this give each new user a 70% chance of getting opted into badges and a 30% chance of being opted into the control group?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/165719698)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
