### PR TITLE
DRY values for web registrations 

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -203,4 +203,29 @@ class Registrar
 
         return $user;
     }
+
+    /**
+     * Create a new user OR update an existing user (if given).
+     *
+     * @param array $input - Profile fields
+     * @param User $user - Optionally, user to update
+     * @param Closure $customizer - Customize the user instance before saving.
+     * @return User|null
+     */
+    public function registerViaWeb($input, $user = null, Closure $customizer = null)
+    {
+        return $this->register($input, $user, function() use ($user) {
+            if (! is_null($customizer)) {
+                $customizer($user);
+            }
+            // Set the user's country code by Fastly geo-location header.
+            $user->country = country_code();
+            // Set language based on locale (either 'en', 'es-mx').
+            $user->language = app()->getLocale();
+            // Sign the user up for email messaging & give them the "community" topic.
+            $user->email_subscription_status = true;
+            $user->email_subscription_topics = ['community'];
+            // TODO: Check user source detail and assign feature flags if not clubs member.
+        });
+    }
 }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -205,27 +205,34 @@ class Registrar
     }
 
     /**
-     * Create a new user OR update an existing user (if given).
+     * Create a new user via web.
      *
      * @param array $input - Profile fields
-     * @param User $user - Optionally, user to update
      * @param Closure $customizer - Customize the user instance before saving.
      * @return User|null
      */
-    public function registerViaWeb($input, $user = null, Closure $customizer = null)
+    public function registerViaWeb($input, Closure $customizer = null)
     {
-        return $this->register($input, $user, function () use ($user) {
-            if (! is_null($customizer)) {
-                $customizer($user);
-            }
-            // Set the user's country code by Fastly geo-location header.
-            $user->country = country_code();
-            // Set language based on locale (either 'en', 'es-mx').
-            $user->language = app()->getLocale();
-            // Sign the user up for email messaging & give them the "community" topic.
-            $user->email_subscription_status = true;
-            $user->email_subscription_topics = ['community'];
-            // TODO: Check user source detail and assign feature flags if not clubs member.
-        });
+        $user = new User;
+
+        $user->fill($input);
+
+        if (! is_null($customizer)) {
+            $customizer($user);
+        }
+
+        // Set the user's country code by Fastly geo-location header.
+        $user->country = country_code();
+        // Set language based on locale (either 'en', 'es-mx').
+        $user->language = app()->getLocale();
+        // Sign the user up for email messaging & give them the "community" topic.
+        $user->email_subscription_status = true;
+        $user->email_subscription_topics = ['community'];
+
+        // TODO: Check user->source_detail and assign feature flags if not clubs member.
+
+        $user->save();
+
+        return $user;
     }
 }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -217,6 +217,7 @@ class Registrar
 
         $user->fill($input);
 
+        // The user's source_detail is often set via this customizer parameter.
         if (! is_null($customizer)) {
             $customizer($user);
         }

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -214,7 +214,7 @@ class Registrar
      */
     public function registerViaWeb($input, $user = null, Closure $customizer = null)
     {
-        return $this->register($input, $user, function() use ($user) {
+        return $this->register($input, $user, function () use ($user) {
             if (! is_null($customizer)) {
                 $customizer($user);
             }

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -197,7 +197,6 @@ class AuthController extends Controller
 
         // Register and login the user.
         $editableFields = $request->except(User::$internal);
-
         $user = $this->registrar->registerViaWeb($editableFields, function ($user) {
             // Set sms_status, if applicable
             if ($user->mobile) {

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -198,15 +198,8 @@ class AuthController extends Controller
         // Register and login the user.
         $editableFields = $request->except(User::$internal);
         $user = $this->registrar->register($editableFields, null, function ($user) {
-            // Set the user's country code by Fastly geo-location header.
-            $user->country = country_code();
-
-            // Set language based on locale (either 'en', 'es-mx')
-            $user->language = app()->getLocale();
-
-            // Sign the user up for email messaging & give them the "community" topic.
-            $user->email_subscription_status = true;
-            $user->email_subscription_topics = ['community'];
+            // Set default web registration fields.
+            $user->fill(get_default_web_registration_fields());
 
             // Set source_detail, if applicable.
             $sourceDetail = session('source_detail');

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -198,11 +198,6 @@ class AuthController extends Controller
         // Register and login the user.
         $editableFields = $request->except(User::$internal);
         $user = $this->registrar->registerViaWeb($editableFields, function ($user) {
-            // Set sms_status, if applicable
-            if ($user->mobile) {
-                $user->sms_status = 'active';
-            }
-
             // Set source_detail, if applicable.
             $sourceDetail = session('source_detail');
             if ($sourceDetail) {

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -197,9 +197,12 @@ class AuthController extends Controller
 
         // Register and login the user.
         $editableFields = $request->except(User::$internal);
-        $user = $this->registrar->register($editableFields, null, function ($user) {
-            // Set default web registration fields.
-            $user->fill(get_default_web_registration_fields());
+
+        $user = $this->registrar->registerViaWeb($editableFields, function ($user) {
+            // Set sms_status, if applicable
+            if ($user->mobile) {
+                $user->sms_status = 'active';
+            }
 
             // Set source_detail, if applicable.
             $sourceDetail = session('source_detail');
@@ -207,6 +210,7 @@ class AuthController extends Controller
                 $user->source_detail = stringify_object($sourceDetail);
             }
 
+            // TODO: Move this into registerViaWeb.
             // Exclude any 'clubs' referrals from our feature flag tests.
             if (data_get($sourceDetail, 'utm_source') !== 'clubs') {
                 $feature_flags = $user->feature_flags;

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -90,9 +90,8 @@ class FacebookController extends Controller
             $northstarUser->save();
         } else {
             $fields['email'] = $email;
-            $fields = array_merge($fields, get_default_web_registration_fields());
 
-            $northstarUser = $this->registrar->register($fields, null, function (User $user) {
+            $northstarUser = $this->registrar->registerViaWeb($fields, null, function (User $user) {
                 $user->setSource(null, 'facebook');
             });
         }

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -91,7 +91,7 @@ class FacebookController extends Controller
         } else {
             $fields['email'] = $email;
 
-            $northstarUser = $this->registrar->registerViaWeb($fields, null, function (User $user) {
+            $northstarUser = $this->registrar->registerViaWeb($fields, function (User $user) {
                 $user->setSource(null, 'facebook');
             });
         }

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -90,7 +90,7 @@ class GoogleController extends Controller
         } else {
             $fields['email'] = $email;
 
-            $northstarUser = $this->registrar->registerViaWeb($fields, null, function (User $user) {
+            $northstarUser = $this->registrar->registerViaWeb($fields, function (User $user) {
                 $user->setSource(null, 'google');
             });
         }

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -67,6 +67,7 @@ class GoogleController extends Controller
             return redirect('/register')->with('status', 'Unable to verify Google account.');
         }
 
+        $email = $googleUser->email;
         // Some date properties in this array may not contain a year property.
         $birthdaysWithYear = array_filter($googleProfile->birthdays, function ($item) {
             return isset($item->date->year);
@@ -81,19 +82,14 @@ class GoogleController extends Controller
             'birthdate' => Carbon::createFromDate($birthday->year, $birthday->month, $birthday->day),
         ];
 
-        $northstarUser = $this->registrar->resolve(['email' => $googleUser->email]);
+        $northstarUser = $this->registrar->resolve(['email' => $email]);
 
         if ($northstarUser) {
             $northstarUser->updateIfNotSet($fields);
             $northstarUser->save();
         } else {
-            $fields['email'] = $googleUser->email;
-            $fields['country'] = country_code();
-            $fields['language'] = app()->getLocale();
-
-            // Add same email settings as traditional new members
-            $fields['email_subscription_status'] = true;
-            $fields['email_subscription_topics'] = ['community'];
+            $fields['email'] = $email;
+            $fields = array_merge($fields, get_default_web_registration_fields());
 
             $northstarUser = $this->registrar->register($fields, null, function (User $user) {
                 $user->setSource(null, 'google');

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -89,9 +89,8 @@ class GoogleController extends Controller
             $northstarUser->save();
         } else {
             $fields['email'] = $email;
-            $fields = array_merge($fields, get_default_web_registration_fields());
 
-            $northstarUser = $this->registrar->register($fields, null, function (User $user) {
+            $northstarUser = $this->registrar->registerViaWeb($fields, null, function (User $user) {
                 $user->setSource(null, 'google');
             });
         }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -333,3 +333,21 @@ function format_mobile(PhoneNumber $number, $format): string
 
     return $parser->format($number, $format);
 }
+
+/**
+ * Returns array of fields and values to use for a new user registering via web.
+ *
+ * @return array
+ */
+function get_default_web_registration_fields()
+{
+    return [
+        // Set the user's country code by Fastly geo-location header.
+        'country' => country_code(),
+        // Set language based on locale (either 'en', 'es-mx').
+        'language' => app()->getLocale(),
+        // Sign the user up for email messaging & give them the "community" topic.
+        'email_subscription_status' => true,
+        'email_subscription_topics' => ['community'],
+    ];
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -333,21 +333,3 @@ function format_mobile(PhoneNumber $number, $format): string
 
     return $parser->format($number, $format);
 }
-
-/**
- * Returns array of fields and values to use for a new user registering via web.
- *
- * @return array
- */
-function get_default_web_registration_fields()
-{
-    return [
-        // Set the user's country code by Fastly geo-location header.
-        'country' => country_code(),
-        // Set language based on locale (either 'en', 'es-mx').
-        'language' => app()->getLocale(),
-        // Sign the user up for email messaging & give them the "community" topic.
-        'email_subscription_status' => true,
-        'email_subscription_topics' => ['community'],
-    ];
-}

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -104,6 +104,8 @@ class FacebookTest extends BrowserKitTestCase
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
         $this->assertEquals($user->source_detail, 'facebook');
+        $this->assertEquals($user->country_code, country_code());
+        $this->assertEquals($user->language, app()->getLocale());
         $this->assertEquals($user->email_subscription_status, true);
         $this->assertEquals($user->email_subscription_topics, ['community']);
     }

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -128,6 +128,8 @@ class GoogleTest extends BrowserKitTestCase
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
         $this->assertEquals($user->source_detail, 'google');
+        $this->assertEquals($user->country_code, country_code());
+        $this->assertEquals($user->language, app()->getLocale());
         $this->assertEquals($user->email_subscription_status, true);
         $this->assertEquals($user->email_subscription_topics, ['community']);
         $this->assertEquals($user->birthdate, new Carbon\Carbon('2001-07-11'));


### PR DESCRIPTION
#### What's this PR do?

Branching from #942, this PR adds a `get_default_web_registration_fields` helper to DRY setting default values for web registrations (account created via the register page, Facebook login, or Google login)

#### How should this be reviewed?

👀 


#### Checklist
- [x] Tests added for new features/bug fixes.
