### PR TITLE
Use data_get to safely retrieve utm_source value

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -223,7 +223,7 @@ class AuthController extends Controller
 
             // If the badges test is running, sort users into badges group control group
             // (while ensuring that we completely exclude any 'club' referrals).
-            if (config('features.badges') && $sourceDetail['utm_source'] !== 'clubs') {
+            if (config('features.badges') && data_get($sourceDetail, 'utm_source') !== 'clubs') {
                 $feature_flags = $user->feature_flags;
 
                 // Give 70% users the badges flag (1-7), 30% in control (8-10)


### PR DESCRIPTION
#### What's this PR do?
This PR uses `data_get` to safely retrieve the `utm_source` value from `$sourceDetails`.

We're seeing a disparity between development environment where this is _not_ triggering an `undefined index` error for `null` $sourceDetails and QA where it _is_ triggering this error.

We'll continue looking into this. This fix is for now.

#### How should this be reviewed?
👁 

#### Relevant Tickets
#910 
[Slack](https://dosomething.slack.com/archives/C02BBRN5A/p1568043847017400)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
