### PR TITLE
Don't overwrite existing user data with Social Login

### DIFF
--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -84,7 +84,7 @@ class FacebookController extends Controller
         $northstarUser = $this->registrar->resolve(['email' => $facebookUser->email]);
 
         if ($northstarUser) {
-            $northstarUser->fillUnlessNull($fields);
+            $northstarUser->updateIfNotSet($fields);
             $northstarUser->save();
         } else {
             $fields['email'] = $facebookUser->email;

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -84,7 +84,7 @@ class GoogleController extends Controller
         $northstarUser = $this->registrar->resolve(['email' => $googleUser->email]);
 
         if ($northstarUser) {
-            $northstarUser->fillUnlessNull($fields);
+            $northstarUser->updateIfNotSet($fields);
             $northstarUser->save();
         } else {
             $fields['email'] = $googleUser->email;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -577,14 +577,18 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Fill & save the user with the given array of fields.
+     * Update user with the given array of fields if field is not already set.
      * Filter out any fields that have a null value.
      *
      * @param  array $fields
      */
-    public function fillUnlessNull($fields)
+    public function updateIfNotSet($fields)
     {
-        $this->fill(array_filter($fields));
+        foreach (array_filter($fields) as $key => $value) {
+            if (! isset($this->{$key})) {
+                $this->{$key} = $value;
+            }
+        }
     }
 
     /**

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -164,8 +164,9 @@ class FacebookTest extends BrowserKitTestCase
         $this->visit('/facebook/verify');
 
         $user = auth()->user();
-        $this->assertEquals($user->first_name, 'Puppet');
+        $this->assertEquals($user->first_name, 'Joe');
         $this->assertEquals($user->last_name, 'Sloth');
+        $this->assertEquals($user->birthdate, $factoryUser->birthdate);
     }
 
     /**

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -170,8 +170,8 @@ class GoogleTest extends BrowserKitTestCase
         $this->visit('/google/verify');
 
         $user = auth()->user();
-        $this->assertEquals($user->first_name, 'Puppet');
+        $this->assertEquals($user->first_name, 'Joe');
         $this->assertEquals($user->last_name, 'Sloth');
-        $this->assertEquals($user->birthdate, new Carbon\Carbon('2001-07-11'));
+        $this->assertEquals($user->birthdate, $factoryUser->birthdate);
     }
 }


### PR DESCRIPTION
#### What's this PR do?

Modifies Facebook and Google login to avoid updating an existing Northstar user's first name, last name, birthdate if values exist already. Not sure if we intended to always overwrite a user's first/last name and birthdate upon Facebook login when it was introduced in #608 (which I followed by example in #927) but this avoids it per request in [Pivotal](https://www.pivotaltracker.com/n/projects/2401401/stories/167675336/comments/207834606)

#### How should this be reviewed?

1. Modifying your Northstar user's (that has a DS or Gmail email) first name, last name, and birthday
2. Sign in with Google (e.g. visit northstar/google/continue)
3. Verify your Northstar user details remain per changes made in step 1

#### Relevant Tickets

* Google - https://www.pivotaltracker.com/n/projects/2401401/stories/167675336
* FB - https://www.pivotaltracker.com/n/projects/2401401/stories/169210839

#### Checklist
- [ ] Documentation added for changed endpoints.
- [x] Tests added for new features/bug fixes.
