### PR TITLE
Some quick updates.

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -423,8 +423,7 @@ function init() {
       // Tracks clicking on the Login With Facebook button.
       trackAnalyticsEvent({
         metadata: {
-          category: 'login_facebook',
-          label: 'authentication',
+          category: 'authentication',
           noun: 'login_facebook',
           target: 'button',
           verb: 'clicked',

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -15,7 +15,7 @@ return [
     'get_started' => [
         'log_in' => 'Log in to get started!',
         'create_account' => 'Create a DoSomething.org account to get started!',
-        'call_to_action' => 'Join 6 million young people taking action.',
+        'call_to_action' => 'Join millions of young people taking action.',
     ],
     'validation' => [
         'issues' => 'Hmm, there were some issues with that submission:',


### PR DESCRIPTION
#### What's this PR do?
This PR fixes a typo where the `category` for analytics was switched with the `label`; also turns out that since the `label` and noun` are the same, we don't actually need the `label` (it gets populated w/ the `noun` value.

Also includes a copy fix that @ngjo wanted to get in 💃 

#### How should this be reviewed?
👀 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
