### PR TITLE
Onboarding Form Buttons

### DIFF
--- a/resources/assets/scss/_components/_button.scss
+++ b/resources/assets/scss/_components/_button.scss
@@ -1,0 +1,18 @@
+.button {
+  &.normal-case {
+    text-transform: none;
+  }
+
+  // @TODO: incorporate this into Forge, or utilize whatever ends up being the new -secondary style.
+  &.-secondary-beta {
+    background: $white;
+    // Tailwind color ($gray-500 in Phoenix https://git.io/JeW8A).
+    color: #999;
+    // Use box shadow inset so border is within the bounds of the button.
+    box-shadow: inset 0px 0px 0px 2px;
+
+    &:hover {
+      color: $black;
+    }
+  }
+}

--- a/resources/assets/scss/_components/_button.scss
+++ b/resources/assets/scss/_components/_button.scss
@@ -1,6 +1,6 @@
 .button {
-  &.normal-case {
-    text-transform: none;
+  &.capitalize {
+    text-transform: capitalize;
   }
 
   // @TODO: incorporate this into Forge, or utilize whatever ends up being the new -secondary style.

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -32,6 +32,7 @@
 @import '_components/_password-visibility';
 @import '_components/_text-field';
 @import '_components/_field-label';
+@import '_components/_button';
 
 // Regions - complete sections of an interface
 @import '_regions/_chrome';

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -30,7 +30,7 @@
             <p class="footnote"><em>DoSomething.org weekly updates will be sent to your phone number 1 time per week from 38383. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for help. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages. T-Mobile is not liable for delayed or undelivered messages.</em></p>
         </div>
 
-        <p class="font-bold mt-8">Our Email Newsletters</p>
+        <p class="font-bold mt-6">Our Email Newsletters</p>
         <p class="mt-1">Community! Scholarships! News! Exclamation points! Our email newsletters are bringing inspiration and education straight to your inbox. Let us know which ones you want.</p>
 
         <div class="form-item mt-3">

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Edit Profile | DoSomething.org')
 
 @section('form-image-url')
-    '/images/registration-v2-03.svg'
+    '/images/subscription-form-bg.png'
 @endsection
 
 @section('profile-title')

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -61,17 +61,18 @@
             </label>
         </div>
 
-        <ul class="form-actions -inline">
-            <li>
-                <div class="form-actions">
-                    <a href="{{ $intended }}" class="button">Skip</a>
+        <div class="flex pt-4">
+            <div class="w-1/3 flex justify-start">
+                <img src="/images/subscription-form-icon.svg" />
+            </div>
+            <div class="w-2/3 flex justify-around sm:justify-end p-2">
+                <div class="m-1">
+                    <a href="{{ $intended }}" class="button normal-case -secondary-beta">Skip</a>
                 </div>
-            </li>
-            <li>
-                <div class="form-actions">
-                    <input type="submit" class="button" value="Finish">
+                <div class="m-1">
+                    <input type="submit" class="button normal-case" value="Finish">
                 </div>
-            </li>
-        </ul>
+            </div>
+        </div>
     </form>
 @endsection

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -30,10 +30,10 @@
             <p class="footnote"><em>DoSomething.org weekly updates will be sent to your phone number 1 time per week from 38383. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for help. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages. T-Mobile is not liable for delayed or undelivered messages.</em></p>
         </div>
 
-        <p class="font-bold mt-2">Our Email Newsletters</p>
+        <p class="font-bold mt-8">Our Email Newsletters</p>
         <p class="mt-1">Community! Scholarships! News! Exclamation points! Our email newsletters are bringing inspiration and education straight to your inbox. Let us know which ones you want.</p>
 
-        <div class="form-item mt-1">
+        <div class="form-item mt-3">
             <label for="community" class="option -checkbox">
                 {{-- @TODO: DRY up this 'checked' logic somehow? Integrate this into the checkbox partial? --}}
                 <input type="checkbox" name="email_subscription_topics[]" id="community" value="community" {{in_array("community", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -67,10 +67,10 @@
             </div>
             <div class="w-2/3 flex justify-around sm:justify-end p-2">
                 <div class="m-1">
-                    <a href="{{ $intended }}" class="button normal-case -secondary-beta">Skip</a>
+                    <a href="{{ $intended }}" class="button capitalize -secondary-beta">Skip</a>
                 </div>
                 <div class="m-1">
-                    <input type="submit" class="button normal-case" value="Finish">
+                    <input type="submit" class="button capitalize" value="Finish">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### What's this PR do?
This PR adds styled buttons and the progress icon to the profile subscriptions form.
I basically copied over the format implemented in #922 with some very minor adjustments for spacing.

The mocks required adding some new styling to accommodate the 'secondary' skip button. @lkpttn mentioned wanting to potentially formalize this as the new [`-secondary`](https://github.com/DoSomething/forge/blob/3828463212a96e97b154b0afa007da30b869c5ab/scss/_components/_forms/_button.scss#L66-L81) modifier style, so until then, I figured we could just feed off of the current `.button` styles, with the custom overwritten rules set up as a `-secondary-beta` class.

I also added a `.capitalize` class a la Tailwind which we can use for these buttons since they're not meant to be uppercased as regular buttons are in [Forge](https://github.com/DoSomething/forge/blob/3828463212a96e97b154b0afa007da30b869c5ab/scss/_components/_forms/_button.scss#L33).

I also generally tweaked the margin a bit to better fit with the mock, and updated to use the correct background image.

#### How should this be reviewed?
Make sure I didn't do anything too crazy here. Bearing in mind that this should be temporary and can be better refactored once Tailwind is formalized into Forge, and the `-secondary` class is updated.

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/168353804

#### Checklist
- [ ] Tests added for new features/bug fixes.

📸 
- [Large](https://user-images.githubusercontent.com/12417657/66430412-15dcff00-e9e8-11e9-888d-238d411f64cf.png)
- [Medium](https://user-images.githubusercontent.com/12417657/66430413-15dcff00-e9e8-11e9-9bb8-460034fe4524.png)
- [Small](https://user-images.githubusercontent.com/12417657/66430414-15dcff00-e9e8-11e9-9751-b9b948035144.png)


