### PR TITLE
Add optional fields proof-of-concept.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ APP_AUTH_KEY=
 # Feature Flags
 DS_ENABLE_BLINK=false
 DS_ENABLE_RATE_LIMITING=false
+DS_OPTIONAL_FIELDS=false
 
 # Drivers:
 MAIL_DRIVER=log

--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -28,6 +28,7 @@ trait TransformsResponses
     public function transform($resource, $code)
     {
         $manager = new Manager();
+        $manager->parseIncludes(request()->query('include', ''));
         $manager->setSerializer(new DataArraySerializer());
         $response = $manager->createData($resource)->toArray();
 

--- a/app/Http/Transformers/BaseTransformer.php
+++ b/app/Http/Transformers/BaseTransformer.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Northstar\Http\Transformers;
+
+use League\Fractal\Scope;
+use Northstar\Models\User;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Gate;
+use League\Fractal\TransformerAbstract;
+
+class BaseTransformer extends TransformerAbstract
+{
+    /**
+     * Resources that can be included if requested.
+     *
+     * @return array
+     */
+    public function getAvailableIncludes()
+    {
+        return static::$model::$sensitive;
+    }
+
+    /**
+     * Set the resources that will be included by default.
+     *
+     * @return array
+     */
+    public function getDefaultIncludes()
+    {
+        // If we've enabled the "optional fields" feature flag, then any fields
+        // containing sensitive information must be explicitly requested:
+        if (config('features.optional_fields')) {
+            return [];
+        }
+
+        // Until then, include everything!
+        return $this->getAvailableIncludes();
+    }
+
+    /**
+     * Load any resources specified by the `?include=` query parameter and
+     * automatically register `includeFieldName` handlers for optional
+     * fields on the User model, with authorization & logging.
+     *
+     * @param Scope  $scope
+     * @param string $attribute
+     * @param mixed  $resource
+     *
+     * @throws \Exception
+     *
+     * @return \League\Fractal\Resource\ResourceInterface
+     */
+    protected function callIncludeMethod(Scope $scope, $attribute, $resource)
+    {
+        // Is this a sensitive attribute? If so, check authorization & log access:
+        if (in_array($attribute, static::$model::$sensitive)) {
+            if (! $this->authorize($resource, $attribute)) {
+                return null;
+            }
+
+            // @TODO: Log access to this optional field.
+            // ...
+        }
+
+        // If we don't have a custom "include" method, try default resolver:
+        if (! method_exists($this, 'include'.Str::studly($attribute))) {
+            return $this->primitive($resource->{$attribute});
+        }
+
+        return parent::callIncludeMethod($scope, $attribute, $resource);
+    }
+}

--- a/app/Http/Transformers/BaseTransformer.php
+++ b/app/Http/Transformers/BaseTransformer.php
@@ -56,8 +56,11 @@ class BaseTransformer extends TransformerAbstract
             return null;
         }
 
-        // @TODO: Log access to this optional field.
-        // ...
+        // Log access to this optional field:
+        if (config('features.optional-fields')) {
+            // @TODO: Can we batch up all the included fields in a single log message?
+            info('Sensitive field viewed for '.$resource->id, ['attribute' => $attribute]);
+        }
 
         // If we don't have a custom "include" method, try default resolver:
         if (! method_exists($this, 'include'.Str::studly($attribute))) {

--- a/app/Http/Transformers/BaseTransformer.php
+++ b/app/Http/Transformers/BaseTransformer.php
@@ -28,7 +28,7 @@ class BaseTransformer extends TransformerAbstract
     {
         // If we've enabled the "optional fields" feature flag, then any fields
         // containing sensitive information must be explicitly requested:
-        if (config('features.optional_fields')) {
+        if (config('features.optional-fields')) {
             return [];
         }
 

--- a/app/Http/Transformers/BaseTransformer.php
+++ b/app/Http/Transformers/BaseTransformer.php
@@ -5,7 +5,6 @@ namespace Northstar\Http\Transformers;
 use League\Fractal\Scope;
 use Northstar\Models\User;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Gate;
 use League\Fractal\TransformerAbstract;
 
 class BaseTransformer extends TransformerAbstract

--- a/app/Http/Transformers/BaseTransformer.php
+++ b/app/Http/Transformers/BaseTransformer.php
@@ -16,7 +16,7 @@ class BaseTransformer extends TransformerAbstract
      */
     public function getAvailableIncludes()
     {
-        return static::$model::$sensitive;
+        return [];
     }
 
     /**
@@ -51,15 +51,13 @@ class BaseTransformer extends TransformerAbstract
      */
     protected function callIncludeMethod(Scope $scope, $attribute, $resource)
     {
-        // Is this a sensitive attribute? If so, check authorization & log access:
-        if (in_array($attribute, static::$model::$sensitive)) {
-            if (! $this->authorize($resource, $attribute)) {
-                return null;
-            }
-
-            // @TODO: Log access to this optional field.
-            // ...
+        // Is the viewer authorized to see this include?
+        if (! $this->authorize($resource, $attribute)) {
+            return null;
         }
+
+        // @TODO: Log access to this optional field.
+        // ...
 
         // If we don't have a custom "include" method, try default resolver:
         if (! method_exists($this, 'include'.Str::studly($attribute))) {

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -8,11 +8,14 @@ use Illuminate\Support\Facades\Gate;
 class UserTransformer extends BaseTransformer
 {
     /**
-     * The model this transformer is processing.
+     * Resources that can be included if requested.
      *
-     * @param User $user
+     * @return array
      */
-    protected static $model = User::class;
+    public function getAvailableIncludes()
+    {
+        return User::$sensitive;
+    }
 
     /**
      * Is the viewer authorized to see the given optional field?

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -4,7 +4,6 @@ namespace Northstar\Http\Transformers;
 
 use Northstar\Models\User;
 use Illuminate\Support\Facades\Gate;
-use League\Fractal\Resource\Primitive;
 
 class UserTransformer extends BaseTransformer
 {
@@ -24,9 +23,12 @@ class UserTransformer extends BaseTransformer
     }
 
     /**
-     * ...
+     * Include the `birthdate` field.
+     *
+     * @return \League\Fractal\Resource\Primitive
      */
-    public function includeBirthdate(User $user) {
+    public function includeBirthdate(User $user)
+    {
         return $this->primitive(format_date($user->birthdate, 'Y-m-d'));
     }
 
@@ -39,14 +41,10 @@ class UserTransformer extends BaseTransformer
         $response = [
             'id' => $user->_id,
             'first_name' => $user->first_name,
+            'display_name' => $user->display_name,
+            'last_initial' => $user->last_initial,
+            'photo' => null,
         ];
-
-        if (Gate::allows('view-full-profile', $user)) {
-            $response['last_name'] = $user->last_name;
-        }
-
-        $response['last_initial'] = $user->last_initial;
-        $response['photo'] = null;
 
         if (Gate::allows('view-full-profile', $user)) {
             $response['facebook_id'] = $user->facebook_id;
@@ -82,6 +80,7 @@ class UserTransformer extends BaseTransformer
         $response['voting_plan_method_of_transport'] = $user->voting_plan_method_of_transport;
         $response['voting_plan_time_of_day'] = $user->voting_plan_time_of_day;
         $response['voting_plan_attending_with'] = $user->voting_plan_attending_with;
+
         $response['language'] = $user->language;
         $response['country'] = $user->country;
 

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -36,6 +36,17 @@ class UserTransformer extends BaseTransformer
     }
 
     /**
+     * Include the `mobile` field.
+     *
+     * @return \League\Fractal\Resource\Primitive
+     */
+    public function includeMobile(User $user)
+    {
+        // @TODO: These `v2/user` endpoints should return the standard E.164 format!
+        return $this->primitive(format_legacy_mobile($user->mobile));
+    }
+
+    /**
      * @param User $user
      * @return array
      */

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -4,10 +4,32 @@ namespace Northstar\Http\Transformers;
 
 use Northstar\Models\User;
 use Illuminate\Support\Facades\Gate;
-use League\Fractal\TransformerAbstract;
+use League\Fractal\Resource\Primitive;
 
-class UserTransformer extends TransformerAbstract
+class UserTransformer extends BaseTransformer
 {
+    /**
+     * The model this transformer is processing.
+     *
+     * @param User $user
+     */
+    protected static $model = User::class;
+
+    /**
+     * Is the viewer authorized to see the given optional field?
+     */
+    public function authorize(User $user, $attribute)
+    {
+        return Gate::allows('view-full-profile', $user);
+    }
+
+    /**
+     * ...
+     */
+    public function includeBirthdate(User $user) {
+        return $this->primitive(format_date($user->birthdate, 'Y-m-d'));
+    }
+
     /**
      * @param User $user
      * @return array
@@ -27,15 +49,10 @@ class UserTransformer extends TransformerAbstract
         $response['photo'] = null;
 
         if (Gate::allows('view-full-profile', $user)) {
-            $response['email'] = $user->email;
-            $response['mobile'] = format_legacy_mobile($user->mobile);
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = [];
-            $response['birthdate'] = format_date($user->birthdate, 'Y-m-d');
 
-            $response['addr_street1'] = $user->addr_street1;
-            $response['addr_street2'] = $user->addr_street2;
             $response['addr_city'] = $user->addr_city;
             $response['addr_state'] = $user->addr_state;
             $response['addr_zip'] = $user->addr_zip;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -147,6 +147,21 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
+     * Attributes that contain personally-indentifiable information. These
+     * can be requested via the API with the `?include=` query parameter.
+     *
+     * @var array
+     */
+    public static $sensitive = [
+        'email',
+        'mobile',
+        'last_name',
+        'addr_street1',
+        'addr_street2',
+        'birthdate',
+    ];
+
+    /**
      * The attributes that should be hidden for arrays.
      *
      * @var array

--- a/config/features.php
+++ b/config/features.php
@@ -20,4 +20,6 @@ return [
 
     'badges' => env('DS_BADGES_TEST', false),
 
+    'optional_fields' => env('DS_OPTIONAL_FIELDS', false),
+
 ];

--- a/config/features.php
+++ b/config/features.php
@@ -20,6 +20,6 @@ return [
 
     'badges' => env('DS_BADGES_TEST', false),
 
-    'optional_fields' => env('DS_OPTIONAL_FIELDS', false),
+    'optional-fields' => env('DS_OPTIONAL_FIELDS', false),
 
 ];

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -90,16 +90,15 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
     /**
      * Assert that the JSON response does not have the given field.
      *
-     * @param  array|null  $structure
-     * @param  array|null  $responseData
+     * @param  string|array  $key - The JSON path, in "dot notation".
      * @return $this
      */
-    public function dontSeeJsonField($path)
+    public function dontSeeJsonField($key)
     {
         $responseData = $this->decodeResponseJson();
 
-        if (array_has($responseData, $path)) {
-            Assert::fail('Did not expect to find JSON response at '.$path);
+        if (array_has($responseData, $key)) {
+            Assert::fail('Did not expect to find JSON response at '.$key);
         }
 
         return $this;
@@ -108,21 +107,21 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
     /**
      * Assert that the JSON response has the given field.
      *
-     * @param  array|null  $structure
-     * @param  array|null  $responseData
+     * @param  string|array  $key - The JSON path, in "dot notation".
+     * @param  mixed $expected - Optionally, the expected value to assert.
      * @return $this
      */
-    public function seeJsonField($path, $expected = null)
+    public function seeJsonField($key, $expected = null)
     {
         $responseData = $this->decodeResponseJson();
 
-        if (! array_has($responseData, $path)) {
-            Assert::fail('Expected to find JSON response at '.$path);
+        if (! array_has($responseData, $key)) {
+            Assert::fail('Expected to find JSON response at '.$key);
         }
 
-        $actual = array_get($responseData, $path);
+        $actual = array_get($responseData, $key);
         if ($expected !== null && $actual !== $expected) {
-            Assert::fail('Expected to find "'.$expected.'" in response at '.$path.', found: '.$actual);
+            Assert::fail('Expected to find "'.$expected.'" in response at '.$key.', found: '.$actual);
         }
 
         return $this;

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -3,6 +3,7 @@
 use Tests\CreatesApplication;
 use Tests\WithMocks;
 use Tests\WithAuthentication;
+use PHPUnit\Framework\Assert;
 
 abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
 {
@@ -82,6 +83,47 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
     {
         $header = $this->transformHeadersToServerVars([$name => $value]);
         $this->serverVariables = array_merge($this->serverVariables, $header);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the JSON response does not have the given field.
+     *
+     * @param  array|null  $structure
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function dontSeeJsonField($path)
+    {
+        $responseData = $this->decodeResponseJson();
+
+        if (array_has($responseData, $path)) {
+            Assert::fail('Did not expect to find JSON response at '.$path);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the JSON response has the given field.
+     *
+     * @param  array|null  $structure
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function seeJsonField($path, $expected = null)
+    {
+        $responseData = $this->decodeResponseJson();
+
+        if (! array_has($responseData, $path)) {
+            Assert::fail('Expected to find JSON response at '.$path);
+        }
+
+        $actual = array_get($responseData, $path);
+        if ($expected !== null && $actual !== $expected) {
+            Assert::fail('Expected to find "'.$expected.'" in response at '.$path.', found: '.$actual);
+        }
 
         return $this;
     }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -169,7 +169,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that staffers can request optional fields.
+     * Test that normal users can't request optional fields.
      * GET /v2/users/:id
      *
      * @return void

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -169,6 +169,48 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that staffers can request optional fields.
+     * GET /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2GetOptionalFieldsFromUserAsNormalUser()
+    {
+        config(['features.optional-fields' => true]);
+
+        $user = factory(User::class)->create();
+
+        // Normal users should not be able to query sensitive values for others:
+        $this->asNormalUser()->get('v2/users/'.$user->id.'?include=email,addr_street1');
+        $this->assertResponseOk()
+            ->dontSeeJsonField('data.email')
+            ->dontSeeJsonField('data.addr_street1');
+    }
+
+    /**
+     * Test that staffers can request optional fields.
+     * GET /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2GetOptionalFieldsFromUserAsAdmin()
+    {
+        config(['features.optional-fields' => true]);
+
+        $user = factory(User::class)->create();
+
+        // Check that sensitive fields are not included by default:
+        $this->asStaffUser()->get('v2/users/'.$user->id);
+        $this->assertResponseOk()->dontSeeJsonField('data.email');
+
+        // When we re-query with `?include=`, we should see them!
+        $this->asStaffUser()->get('v2/users/'.$user->id.'?include=email,addr_street1');
+        $this->assertResponseOk()
+            ->seeJsonField('data.email', $user->email)
+            ->seeJsonField('data.addr_street1', $user->addr_street1);
+    }
+
+    /**
      * Test that a staffer can update a user's profile.
      * PUT /v2/users/:id
      *


### PR DESCRIPTION
#### What's this PR do?
This PR implements "optional fields" in Northstar, from the [Access Control & Auditing](https://docs.google.com/document/d/1OclKWYEtjo0LTI9DzKaVG1dEBY6kfAEEgYZVRzSlD7s/edit) spec. Once this feature is shipped, it will remove fields marked as "sensitive" from the base API response, and allow them to be optionally requested with the `?include=…` query parameter.

For example, if we wanted to display a user's street address in Aurora, we might request:

```
v2/users/5571f4f5a59dbf3c7a8b4569?include=addr_street1,addr_street2
```

When a field is included in this way, we can then create a paper trail (in Papertrail!) for any requests that include more sensitive user information.

#### How should this be reviewed?

This work is behind a `DS_OPTIONAL_FIELDS` feature flag, so can be safely merged.

~I'll add some tests before marking this as "ready to review".~ Done! I also ended up adding two custom assertions, `seeJsonField` and `dontSeeJsonField`, to make it easier to test whether a particular field is included in the JSON response.

#### Relevant Tickets
[#167596587](https://www.pivotaltracker.com/story/show/167596587)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
