### PR TITLE
New Onboarding Flow - Analytics Events

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -490,8 +490,8 @@ function init() {
       });
     });
 
-    $('.login-link').on('click', (e) => {
-      const target = e.target.dataset.target || 'button';
+    $('.login-link').on('click', (element) => {
+      const target = element.target.dataset.target || 'button';
 
       // Tracks clicking on any of the 'Log in' buttons and links.
       trackAnalyticsEvent({

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -347,9 +347,6 @@ function init() {
   Validation.Events.subscribe('Validation:Submitted', (topic, args) => {
     // Tracks when an inline validation error free submission is made.
     trackAnalyticsEvent({
-      context: {
-        suggestion: args,
-      },
       metadata: {
         category: getCategoryFromPath(),
         noun: 'register',

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -304,7 +304,7 @@ function init() {
     trackAnalyticsEvent({
       metadata: {
         adjective: `field_${args}`,
-        category: 'authentication',
+        category: getCategoryFromPath(),
         label: args,
         noun: 'error',
         target: 'error',
@@ -321,7 +321,7 @@ function init() {
       },
       metadata: {
         adjective: 'field_email',
-        category: 'authentication',
+        category: getCategoryFromPath(),
         label: 'email_suggestion',
         noun: 'suggestion',
         target: 'suggestion',
@@ -335,7 +335,7 @@ function init() {
     trackAnalyticsEvent({
       metadata: {
         adjective: 'field_email',
-        category: 'authentication',
+        category: getCategoryFromPath(),
         label: 'email_suggestion',
         noun: 'suggestion',
         target: 'suggestion',
@@ -351,7 +351,7 @@ function init() {
         suggestion: args,
       },
       metadata: {
-        category: 'authentication',
+        category: getCategoryFromPath(),
         noun: 'register',
         target: 'form',
         verb: 'submitted',
@@ -364,7 +364,7 @@ function init() {
     trackAnalyticsEvent({
       metadata: {
         adjective: 'submit_register',
-        category: 'authentication',
+        category: getCategoryFromPath(),
         label: 'submit_register',
         noun: 'error',
         target: 'error',
@@ -512,7 +512,7 @@ function init() {
           validationMessages,
         },
         metadata: {
-          category: 'authentication',
+          category: getCategoryFromPath(),
           label: 'validation_error',
           noun: 'validation',
           target: 'validation',

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -405,7 +405,7 @@ function init() {
           verb: 'submitted',
         },
       });
-    })
+    });
 
     $('#password-reset-form').on('submit', () => {
       // Tracks password reset form submissions.
@@ -417,7 +417,7 @@ function init() {
           verb: 'submitted',
         },
       });
-    })
+    });
 
     $('.facebook-login').on('click', () => {
       // Tracks clicking on the Login With Facebook button.
@@ -441,7 +441,7 @@ function init() {
           verb: 'clicked',
         },
       });
-    })
+    });
 
     $('.register-link').on('click', () => {
       // Tracks clicking on any of the 'Register' or 'Create account' buttons and links.
@@ -453,7 +453,7 @@ function init() {
           verb: 'clicked',
         },
       });
-    })
+    });
 
     $('.forgot-password-link').on('click', () => {
       // Tracks clicking on the 'Forgot Password' link.
@@ -465,7 +465,7 @@ function init() {
           verb: 'clicked',
         },
       });
-    })
+    });
 
     // Check for and track validation errors returned from the backend after form submission.
     const $validationErrors = $('.validation-error');

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -491,6 +491,10 @@ function init() {
     });
 
     $('.login-link').on('click', (element) => {
+      // @HACK: Allow overriding the default 'button' target via a data-target attribute.
+      // (Ideally this should be standard and consistant based on the element type (e.g. a tag vs button),
+      // however, we're accounting for legacy 'button' events tracked on <a> tags.)
+      // (See DoSomething Slack: http://bit.ly/32kcSWE).
       const target = element.target.dataset.target || 'button';
 
       // Tracks clicking on any of the 'Log in' buttons and links.

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -431,13 +431,15 @@ function init() {
       });
     });
 
-    $('.login-link').on('click', () => {
+    $('.login-link').on('click', (e) => {
+      const target = e.target.dataset.target || 'button';
+
       // Tracks clicking on any of the 'Log in' buttons and links.
       trackAnalyticsEvent({
         metadata: {
           category: 'authentication',
           noun: 'login',
-          target: 'button',
+          target,
           verb: 'clicked',
         },
       });

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -100,6 +100,8 @@ const getCategoryFromPath = () => {
 
 /**
  * Parse an id value to discern the form type (with a sensible default).
+ * The id should contain at least two hyphen-separated values -
+ * e.g. an id of 'profile-register-form' would yield the 'register' value.
  *
  * @param {String} [id='']
  * @return {String}

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -82,6 +82,23 @@ export function getAdditionalContext() {
 }
 
 /**
+ * Get the category for an event based on current pathname.
+ *
+ * @return {String}
+ */
+const getCategoryFromPath = () => {
+  const pathToCategoryMap = {
+    '/register': 'authentication',
+    '/profile/about': 'onboarding',
+    '/profile/subscriptions': 'onboarding',
+    // Temporary:
+    '/register-beta': 'authentication',
+  };
+
+  return pathToCategoryMap[window.location.pathname] || 'authentication';
+}
+
+/**
  * Parse analytics event name parameters into a snake cased string.
  *
  * @param  {String}      verb

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -467,6 +467,18 @@ function init() {
       });
     });
 
+    $('.form-skip').on('click', () => {
+      // Tracks clicking on the 'Skip' button in onboarding forms.
+      trackAnalyticsEvent({
+        metadata: {
+          category: 'onboarding',
+          noun: 'skip',
+          target: 'button',
+          verb: 'clicked',
+        },
+      });
+    });
+
     // Check for and track validation errors returned from the backend after form submission.
     const $validationErrors = $('.validation-error');
     if ($validationErrors && $validationErrors.length) {

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -99,6 +99,14 @@ const getCategoryFromPath = () => {
 }
 
 /**
+ * Parse an id value to discern the form type (with a sensible default).
+ *
+ * @param {String} [id='']
+ * @return {String}
+ */
+const getFormTypeFromId = (id = '') => id.split('-')[1] || 'form';
+
+/**
  * Parse analytics event name parameters into a snake cased string.
  *
  * @param  {String}      verb
@@ -349,7 +357,7 @@ function init() {
     trackAnalyticsEvent({
       metadata: {
         category: getCategoryFromPath(),
-        noun: 'register',
+        noun: getFormTypeFromId(args),
         target: 'form',
         verb: 'submitted',
       },
@@ -357,12 +365,14 @@ function init() {
   });
 
   Validation.Events.subscribe('Validation:SubmitError', (topic, args) => {
+    const formType = getFormTypeFromId(args);
+
     // Tracks when a submission is prevented due to inline validation errors.
     trackAnalyticsEvent({
       metadata: {
-        adjective: 'submit_register',
+        adjective: `submit_${formType}`,
         category: getCategoryFromPath(),
-        label: 'submit_register',
+        label: `submit_${formType}`,
         noun: 'error',
         target: 'error',
         verb: 'triggered',

--- a/resources/views/auth/register-beta.blade.php
+++ b/resources/views/auth/register-beta.blade.php
@@ -60,5 +60,7 @@
 
     @include('auth.facebook')
 
-    <p class="text-gray-500 mt-5">Already have an account? <a href="{{ url('login') }}">Log In</a></p>
+    <p class="text-gray-500 mt-5">
+        Already have an account? <a class="login-link" href="{{ url('login') }}" data-target="link">Log In</a>
+    </p>
 @endsection

--- a/resources/views/auth/register-beta.blade.php
+++ b/resources/views/auth/register-beta.blade.php
@@ -18,7 +18,7 @@
         @include('forms.errors', ['errors' => $errors])
     @endif
 
-    <form method="POST" action="{{ url('register-beta')}}">
+    <form id="profile-register-form" method="POST" action="{{ url('register-beta')}}">
         {{ csrf_field() }}
 
         <div class="md:flex md:flex-wrap md:justify-between">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -28,7 +28,7 @@
             </div>
         @endif
 
-        <form id="profile-registration-form" method="POST" action="{{ url('register') }}">
+        <form id="profile-register-form" method="POST" action="{{ url('register') }}">
             <input name="_token" type="hidden" value="{{ csrf_token() }}">
 
             <div>

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -78,7 +78,7 @@
             </div>
             <div class="w-2/3 flex justify-around md:justify-end p-2">
                 <div class="m-1">
-                    <a href="{{ url('profile/subscriptions') }}" class="button capitalize -secondary-beta">Skip</a>
+                    <a href="{{ url('profile/subscriptions') }}" class="button capitalize -secondary-beta form-skip">Skip</a>
                 </div>
                 <div class="m-1">
                     <input type="submit" id="register-submit" class="button capitalize" value="Next">

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -19,7 +19,7 @@
         @include('forms.errors', ['errors' => $errors])
     @endif
 
-    <form method="POST" action="{{ url('profile/about') }}">
+    <form id="profile-about-form" method="POST" action="{{ url('profile/about') }}">
         <input type="hidden" name="_method" value="PATCH">
         {{ csrf_field() }}
 

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -26,7 +26,7 @@
         <div class="form-item flex flex-wrap justify-between md:justify-start">
             <div class="w-1/2">
                 <label for="birthdate" class="field-label">Birthday (MM/DD/YYYY)</label>
-                <input name="birthdate" type="text" id="birthdate" class="text-field js-validate" placeholder="MM/DD/YYYY" value="{{ old('birthdate') ?: format_date($user->birthdate, "m/d/Y") }}" data-validate="birthday" />
+                <input name="birthdate" type="text" id="birthdate" class="text-field js-validate" placeholder="MM/DD/YYYY" value="{{ old('birthdate') ?: format_date($user->birthdate, "m/d/Y") }}" data-validate="birthday" autofocus />
             </div>
         </div>
 

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -18,7 +18,7 @@
         @include('forms.errors', ['errors' => $errors])
     @endif
 
-    <form method="POST" action="{{ url('profile/subscriptions')}}">
+    <form id="profile-subscriptions-form" method="POST" action="{{ url('profile/subscriptions')}}">
         {{ method_field('PATCH') }}
         {{ csrf_field() }}
 

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -67,7 +67,7 @@
             </div>
             <div class="w-2/3 flex justify-around sm:justify-end p-2">
                 <div class="m-1">
-                    <a href="{{ $intended }}" class="button capitalize -secondary-beta">Skip</a>
+                    <a href="{{ $intended }}" class="button capitalize -secondary-beta form-skip">Skip</a>
                 </div>
                 <div class="m-1">
                     <input type="submit" class="button capitalize" value="Finish">

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -24,7 +24,7 @@
 
         <div class="form-item">
             <label for="mobile" class="field-label">Cell Phone # (Optional)</label>
-            <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') ?: $user->mobile }}" data-validate="phone" />
+            <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') ?: $user->mobile }}" data-validate="phone" autofocus />
         </div>
         <div class="form-item">
             <p class="footnote"><em>DoSomething.org weekly updates will be sent to your phone number 1 time per week from 38383. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for help. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages. T-Mobile is not liable for delayed or undelivered messages.</em></p>


### PR DESCRIPTION
#### What's this PR do?
🔬 This PR updates our general analytics logic to account (_account - get it?_) for the new registration and onboarding flow.

We're adding some new events, as listed on [this doc](https://docs.google.com/spreadsheets/d/1lm-fGrIm85nUTxSojqyCt_Ehmm1zEbViFhKpxcJiz1A/edit#gid=406441516) in the _green_ cells.

We're also updating the general logic for many of our events to be more general, accounting for both register and onboarding flows, notably:
- 🎯  17e605df8c15c26be3a28028a98424e702659a30, 17e605df8c15c26be3a28028a98424e702659a30 allow setting the `target` for `.login-links` click events, to account for legacy buttons tracked as links (see clarifying comment in https://github.com/DoSomething/northstar/commit/f50b286f64a4fb2136beecaa96719a5d1a14d815)
- ®️ 6e5cf6962c780a75057e73a306ca44797dd5b252, 67a8b43a4807e4fbe5ec54cba7a5e489a6641ff4 help us grab the `category` for events based on the URL, so that we can differentiate between `onboarding` and `authentication` events (`/register` is clearly `authentication`, `/profile/[about|subscriptions]` would be `onboarding`)
- 👁 🇩🇪  d1a5983d977d3664ce19fe9894e50a6987ccd959 some of our submission events were hardcoded to `register` (as an adjective describing the form, or just the `noun` to begin with), this adds a helper to dynamically grab the form type using the `id` attribute, which should follow what I think is a reasonable convention (which is based on an existing id) of `profile-[form type]-form`.
-👂 4fb0ec5935ebcd818a76705b5047c28536345a14 will add a temporary event listener for the onboarding forms, to allow us to track the form submission in the absence of a `dosomething-validation` published event, which only is triggered when the form contains _required_ or _populated_ inputs. See [this sumptuous Slack thread](sumptuous) for more context. (@weerd's apt alternative recommendation to update the `dosomething-validation` package can be tackled in a cleanup sprint (@ngjo took an oath that we'd be able to) since my attempt to do it that way was blocked by what look like some tricky breaking dependency updates we need to make for security which should probably be tackled before we update the package (or so I assumed.))

👟 
I snuck in [one](https://github.com/DoSomething/northstar/commit/bf66cfc8534db10818d2b5a64889d1098769148d) or [two](https://github.com/DoSomething/northstar/commit/2fb35528a207e51dfa8de603a4b7a6bbbae55395) easy wins, while I was poking around.

#### How should this be reviewed?
I've manually tested all expected analytics events, along with the new ones - and things seem spry. That being said, some of this logic was tricky to finesse so call out anything suspicious! There's certainly some controversial logic implemented here, so I'd venture to suggest that some larger suggested updates based on feedback could wait for a post launch cleanup, and I'd advocate for a larger cleanup of this analytics flow in general since we've certainly outgrown the boutique artisanal analytics setup we started with, and have demonstrably reached a point of complexity deserving of some 👀 and rethinking. That being said, anything unconscionable quite obviously needs to be updated before this merges.

NAMING! I didn't have much time for good creative naming ideation -- so any better naming ideas for these events/matadata/helpers are most welcome!

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/169013232

See [#topic-web-analytics](https://dosomething.slack.com/archives/CJU7WCQG4/p1570816458009600) in Slack for more context on the new categories etc. 

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
