### PR TITLE
Fix Checkboxes In Subscriptions Form

### DIFF
--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -32,7 +32,7 @@ class ProfileSubscriptionsController extends Controller
     {
         return view('profiles.subscriptions.edit', [
             'user' => auth()->guard('web')->user(),
-            'intended' => session()->pull('url.intended') ?: '/',
+            'intended' => session()->pull('url.intended', '/'),
         ]);
     }
 

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -36,22 +36,26 @@
         <div class="form-item mt-1">
             <label for="community" class="option -checkbox">
                 {{-- @TODO: DRY up this 'checked' logic somehow? Integrate this into the checkbox partial? --}}
-                <input type="checkbox" name="email_subscription_topics[]" id="community" value="community" class="mt-1" {{in_array("community", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <input type="checkbox" name="email_subscription_topics[]" id="community" value="community" {{in_array("community", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <span class="option__indicator"></span>
                 <span class="font-bold">WYD (What You’re Doing)</span>
                 <p class="footnote">Our weekly community newsletter. Learn what DoSomething members are doing to change the world, and how you can join them!</p>
             </label>
             <label for="scholarships" class="option -checkbox">
-                <input type="checkbox" name="email_subscription_topics[]" id="scholarships" value="scholarships" class="mt-1" {{in_array("scholarships", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <input type="checkbox" name="email_subscription_topics[]" id="scholarships" value="scholarships" {{in_array("scholarships", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <span class="option__indicator"></span>
                 <span class="font-bold">Pays To Do Good</span>
                 <p class="footnote">Our monthly scholarships newsletter. Earn easy scholarships for volunteering, get clutch tips on applying, and read the latest news about education.</p>
             </label>
             <label for="news" class="option -checkbox">
-                <input type="checkbox" name="email_subscription_topics[]" id="news" value="news" class="mt-1" {{in_array("news", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <input type="checkbox" name="email_subscription_topics[]" id="news" value="news" {{in_array("news", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <span class="option__indicator"></span>
                 <span class="font-bold">The Breakdown</span>
                 <p class="footnote">Our current events newsletter, sent twice a week. Featuring the week’s headlines and ways to impact them, you can read the news *and* change the news.</p>
             </label>
             <label for="lifestyle" class="option -checkbox">
-                <input type="checkbox" name="email_subscription_topics[]" id="lifestyle" value="lifestyle" class="mt-1" {{in_array("lifestyle", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <input type="checkbox" name="email_subscription_topics[]" id="lifestyle" value="lifestyle" {{in_array("lifestyle", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
+                <span class="option__indicator"></span>
                 <span class="font-bold">The Boost</span>
                 <p class="footnote">Our weekly cause and lifestyle newsletter. You’ll receive one article (like an inspiring story of a young changemaker or a how-to volunteering guide), plus one related action every Thursday.</p>
             </label>


### PR DESCRIPTION
#### What's this PR do?
Adds a `span.option__indicator` to the checkboxes on the profile subscriptions edit form, so that the checkboxes display with grandeur and are not hidden with drabness.

(I also snuck in a slight simplification of `session->pull` in the SubscriptionsController 🤫)

#### How should this be reviewed?
✅ 

#### Relevant Tickets
https://dosomething.slack.com/archives/C02BBRN5A/p1570204142001600?thread_ts=1570201214.000500&cid=C02BBRN5A
