### PR TITLE
Additional newsletter subscription reset types

### DIFF
--- a/app/PasswordResetType.php
+++ b/app/PasswordResetType.php
@@ -12,18 +12,39 @@ class PasswordResetType
     public static $forgotPassword = 'forgot-password';
 
     /**
-     * A Breakdown Subscriber Activate Account type.
+     * A Boost subscriber Activate Account type.
+     *
+     * @var string
+     */
+    public static $boostActivateAccount = 'boost-activate-account';
+
+    /**
+     * A Breakdown subscriber Activate Account type.
      *
      * @var string
      */
     public static $breakdownActivateAccount = 'breakdown-activate-account';
 
     /**
-     * A Rock The Vote Activate Account type.
+     * A Pays To Do Good subscriber Activate Account type.
+     *
+     * @var string
+     */
+    public static $paysToDoGoodActivateAccount = 'pays-to-do-good-activate-account';
+
+    /**
+     * A Rock The Vote registration Activate Account type.
      *
      * @var string
      */
     public static $rockTheVoteActivateAccount = 'rock-the-vote-activate-account';
+
+    /**
+     * A WYD subscriber Activate Account type.
+     *
+     * @var string
+     */
+    public static $wydActivateAccount = 'wyd-activate-account';
 
     /**
      * Returns list of all valid Password Reset Types.
@@ -34,8 +55,11 @@ class PasswordResetType
     {
         return [
             self::$forgotPassword,
+            self::$boostActivateAccount,
             self::$breakdownActivateAccount,
+            self::$paysToDoGoodActivateAccount,
             self::$rockTheVoteActivateAccount,
+            self::$wydActivateAccount,
         ];
     }
 }

--- a/documentation/endpoints/resets.md
+++ b/documentation/endpoints/resets.md
@@ -21,8 +21,11 @@ POST /v2/resets
    *
    * Valid types:
    * - 'forgot-password'
+   * - `boost-activate-account`
    * - 'breakdown-activate-account'
+   * - `pays-to-do-good-activate-account`
    * - 'rock-the-vote-activate-account' 
+   * - `wyd-activate-account`
    */
   type: String
 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds 3 new valid password reset types:

* `boost-activate-account`
* `pays-to-do-good-activate-account`
* `wyd-activate-account`

which can be passed to the `POST /resets` endpoint. This endpoint is used by Chompy's email subscription import to generate a valid reset password URL for a user and send it to Customer.io as an `call_to_action_email` event. 

The next steps for setting up these new Activate Account emails will take place outside of this repo. As outlined in [docs.dosomething.org](http://docs.dosomething.org/non-traditional-member-activation#create-new-type), they are:

* Set up Customer.io campaigns in staging and production to send an email when a `call_to_action_event` is created with one of these 3 new types

* Modify Chompy email subscription import to send `POST /resets` request for each email subscription topic (currently only sends for `news` subscribers)

* Update [docs.dosomething.org with new password reset types](http://docs.dosomething.org/customer-io#call-to-action-email)

#### How should this be reviewed?

👀 

#### Relevant Tickets

https://www.pivotaltracker.com/story/show/169043520

