### PR TITLE
Removes unnecessary check for missing email in Google auth

### DIFF
--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -67,13 +67,6 @@ class GoogleController extends Controller
             return redirect('/register')->with('status', 'Unable to verify Google account.');
         }
 
-        // If we were denied access to read email, do not log them in.
-        if (empty($googleUser->email)) {
-            logger()->info('google_email_hidden');
-
-            return redirect('/register')->with('status', 'We need your email to contact you if you win a scholarship.');
-        }
-
         // Some date properties in this array may not contain a year property.
         $birthdaysWithYear = array_filter($googleProfile->birthdays, function ($item) {
             return isset($item->date->year);

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -174,21 +174,4 @@ class GoogleTest extends BrowserKitTestCase
         $this->assertEquals($user->last_name, 'Sloth');
         $this->assertEquals($user->birthdate, new Carbon\Carbon('2001-07-11'));
     }
-
-    /**
-     * If the user does not share email, it should not authenticate them.
-     */
-    public function testMissingEmail()
-    {
-        $abstractUser = $this->mockSocialiteAbstractUser('', 'Puppet', 'Sloth', '12345', 'token');
-        $this->mockSocialiteFromUser($abstractUser);
-        $this->mock(Google::class)
-          ->shouldReceive('getProfile')
-          ->andReturn($this->mockGoogleProfile('12345'));
-
-        $this->visit('/google/verify')
-            ->seePageIs('/register')
-            ->see('We need your email');
-        $this->dontSeeIsAuthenticated('web');
-    }
 }


### PR DESCRIPTION
#### What's this PR do?

This PR removes code that checks for a hidden email when a Google user authenticates. This code was copied by example from the `FacebookController`, and isn't applicable to Google authentication where email must be shared.

<img width="390" alt="Screen Shot 2019-10-16 at 10 21 36 AM" src="https://user-images.githubusercontent.com/1236811/67016653-6241d200-f0ad-11e9-9948-4345d55eb18d.png">

Note - view complete date of birth is able to be unchecked. In that case, the user is directed back to the registration page with a [message "Unable to verify Google account".](https://github.com/DoSomething/northstar/blob/e8c480adac76c4bcceed79a528b79a8e58355b33/app/Http/Controllers/Web/GoogleController.php#L67)

#### How should this be reviewed?

👀 

#### Relevant Tickets

https://www.pivotaltracker.com/n/projects/2401401/stories/167675336/comments/207823400

#### Checklist
- [x] Tests added for new features/bug fixes.
