### PR TITLE
Exclude Clubs Referrals from the Badges Experiment

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -222,7 +222,8 @@ class AuthController extends Controller
             }
 
             // If the badges test is running, sort users into badges group control group
-            if (config('features.badges')) {
+            // (while ensuring that we completely exclude any 'club' referrals).
+            if (config('features.badges') && $sourceDetail['utm_source'] !== 'clubs') {
                 $feature_flags = $user->feature_flags;
 
                 // Give 70% users the badges flag (1-7), 30% in control (8-10)

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -214,6 +214,31 @@ class WebAuthenticationTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that club referrals do not get feature flags set when the badges test is on.
+     */
+    public function testRegisterFromClubsWithoutBadgeTest()
+    {
+        // Turn on the badge test feature flag
+        config(['features.badges' => true]);
+
+        // Mock a session for the user with a ?utm_source=clubs param, indicating a clubs referral
+        $this->withSession(['source_detail' => ['utm_source' => 'clubs']])
+            ->withHeader('X-Fastly-Country-Code', 'US')
+            ->register();
+
+        $this->seeIsAuthenticated('web');
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        $this->assertEquals('US', $user->country);
+        $this->assertEquals('en', $user->language);
+
+        // The user should not have any `feature_flags`.
+        $this->assertEquals(true, is_null($user->feature_flags));
+    }
+
+    /**
      * Test that users do not get feature flags set when the badges test is off.
      */
     public function testRegisterWithoutBadgeTest()


### PR DESCRIPTION
#### What's this PR do?
This PR ensures that registering users with a `?utm_source=clubs` in their incoming request (which indicates that they're a special 'clubs' referrals and are opted in to a 'clubs' experience) do _not_ get opted into the badges experiment.

#### How should this be reviewed?
If you visit Phoenix with a `?utm_source=clubs` (or put `source_details => ['utm_source'] = 'clubs'` into your session), and submit the register form, you should _not_ get a `[badges => true]` flag within your user's `feature_flags` property (or really should not be assigned a `feature_flags` prop to begin with!)

#### Relevant Tickets
[Slack Thread](https://dosomething.slack.com/archives/C02BBRN5A/p1567804259009500)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
