### PR TITLE
Write `northstar:delete` command output to logs.

### DIFF
--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -35,14 +35,14 @@ class DeleteUsersCommand extends Command
         $csv = Reader::createFromString($input);
         $csv->setHeaderOffset(0);
 
-        $this->line('Anonymizing '.count($csv).' users...');
+        info('Anonymizing '.count($csv).' users...');
 
         foreach ($csv->getRecords() as $record) {
             $id = $record[$this->option('id_column')];
             $user = User::find($id);
 
             if (! $user) {
-                $this->warn('Skipping: '.$id);
+                info('Skipping: '.$id);
                 continue;
             }
 
@@ -72,9 +72,9 @@ class DeleteUsersCommand extends Command
             // And finally, delete the user's profile in Customer.io:
             $customerIo->deleteUser($user);
 
-            $this->info('Deleted: '.$user->id);
+            info('Deleted: '.$user->id);
         }
 
-        $this->info('Done!');
+        info('Done!');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the `northstar:delete` command to write data to the application's logs so that we can refer back to it in Papertrail after running this command.

![](https://media.giphy.com/media/walCY3Xi1GDYs/giphy.gif)

#### How should this be reviewed?
I keep getting mixed up on how this works! When running a command in "detached" mode, all standard output [is written to the logs](https://devcenter.heroku.com/articles/one-off-dynos#running-tasks-in-background), but "normal" one-off dynos [only log startup & shutdown](https://devcenter.heroku.com/articles/one-off-dynos#formation-dynos-vs-one-off-dynos).

Since we're piping standard input into this command, we can't run in detached mode & so we'll need to make sure we're explicitly writing these to the log. 🎋 

#### Relevant Tickets
[#167327865](https://www.pivotaltracker.com/story/show/167327865)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
