### PR TITLE
Remove nav menu items from Northstar

### DIFF
--- a/resources/assets/scss/_regions/_navigation.scss
+++ b/resources/assets/scss/_regions/_navigation.scss
@@ -1,3 +1,7 @@
 nav.navigation {
   padding-bottom: $base-spacing * 2;
 }
+
+.navigation__logo {
+  padding-bottom: $base-spacing * 2;
+}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,20 +1,6 @@
 <nav class="navigation">
-    <a class="navigation__logo" href="http://www.dosomething.org"><span>DoSomething.org</span></a>
-    <a class="navigation__toggle js-navigation-toggle" href="#"><span>Show Menu</span></a>
     <div class="navigation__menu">
-        <ul class="navigation__primary">
-            <li>
-                <a href="{{ config('services.phoenix.url') }}/campaigns">
-                  <strong class="navigation__title">Explore Campaigns</strong>
-                  <span class="navigation__subtitle">Find ways to take action both online and off.</span>
-                </a>
-            </li>
-            <li>
-                <a href="{{ config('services.phoenix.url') }}/about/who-we-are">
-                  <strong class="navigation__title">What Is DoSomething.org?</strong>
-                  <span class="navigation__subtitle">A global movement for good. </span>
-                </a>
-            </li>
-        </ul>
+        <a class="navigation__logo" href="http://www.dosomething.org"><span>DoSomething.org</span></a>
+        <a class="navigation__toggle js-navigation-toggle" href="#"><span>Show Menu</span></a>
     </div>
 </nav>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,6 +1,4 @@
 <nav class="navigation">
-    <div class="navigation__menu">
-        <a class="navigation__logo" href="http://www.dosomething.org"><span>DoSomething.org</span></a>
-        <a class="navigation__toggle js-navigation-toggle" href="#"><span>Show Menu</span></a>
-    </div>
+    <a class="navigation__logo" href="http://www.dosomething.org"><span>DoSomething.org</span></a>
+    <a class="navigation__toggle js-navigation-toggle" href="#"><span>Show Menu</span></a>
 </nav>


### PR DESCRIPTION
#### What's this PR do?

Removes the circled items below!
![Screen Shot 2019-10-21 at 5 04 42 PM](https://user-images.githubusercontent.com/4240292/67338255-95d19180-f4dd-11e9-96fc-03dfe3ae3d36.png)

Here's what it looks like now:
![image](https://user-images.githubusercontent.com/4240292/67339675-8738a980-f4e0-11e9-8ee3-f08ccbfc1f9f.png)

And on mobile:
![image](https://user-images.githubusercontent.com/4240292/67339701-93246b80-f4e0-11e9-8ec9-ab976698c4c1.png)


#### How should this be reviewed?
I removed those nav menu items (explore campaigns, what is do something?), but I wrapped the logo in a `div` with class of `navigation__menu` to get the padding right. BUT THEN the logo got hidden on mobile, which was a property of `navigation__menu` (which is unfortunately also where the correct padding was coming from). So, I added a css rule for `.navigation__logo` to maintain the same padding as before. I think it looks right now.

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/169217805)

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
