### PR TITLE
Add `feature_flags` to v1 transformer for use in Aurora

### DIFF
--- a/app/Http/Transformers/Legacy/UserTransformer.php
+++ b/app/Http/Transformers/Legacy/UserTransformer.php
@@ -64,6 +64,9 @@ class UserTransformer extends TransformerAbstract
 
             // Voting Plan Status
             $response['voting_plan_status'] = $user->voting_plan_status;
+
+            // Feature Flags
+            $response['feature_flags'] = $user->feature_flags;
         }
 
         // Make a Voting Plan fields to be rendered in messaging


### PR DESCRIPTION
#### What's this PR do?

🎏 Adds `feature_flags` to the `v1` users transformer so that the field can be surfaced in Aurora. I've tested locally by making sure this field shows up when making a request through Paw. It'll be helpful for badges to be able to edit and view this field in Aurora.

#### How should this be reviewed?
👀 

#### Relevant Tickets
🤠 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
