### PR TITLE
Update SMS compliance language on registration form.

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -61,7 +61,7 @@
                     <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') }}" data-validate="phone" />
                 </div>
                 <div class="form-item">
-                    <p class="footnote"><em>DoSomething.org will send you updates from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for help. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages.
+                    <p class="footnote"><em>DoSomething.org will send you updates about different social change actions and scholarship opportunities from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for help. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages.
                     <br>
                     T-Mobile is not liable for delayed or undelivered messages.</em></p>
                 </div>


### PR DESCRIPTION
### What's this PR do?
This pull updates our compliance language on the registration form, based on the [latest recommendations](https://dosomething.slack.com/archives/C02BBRN5A/p1560284524012300) we've received from Twilio.

#### Before:
![Screen Shot 2019-06-27 at 11 05 19 AM](https://user-images.githubusercontent.com/583202/60277470-978e9e00-98cb-11e9-905f-bb2e919ac2ba.png)

#### After:
![Screen Shot 2019-06-27 at 11 08 09 AM](https://user-images.githubusercontent.com/583202/60277580-dae90c80-98cb-11e9-8f50-1e3289f9aa72.png)


#### How should this be reviewed?
Imagine that you're a cell phone carrier. How does this make you feel?

### Relevant Tickets
[#166936463](https://www.pivotaltracker.com/story/show/166936463)

### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
