### PR TITLE
Adds new password reset type for Breakdown import

### DIFF
--- a/app/PasswordResetType.php
+++ b/app/PasswordResetType.php
@@ -12,6 +12,13 @@ class PasswordResetType
     public static $forgotPassword = 'forgot-password';
 
     /**
+     * A Breakdown Subscriber Activate Account type.
+     *
+     * @var string
+     */
+    public static $breakdownActivateAccount = 'breakdown-activate-account';
+
+    /**
      * A Rock The Vote Activate Account type.
      *
      * @var string
@@ -25,6 +32,10 @@ class PasswordResetType
      */
     public static function all()
     {
-        return [self::$forgotPassword, self::$rockTheVoteActivateAccount];
+        return [
+            self::$forgotPassword,
+            self::$breakdownActivateAccount,
+            self::$rockTheVoteActivateAccount,
+        ];
     }
 }

--- a/documentation/endpoints/resets.md
+++ b/documentation/endpoints/resets.md
@@ -21,6 +21,7 @@ POST /v2/resets
    *
    * Valid types:
    * - 'forgot-password'
+   * - 'breakdown-activate-account'
    * - 'rock-the-vote-activate-account' 
    */
   type: String


### PR DESCRIPTION
#### What's this PR do

Adds `breakdown-activate-account` as a valid password reset type, to be used for sending an activate account email when importing Breakdown subscribers.

#### How should this be reviewed?

Can test locally by verifying that http://northstar.test/password/reset/breakdown-activate-account/23o42039ajslkda returns the password reset form with activate account copy (not a 404)

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/167046582

#### Checklist
- [x] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [x] Post a message in #api if this includes something that causes a rebuild!  
