### PR TITLE
Add some computed "preview" fields for admin interfaces.

### DIFF
--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -3,7 +3,6 @@
 namespace Northstar\Auth;
 
 use Carbon\Carbon;
-use libphonenumber\PhoneNumberUtil;
 use libphonenumber\PhoneNumberFormat;
 
 class Normalizer
@@ -75,14 +74,13 @@ class Normalizer
             $mobile = '+'.$mobile;
         }
 
-        try {
-            $parser = PhoneNumberUtil::getInstance();
-            $number = $parser->parse($mobile, 'US');
+        $number = parse_mobile($mobile);
 
-            return $parser->format($number, PhoneNumberFormat::E164);
-        } catch (\libphonenumber\NumberParseException $e) {
+        if (! $number) {
             return '';
         }
+
+        return format_mobile($number, PhoneNumberFormat::E164);
     }
 
     /**

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -62,6 +62,7 @@ class UserTransformer extends BaseTransformer
         ];
 
         if (Gate::allows('view-full-profile', $user)) {
+            $response['email_preview'] = $user->email_preview;
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = [];

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -67,6 +67,7 @@ class UserTransformer extends BaseTransformer
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = [];
+            $response['age'] = $user->age;
 
             $response['addr_city'] = $user->addr_city;
             $response['addr_state'] = $user->addr_state;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -61,6 +61,11 @@ class UserTransformer extends BaseTransformer
             'photo' => null,
         ];
 
+        // We also allow authorized users to request additional fields (see `getAvailableIncludes` above)
+        // via the `?include=...` query parameter. These will automatically be read from the corresponding
+        // field on the user, or an `includeFieldName` method if defined in this transformer.
+        //
+        // NOTE: Optional fields are behind a feature flag & may be included by default!
         if (Gate::allows('view-full-profile', $user)) {
             $response['email_preview'] = $user->email_preview;
             $response['mobile_preview'] = $user->mobile_preview;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -63,6 +63,7 @@ class UserTransformer extends BaseTransformer
 
         if (Gate::allows('view-full-profile', $user)) {
             $response['email_preview'] = $user->email_preview;
+            $response['mobile_preview'] = $user->mobile_preview;
             $response['facebook_id'] = $user->facebook_id;
 
             $response['interests'] = [];

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -54,6 +54,7 @@ class UserTransformer extends BaseTransformer
     {
         $response = [
             'id' => $user->_id,
+            'display_name' => $user->display_name,
             'first_name' => $user->first_name,
             'display_name' => $user->display_name,
             'last_initial' => $user->last_initial,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -249,7 +249,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             return '???';
         }
 
-
         // We'll show the user's email domain for common providers.
         // See: https://dsdata.looker.com/sql/kkk4zqtkwffymv
         $allowedDomains = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -231,6 +231,39 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Computed "email preview" field.
+     *
+     * @return string
+     */
+    public function getEmailPreviewAttribute()
+    {
+        if (! $this->email) {
+            return null;
+        }
+
+        $parsed = imap_rfc822_parse_adrlist($this->email, 'example.com');
+        if (! is_array($parsed) || count($parsed) < 1) {
+            return '???';
+        }
+
+        [ $email ] = $parsed;
+
+        $mailbox = str_limit($email->mailbox, 3);
+
+        // We'll show the user's email domain for common providers.
+        // See: https://dsdata.looker.com/sql/kkk4zqtkwffymv
+        $allowedDomains = [
+            'aim.com', 'aol.com', 'att.net', 'bellsouth.net', 'comcast.net', 'cox.net', 'dosomething.org',
+            'gmail.com', 'hotmail.com', 'icloud.com', 'live.com', 'me.com', 'msn.com', 'outlook.com',
+            'rocketmail.com', 'sbcglobal.net', 'verizon.net', 'yahoo.com', 'ymail.com',
+        ];
+
+        $host = in_array($email->host, $allowedDomains) ? $email->host : str_limit($email->host, 4);
+
+        return $mailbox.'@'.$host;
+    }
+
+    /**
      * Mutator to strip non-numeric characters from mobile numbers.
      *
      * @param string $value

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -206,6 +206,21 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Computed "display name" field, for public profiles,
+     * e.g. "Puppet S." for "Puppet Sloth".
+     *
+     * @return string
+     */
+    public function getDisplayNameAttribute()
+    {
+        if ($this->last_initial) {
+            return $this->first_name.' '.$this->last_initial.'.';
+        }
+
+        return $this->first_name;
+    }
+
+    /**
      * Mutator to normalize email addresses to lowercase.
      *
      * @param string $value

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace Northstar\Models;
 
 use Carbon\Carbon;
+use libphonenumber\PhoneNumberFormat;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -271,6 +272,24 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setMobileAttribute($value)
     {
         $this->attributes['mobile'] = normalize('mobile', $value);
+    }
+
+    public function getMobilePreviewAttribute()
+    {
+        if (! $this->mobile) {
+            return null;
+        }
+
+        $mobile = parse_mobile($this->mobile);
+
+        if (! $mobile) {
+            return '(XXX) XXX-XXXX';
+        }
+
+        $formattedNumber = format_mobile($mobile, PhoneNumberFormat::NATIONAL);
+
+        // Redact the last four digits after formatting.
+        return substr($formattedNumber, 0, -4).'XXXX';
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -313,6 +313,16 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Computed age field.
+     *
+     * @return int
+     */
+    public function getAgeAttribute()
+    {
+        return optional($this->birthdate)->diffInYears(now());
+    }
+
+    /**
      * Mutator for setting the last_messaged_at field.
      *
      * @param string|Carbon $value

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -4,6 +4,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Northstar\Models\Client;
 use Northstar\Auth\Normalizer;
+use libphonenumber\PhoneNumber;
 use Illuminate\Support\HtmlString;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\PhoneNumberFormat;
@@ -303,4 +304,32 @@ function stringify_object($object)
 {
     // e.g. utm_source:test,utm_medium:internet,utm_campaign:uconn_lady_huskies
     return str_replace('=', ':', http_build_query($object, '', ','));
+}
+
+/**
+ * Parse a phone number into a PhoneNumber object.
+ *
+ * @param string $string
+ * @return PhoneNumber
+ */
+function parse_mobile($string): ?PhoneNumber
+{
+    try {
+        $parser = PhoneNumberUtil::getInstance();
+        $number = $parser->parse($string, 'US');
+
+        return $number;
+    } catch (\libphonenumber\NumberParseException $e) {
+        return null;
+    }
+}
+
+/**
+ * Format the given PhoneNumber as a string.
+ */
+function format_mobile(PhoneNumber $number, $format): string
+{
+    $parser = PhoneNumberUtil::getInstance();
+
+    return $parser->format($number, $format);
 }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "league/fractal": "0.18.*",
     "league/iso3166": "^1.0",
     "league/oauth2-server": "^7.3.2",
+    "mmucklo/email-parse": "^2.0",
     "mongodb/mongodb": "~1.2.0",
     "predis/predis": "^1.1",
     "seatgeek/sixpack-php": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "356904571b01536e04001b9521347f90",
+    "content-hash": "3c5f92d5b834b8fff0a613e1abc553cc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -306,6 +306,37 @@
                 "validation"
             ],
             "time": "2019-05-28T15:18:28+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "dasprid/enum",
@@ -2337,6 +2368,59 @@
                 "server"
             ],
             "time": "2019-05-05T09:22:01+00:00"
+        },
+        {
+            "name": "mmucklo/email-parse",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mmucklo/email-parse.git",
+                "reference": "6d1b481d40e01f314ea4d13c1e7f30df3673a371"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mmucklo/email-parse/zipball/6d1b481d40e01f314ea4d13c1e7f30df3673a371",
+                "reference": "6d1b481d40e01f314ea4d13c1e7f30df3673a371",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0",
+                "psr/log": "~1.0",
+                "true/punycode": "~2.0",
+                "zendframework/zend-validator": ">=2.0,<=3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "dev-master",
+                "phpunit/phpunit": "^5.7.0",
+                "symfony/yaml": ">=2.7,<=2.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Email\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew J. Mucklo",
+                    "email": "mmucklo@gmail.com"
+                }
+            ],
+            "description": "email-parse a (reasonably) RFC822 / RF2822-compliant library for batch parsing multiple (and single) email addresses",
+            "keywords": [
+                "RFC2822",
+                "RFC822",
+                "batch-email",
+                "email",
+                "email-parse",
+                "multiple-email",
+                "parse"
+            ],
+            "time": "2017-04-15T01:57:03+00:00"
         },
         {
             "name": "mongodb/mongodb",
@@ -5014,6 +5098,52 @@
             "time": "2017-11-27T11:13:29+00:00"
         },
         {
+            "name": "true/punycode",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/true/php-punycode.git",
+                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/true/php-punycode/zipball/a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
+                "reference": "a4d0c11a36dd7f4e7cd7096076cab6d3378a071e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.7",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TrueBV\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Renan Gonçalves",
+                    "email": "renan.saddam@gmail.com"
+                }
+            ],
+            "description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
+            "homepage": "https://github.com/true/php-punycode",
+            "keywords": [
+                "idna",
+                "punycode"
+            ],
+            "time": "2016-11-16T10:37:54+00:00"
+        },
+        {
             "name": "vlucas/phpdotenv",
             "version": "v2.6.1",
             "source": {
@@ -5127,6 +5257,125 @@
                 "psr-7"
             ],
             "time": "2018-09-05T19:29:37+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "keywords": [
+                "ZendFramework",
+                "stdlib",
+                "zf"
+            ],
+            "time": "2018-08-28T21:34:05+00:00"
+        },
+        {
+            "name": "zendframework/zend-validator",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-validator.git",
+                "reference": "64c33668e5fa2d39c6289a878f927ea2b0850c30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/64c33668e5fa2d39c6289a878f927ea2b0850c30",
+                "reference": "64c33668e5fa2d39c6289a878f927ea2b0850c30",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^3.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.8",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators",
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
+                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
+                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.12.x-dev",
+                    "dev-develop": "2.13.x-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a set of commonly needed validators",
+            "homepage": "https://github.com/zendframework/zend-validator",
+            "keywords": [
+                "validator",
+                "zf2"
+            ],
+            "time": "2019-01-30T14:26:10+00:00"
         }
     ],
     "packages-dev": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,7 @@
         <env name="DS_ENABLE_BLINK" value="true"/>
         <env name="DS_ENABLE_RATE_LIMITING" value="true"/>
         <env name="DS_ENABLE_PASSWORD_GRANT" value="true"/>
+        <env name="DS_OPTIONAL_FIELDS" value="false"/>
         <env name="SIXPACK_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Carbon\Carbon;
 use FakerPhoneNumber;
 use DoSomething\Gateway\Blink;
 use Illuminate\Contracts\Console\Kernel;
@@ -67,6 +68,9 @@ trait CreatesApplication
         // Get a new Faker generator from Laravel.
         $this->faker = app(\Faker\Generator::class);
         $this->faker->addProvider(new FakerPhoneNumber($this->faker));
+
+        // Reset to the current time, if mocked.
+        Carbon::setTestNow(null);
 
         // Reset the testing database & run migrations.
         app()->make('db')->getMongoDB()->drop();

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -36,6 +36,7 @@ class UserTest extends BrowserKitTestCase
         factory(User::class, 5)->create();
 
         $this->asUser($staff, ['role:staff', 'user'])->get('v2/users');
+        $this->dump();
         $this->assertResponseStatus(200);
     }
 

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -36,7 +36,6 @@ class UserTest extends BrowserKitTestCase
         factory(User::class, 5)->create();
 
         $this->asUser($staff, ['role:staff', 'user'])->get('v2/users');
-        $this->dump();
         $this->assertResponseStatus(200);
     }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request adds some "preview" fields, as described in the [Access Control & Auditing spec](https://docs.google.com/document/d/1OclKWYEtjo0LTI9DzKaVG1dEBY6kfAEEgYZVRzSlD7s/edit). These will allow applications (like Aurora or Rogue's admin interface) to provide more helpful "contextual" information without exposing the user's full personal data unnecessarily:

For example, here's how the base `users/:id` response might look for a staff user:

```js
{
  "data": {
    "id": "5d36309ffdce2742ff6c64d2",
    "display_name": "Puppet S.",
    "first_name": "Puppet",
    "last_initial": "S",
    "photo": null,
    "email_preview": "pup...@dosomething.org",
    "mobile_preview": "(950) 968-XXXX",
    "age": 29,
   // and so on...
```

#### How should this be reviewed?
It might be easiest to review this PR commit-by-commit. I also added some tests in a109013 demonstrating how these fields work for anonymous & staff viewers.

#### Relevant Tickets
[#167596587](https://www.pivotaltracker.com/story/show/167596587)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
