### PR TITLE
Add command to remove two-factor authentication for a user.

### DIFF
--- a/app/Console/Commands/RemoveTotpDevice.php
+++ b/app/Console/Commands/RemoveTotpDevice.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Auth\Registrar;
+use Illuminate\Console\Command;
+
+class RemoveTotpDevice extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'totp:remove {username}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove TOTP device from the given user.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(Registrar $registrar)
+    {
+        $username = $this->argument('username');
+        $user = $registrar->resolve(['username' => $username]);
+
+        if (! $user) {
+            return $this->error('User not found.');
+        }
+
+        if (! $user->totp) {
+            return $this->info('User does not have a TOTP device.');
+        }
+
+        if ($this->confirm('Remove TOTP device from '.$username.' ('.$user->id.')?')) {
+            $user->totp = null;
+            $user->save();
+
+            return $this->info('Removed TOTP device.');
+        }
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a simple `totp:remove` command which allows a developer to remove two-factor authentication for the given user. We can maybe add a self-serve UI for this in a future cleanup sprint.

#### How should this be reviewed?
👀

#### Relevant Tickets
[#167071844](https://www.pivotaltracker.com/story/show/167071844)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
