### PR TITLE
Adds referrer_user_id to source_detail

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -67,9 +67,10 @@ class AuthController extends Controller
                 'title' => request()->query('title', trans('auth.get_started.create_account')),
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
-                // Store any provided UTMs or Contentful ID for user's source_detail:
+                // Store any provided UTMs, Referrer User ID, or Contentful ID for user's source_detail:
                 'source_detail' => array_filter([
                     'contentful_id' => request()->query('contentful_id'),
+                    'referrer_user_id' => request()->query('referrer_user_id'),
                     'utm_source' => request()->query('utm_source'),
                     'utm_medium' => request()->query('utm_medium'),
                     'utm_campaign' => request()->query('utm_campaign'),


### PR DESCRIPTION
#### What's this PR do?

Checks for the `referrer_user_id` sent per https://github.com/DoSomething/phoenix-next/pull/1513.

#### How should this be reviewed?

Can verify in tandem with https://github.com/DoSomething/phoenix-next/pull/1513 to verify new registrations on a campaign page with a `referrer_user_id` query parameter have it set within their `source_detail`:

<img width="400" alt="Screen Shot 2019-07-18 at 5 01 48 PM" src="https://user-images.githubusercontent.com/1236811/61499905-c1dcf400-a97d-11e9-901e-367e9c795c6d.png">


#### Relevant Tickets
* [Technical Spec (still in draft)](https://docs.google.com/document/d/1hzw8eBNLTwFFG2KQFdEHdljJbDpgW1awjG3wYjy_A_Q/edit?disco=AAAADRHqDyw&ts=5d2e5495&usp_dm=false)
* https://www.pivotaltracker.com/n/projects/2019429/stories/166457198/comments/204714050
