### PR TITLE
Snowplow Page View call adjustment

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -264,23 +264,6 @@ function init() {
     puckClient = puckClientInit();
   }
 
-  if (typeof window.snowplow === 'function') {
-    // If available, set User ID for Snowplow analytics.
-    if (window.NORTHSTAR_ID) {
-      window.snowplow('setUserId', window.NORTHSTAR_ID);
-    }
-
-    // Track page view to Snowplow analytics.
-    window.snowplow('trackPageView', null, [
-      {
-        schema: `${window.ENV.PHOENIX_URL}/snowplow_schema.json`,
-        data: {
-          payload: JSON.stringify(withoutValueless(getAdditionalContext())),
-        },
-      },
-    ]);
-  }
-
   // Validation Events for the Register form.
   Validation.Events.subscribe('Validation:InlineError', (topic, args) => {
     // Tracks each individual inline error.
@@ -356,8 +339,26 @@ function init() {
     });
   });
 
-  // Custom tracking events.
   $(document).ready(() => {
+    if (typeof window.snowplow === 'function') {
+      // If available, set User ID for Snowplow analytics.
+      if (window.NORTHSTAR_ID) {
+        window.snowplow('setUserId', window.NORTHSTAR_ID);
+      }
+
+      // Track page view to Snowplow analytics.
+      window.snowplow('trackPageView', null, [
+        {
+          schema: `${window.ENV.PHOENIX_URL}/snowplow_schema.json`,
+          data: {
+            payload: JSON.stringify(withoutValueless(getAdditionalContext())),
+          },
+        },
+      ]);
+    }
+
+    // Custom tracking events:
+
     // Tracks an auto focused form field (which will already be focused upon page load).
     const focusedElement = $('input:focus');
     if (focusedElement.length) {


### PR DESCRIPTION
#### What's this PR do?
Simply waits to call the Snowplow `pageView` & `setUserId` calls unitl the `$(document).ready()` callback is invoked.

This puts the call more at parity with [when we invoke it](https://github.com/DoSomething/phoenix-next/blob/b96abb3a0df3a61ee8caa05f54a9f5b8b8b34dac/resources/assets/init.js#L66) in Phoenix (Though there we use a `domContentLoaded` which is [supposed to be the same](https://eager.io/blog/how-to-decide-when-your-code-should-run/)).

Context:
We seem to be seeing missing page view events on Northstar, this felt like a safe easy way to somewhat rule out them not firing due to being invoked before the snowplow script has had a chance to load!

#### How should this be reviewed?
👓 

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/166546346

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
