### PR TITLE
Bring back voting plan fields for c.io

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -540,6 +540,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'physical_health' => in_array('physical_health', $this->causes) ? true : false,
             'racial_justice_equity' => in_array('racial_justice_equity', $this->causes) ? true : false,
             'sexual_harassment_assault' => in_array('sexual_harassment_assault', $this->causes) ? true : false,
+            'voting_plan_status' => $this->voting_plan_status,
+            'voting_plan_method_of_transport' => $this->voting_plan_method_of_transport,
+            'voting_plan_time_of_day' => $this->voting_plan_time_of_day,
+            'voting_plan_attending_with' => $this->voting_plan_attending_with,
         ];
 
         // Only include email subscription status if we have that information.

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -56,6 +56,10 @@ class UserModelTest extends BrowserKitTestCase
             'physical_health' => false,
             'racial_justice_equity' => false,
             'sexual_harassment_assault' => true,
+            'voting_plan_status' => null,
+            'voting_plan_method_of_transport' => null,
+            'voting_plan_time_of_day' => null,
+            'voting_plan_attending_with' => null,
         ]);
     }
 


### PR DESCRIPTION
#### What's this PR do?
It undoes https://github.com/DoSomething/northstar/pull/838! We removed the 4 voting plan related fields from the payload we send to Customer.io because we were limited to sending only 30 attributes and at the time, these fields were not being updated so we knew we didn't need to send them. But now, voting is back and we can send more attributes to Customer.io, so we've brought them back!

#### How should this be reviewed?
Will these fields be sent to Customer.io with the rest of the user attributes?

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/168931878)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
