### PR TITLE
Add 'northstar:id' command.

### DIFF
--- a/app/Console/Commands/IdentifyUsersCommand.php
+++ b/app/Console/Commands/IdentifyUsersCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use League\Csv\Reader;
+use League\Csv\Writer;
+use Northstar\Auth\Registrar;
+use Illuminate\Console\Command;
+
+class IdentifyUsersCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:id {column=email}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get IDs, given a CSV with column that uniquely identifies users.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(Registrar $registrar)
+    {
+        $column = $this->argument('column');
+        $output = Writer::createFromString();
+        $output->insertOne([$column, 'id']);
+
+        $stdin = file_get_contents('php://stdin');
+        $csv = Reader::createFromString($stdin);
+        $csv->setHeaderOffset(0);
+
+        $count = 0;
+        foreach ($csv->getRecords() as $record) {
+            $user = $registrar->resolve([$column => $record[$column]]);
+            $id = $user ? $user->id : '-';
+
+            $output->insertOne([$record[$column], $id]);
+        }
+
+        $this->line($output->getContent());
+    }
+}

--- a/app/Console/Commands/IdentifyUsersCommand.php
+++ b/app/Console/Commands/IdentifyUsersCommand.php
@@ -48,7 +48,6 @@ class IdentifyUsersCommand extends Command
         $csv = Reader::createFromString($stdin);
         $csv->setHeaderOffset(0);
 
-        $count = 0;
         foreach ($csv->getRecords() as $record) {
             $user = $registrar->resolve([$column => $record[$column]]);
             $id = $user ? $user->id : '-';

--- a/app/Console/Commands/IdentifyUsersCommand.php
+++ b/app/Console/Commands/IdentifyUsersCommand.php
@@ -14,7 +14,7 @@ class IdentifyUsersCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:id {column=email}';
+    protected $signature = 'northstar:id {column=email} {--database_column=}';
 
     /**
      * The console command description.
@@ -51,7 +51,8 @@ class IdentifyUsersCommand extends Command
         $output->insertOne(array_merge(['id'], $csv->getHeader()));
 
         foreach ($csv->getRecords() as $record) {
-            $user = $registrar->resolve([$column => $record[$column]]);
+            $databaseColumn = $this->option('database_column') ?: $column;
+            $user = $registrar->resolve([$databaseColumn => $record[$column]]);
 
             $output->insertOne(array_merge([
                 'id' => $user ? $user->id : '-',

--- a/example.csv
+++ b/example.csv
@@ -1,0 +1,7 @@
+"Requester email address","First Name"
+test@dosomething.org,Dave
+admin@dosomething.org,Admin
+sporer.winston@example.org,Sporer
+haylee.buckridge@example.org,Haylee
+aniya.carroll@example.org,Aniya
+nobody@example.com,Nobody

--- a/tests/Console/IdentifyUsersCommandTest.php
+++ b/tests/Console/IdentifyUsersCommandTest.php
@@ -15,7 +15,7 @@ class IdentifyUsersCommandTest extends TestCase
         User::forceCreate(['_id' => '5d3630a0fdce2742ff6c64d5', 'email' => 'haylee.buckridge@example.org']);
 
         // Run the 'northstar:id' command on the 'example-identify-input.csv' file:
-        $this->artisan('northstar:id', ['input' => $input, 'output' => $output, '--csv_column' => "Requester email address"]);
+        $this->artisan('northstar:id', ['input' => $input, 'output' => $output, '--csv_column' => 'Requester email address']);
 
         // The command should create a CSV matching our expected output:
         $this->assertFileEquals('tests/Console/example-identify-output.csv', $output);

--- a/tests/Console/IdentifyUsersCommandTest.php
+++ b/tests/Console/IdentifyUsersCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Northstar\Models\User;
+
+class IdentifyUsersCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_identify_users()
+    {
+        $input = 'tests/Console/example-identify-input.csv';
+        $output = tempnam(sys_get_temp_dir(), 'IdentifyUsersCommandTest');
+
+        // Create the expected users we're going to identify:
+        User::forceCreate(['_id' => '5d3630a0fdce2742ff6c64d4', 'email' => 'sporer.winston@example.org']);
+        User::forceCreate(['_id' => '5d3630a0fdce2742ff6c64d5', 'email' => 'haylee.buckridge@example.org']);
+
+        // Run the 'northstar:id' command on the 'example-identify-input.csv' file:
+        $this->artisan('northstar:id', ['input' => $input, 'output' => $output, '--csv_column' => "Requester email address"]);
+
+        // The command should create a CSV matching our expected output:
+        $this->assertFileEquals('tests/Console/example-identify-output.csv', $output);
+    }
+}

--- a/tests/Console/example-identify-input.csv
+++ b/tests/Console/example-identify-input.csv
@@ -1,7 +1,4 @@
 "Requester email address","First Name"
-test@dosomething.org,Dave
-admin@dosomething.org,Admin
 sporer.winston@example.org,Sporer
 haylee.buckridge@example.org,Haylee
-aniya.carroll@example.org,Aniya
 nobody@example.com,Nobody

--- a/tests/Console/example-identify-output.csv
+++ b/tests/Console/example-identify-output.csv
@@ -1,0 +1,4 @@
+id,"Requester email address","First Name"
+5d3630a0fdce2742ff6c64d4,sporer.winston@example.org,Sporer
+5d3630a0fdce2742ff6c64d5,haylee.buckridge@example.org,Haylee
+N/A,nobody@example.com,Nobody


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `northstar:id` command that can be used to resolve user IDs from a CSV based on an indexed field on the users collection (such as `email` or `mobile`). For example:

```
$ cat example.csv
email
test@dosomething.org
admin@dosomething.org
sporer.winston@example.org
haylee.buckridge@example.org
aniya.carroll@example.org

$ cat example.csv | php artisan northstar:id
email,id
test@dosomething.org,5d36309ffdce2742ff6c64d2
admin@dosomething.org,5d3630a0fdce2742ff6c64d3
sporer.winston@example.org,5d3630a0fdce2742ff6c64d4
haylee.buckridge@example.org,5d3630a0fdce2742ff6c64d5
aniya.carroll@example.org,5d3630a0fdce2742ff6c64d6
```

I'm experimenting with using standard input to provide the CSV to the Artisan command (which should be [supported by `heroku run`](https://devcenter.heroku.com/articles/one-off-dynos#formation-dynos-vs-one-off-dynos)) because that means we won't need to put these CSVs in an S3 bucket in order to process them.

#### How should this be reviewed?
Give it a look! I'll see if I can write up a test before merging this.

#### Relevant Tickets
[#167327823](https://www.pivotaltracker.com/story/show/167327823)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
