### PR TITLE
Temporary feature flag redirecting to new register flow

### DIFF
--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -39,11 +39,6 @@ class AuthController extends Controller
      */
     public function getRegister()
     {
-        // Temporary 'feature flag' to redirect users to the new register flow (for testing).
-        if (session('registerBeta', false)) {
-            return redirect('register-beta');
-        }
-
         return view('auth.register', ['coverImage' => true]);
     }
 

--- a/app/Http/Controllers/Legacy/AuthController.php
+++ b/app/Http/Controllers/Legacy/AuthController.php
@@ -39,6 +39,11 @@ class AuthController extends Controller
      */
     public function getRegister()
     {
+        // Temporary 'feature flag' to redirect users to the new register flow (for testing).
+        if (session('registerBeta', false)) {
+            return redirect('register-beta');
+        }
+
         return view('auth.register', ['coverImage' => true]);
     }
 

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -67,6 +67,8 @@ class AuthController extends Controller
                 'title' => request()->query('title', trans('auth.get_started.create_account')),
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
+                // Temporary 'feature flag' to redirect to the new registration flow (for testing).
+                'registerBeta' => request()->query('register_beta'),
                 // Store any provided UTMs, Referrer User ID, or Contentful ID for user's source_detail:
                 'source_detail' => array_filter([
                     'contentful_id' => request()->query('contentful_id'),

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -67,8 +67,6 @@ class AuthController extends Controller
                 'title' => request()->query('title', trans('auth.get_started.create_account')),
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
-                // Temporary 'feature flag' to redirect to the new registration flow (for testing).
-                'registerBeta' => request()->query('register_beta'),
                 // Store any provided UTMs, Referrer User ID, or Contentful ID for user's source_detail:
                 'source_detail' => array_filter([
                     'contentful_id' => request()->query('contentful_id'),
@@ -80,7 +78,7 @@ class AuthController extends Controller
             ]);
 
             // Optionally, we can override the default authorization page using `?mode=login`.
-            $authorizationRoute = request()->query('mode') === 'login' ? 'login' : 'register';
+            $authorizationRoute = request()->query('mode') ?: 'register';
 
             return redirect()->guest($authorizationRoute);
         }


### PR DESCRIPTION
#### What's this PR do?
 🚩Adds a temporary feature flag - via query parameter - to redirect users to use the new registration flow. We'll use this from the Phoenix end, to allow testing the new flow end-to-end without any disruption on production.

EDIT: Updated re https://github.com/DoSomething/northstar/pull/929#discussion_r334029291 in https://github.com/DoSomething/northstar/pull/929/commits/85c62100c6369295da49d85ee8bab8ca582e0829 to simply utilize the `mode` to affect the authorization route. Way cleaner ☺️ 

This won't work just yet! 
- I'll add a corresponding PR on Phoenix to send over this param
- This relies on the temporary `register-beta` route defined in #924 which hasn't been merged yet. 

#### How should this be reviewed?
👁 

#### Relevant Tickets
We discussed this idea [here on Slack](https://dosomething.slack.com/archives/C02BBRN5A/p1570732864009800)

