### PR TITLE
Sms Status in Subscriptions Onboarding

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -208,11 +208,6 @@ class AuthController extends Controller
             $user->email_subscription_status = true;
             $user->email_subscription_topics = ['community'];
 
-            // Set sms_status, if applicable
-            if ($user->mobile) {
-                $user->sms_status = 'active';
-            }
-
             // Set source_detail, if applicable.
             $sourceDetail = session('source_detail');
             if ($sourceDetail) {

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -45,7 +45,17 @@ class ProfileSubscriptionsController extends Controller
         $user = auth()->guard('web')->user();
 
         $this->registrar->validate($request, $user);
-        $this->registrar->register($request->all(), $user);
+
+        $currentMobile = $user->mobile;
+
+        $this->registrar->register($request->all(), $user, function ($user) use ($currentMobile) {
+            // Set the sms_status if we're adding or updating the user's mobile.
+            if ($user->mobile && $user->mobile !== $currentMobile) {
+                $user->sms_status = 'active';
+            }
+        });
+
+        dd($user->sms_status);
 
         return redirect()->intended('/');
     }

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -55,8 +55,6 @@ class ProfileSubscriptionsController extends Controller
             }
         });
 
-        dd($user->sms_status);
-
         return redirect()->intended('/');
     }
 }


### PR DESCRIPTION
#### What's this PR do?
This PR ensures a user's `sms_status` is set to `'active'` if they add or update their `mobile` number in the onboarding flow.

(The logic is there to ensure we don't unintentionally resubscribe a user if they merely submitted the form without updating their existing unsubscribed number.)

#### How should this be reviewed?
👁 

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/169193734 (See comments for discussion confirming this logic.)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
