### PR TITLE
Update our "delete user" command.

### DIFF
--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -74,5 +74,7 @@ class DeleteUsersCommand extends Command
 
             $this->info('Deleted: '.$user->id);
         }
+
+        $this->info('Done!');
     }
 }

--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -34,12 +34,14 @@ class DeleteUsersCommand extends Command
         $csv = Reader::createFromString($input);
         $csv->setHeaderOffset(0);
 
-        $this->line('Anonymized '.count($csv).' users...');
+        $this->line('Anonymizing '.count($csv).' users...');
 
         foreach ($csv->getRecords() as $record) {
-            $user = User::find($record[$this->option('id_column')]);
+            $id = $record[$this->option('id_column')];
+            $user = User::find($id);
+
             if (! $user) {
-                $this->warn('Skipping: '.$record[$this->option('id_column')]);
+                $this->warn('Skipping: '.$id);
                 continue;
             }
 

--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -59,6 +59,10 @@ class DeleteUsersCommand extends Command
                 $user->drop($fields);
             }
 
+            // Set a flag so we know this user was deleted:
+            $user->deleted_at = now();
+            $user->save();
+
             // Delete refresh tokens to end any active sessions:
             $token = RefreshToken::where('user_id', $user->id)->delete();
 

--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -7,14 +7,14 @@ use Northstar\Models\User;
 use Illuminate\Console\Command;
 use Northstar\Models\RefreshToken;
 
-class AnonymizeUserCommand extends Command
+class DeleteUsersCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'northstar:anon {path}';
+    protected $signature = 'northstar:delete {path}';
 
     /**
      * The console command description.

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -125,4 +125,20 @@ class Model extends BaseModel
 
         return $changed;
     }
+
+    /**
+     * Save the model to the database, without model events.
+     * @see https://stackoverflow.com/a/51301753
+     *
+     * @param array $options
+     */
+    public function saveQuietly(array $options = [])
+    {
+        $dispatcher = self::getEventDispatcher();
+        self::unsetEventDispatcher();
+
+        $this->save($options);
+
+        self::setEventDispatcher($dispatcher);
+    }
 }

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -2,6 +2,8 @@
 
 namespace Northstar\Services;
 
+use Northstar\Models\User;
+
 class CustomerIo
 {
     /**
@@ -43,5 +45,16 @@ class CustomerIo
         return $this->client->post('customers/'.$user->id.'/events', [
             'form_params' => $payload,
         ]);
+    }
+
+    /**
+     * Delete the given user's profile in Customer.io
+     * @see https://customer.io/docs/api/#apitrackcustomerscustomers_delete
+     *
+     * @param User $user
+     */
+    public function deleteUser(User $user)
+    {
+        return $this->client->delete('customers/'.$user->id);
     }
 }

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -28,11 +28,17 @@ class DeleteUsersCommandTest extends TestCase
     /**
      * Assert that the given model has been anonymized.
      *
-     * @param User $user
+     * @param User $before
      */
-    protected function assertAnonymized($user)
+    protected function assertAnonymized($before)
     {
-        $attributes = $user->fresh()->getAttributes();
+        $after = $before->fresh();
+        $attributes = $after->getAttributes();
+
+        // The birthdate should be set to January 1st of the same year:
+        $this->assertEquals($before->birthdate->year, $after->birthdate->year);
+        $this->assertEquals(1, $after->birthdate->month);
+        $this->assertEquals(1, $after->birthdate->day);
 
         // We should not see any fields with PII:
         $this->assertArrayNotHasKey('email', $attributes);

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -13,7 +13,7 @@ class DeleteUsersCommandTest extends TestCase
         $user1 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d4'])->first();
         $user2 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d5'])->first();
 
-        // Run the 'northstar:id' command on the 'example-identify-input.csv' file:
+        // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
         $this->artisan('northstar:delete', ['input' => $input]);
 
         // The command should remove

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Northstar\Models\User;
+use Northstar\Services\CustomerIo;
 
 class DeleteUsersCommandTest extends TestCase
 {
@@ -12,6 +13,9 @@ class DeleteUsersCommandTest extends TestCase
         // Create the expected users we're going to destroy:
         $user1 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d4'])->first();
         $user2 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d5'])->first();
+
+        // Mock the Customer.io API & assert that we make two "delete" requests:
+        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->twice();
 
         // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
         $this->artisan('northstar:delete', ['input' => $input]);

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Northstar\Models\User;
+
+class DeleteUsersCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_delete_users()
+    {
+        $input = 'tests/Console/example-identify-output.csv';
+
+        // Create the expected users we're going to destroy:
+        $user1 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d4'])->first();
+        $user2 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d5'])->first();
+
+        // Run the 'northstar:id' command on the 'example-identify-input.csv' file:
+        $this->artisan('northstar:delete', ['input' => $input]);
+
+        // The command should remove
+        $this->assertAnonymized($user1);
+        $this->assertAnonymized($user2);
+    }
+
+    /**
+     * Assert that the given model has been anonymized.
+     *
+     * @param User $user
+     */
+    protected function assertAnonymized($user)
+    {
+        $attributes = $user->fresh()->getAttributes();
+
+        // We should not see any fields with PII:
+        $this->assertArrayNotHasKey('email', $attributes);
+        $this->assertArrayNotHasKey('first_name', $attributes);
+        $this->assertArrayNotHasKey('last_name', $attributes);
+        $this->assertArrayNotHasKey('addr_street1', $attributes);
+        $this->assertArrayNotHasKey('addr_street2', $attributes);
+
+        // ...but we should still have some demographic fields:
+        $this->assertArrayHasKey('addr_zip', $attributes);
+    }
+}

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -39,5 +39,8 @@ class DeleteUsersCommandTest extends TestCase
 
         // ...but we should still have some demographic fields:
         $this->assertArrayHasKey('addr_zip', $attributes);
+
+        // We should also have set a "deleted at" flag:
+        $this->assertArrayHasKey('deleted_at', $attributes);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request makes some updates to our "delete user" command, now that we'll be running it more often for account deletion requests:
-  I've renamed it to `northstar:delete` since it's not GDPR-specific anymore.
- I added the ability to pipe in a CSV (like in #901), so we don't need temporary storage.
- I've also updated it to remove _all_ fields (unless whitelisted) and set a `deleted_at` flag.
- Finally, it will now delete each user's profile in Customer.io (including all events).

#### How should this be reviewed?
I added a test for this command in b5b15f9.

#### Relevant Tickets
[#167327865](https://www.pivotaltracker.com/story/show/167327865)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
