### PR TITLE
Google Authentication - Confirm Required User Attributes

### DIFF
--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -28,9 +28,9 @@ class GoogleController extends Controller
      *
      * @return \Illuminate\Http\RedirectResponse
      */
-    protected function redirectUnsuccessfulRequest()
+    protected function redirectUnsuccessfulRequest($message = null)
     {
-        return redirect('/register')->with('status', 'Unable to verify Google account.');
+        return redirect('/register')->with('status', $message ?: 'Unable to verify Google account.');
     }
 
     /**
@@ -86,7 +86,7 @@ class GoogleController extends Controller
 
         // If this is a new registration, ensure we've received the required profile fields.
         if (! $northstarUser && (! $firstName || ! $lastName)) {
-            return $this->redirectUnsuccessfulRequest();
+            return $this->redirectUnsuccessfulRequest('We need your first and last name to create your account! Please confirm that these are set on your Google profile and try again.');
         }
 
         $birthday = null;

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -26,7 +26,7 @@ class GoogleController extends Controller
     /**
      * Redirect unsuccessful authentication requests.
      *
-     * @return Redirect
+     * @return \Illuminate\Http\RedirectResponse
      */
     protected function redirectUnsuccessfulRequest()
     {

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -77,17 +77,20 @@ class GoogleController extends Controller
             return $this->redirectUnsuccessfulRequest();
         }
 
-        // Ensure all required user attributes are available on the given profile.
-        foreach (['given_name', 'family_name'] as $requiredAttribute) {
-            if (! array_key_exists($requiredAttribute, $googleUser->user)) {
-                return $this->redirectUnsuccessfulRequest();
-            }
-        }
-
         $email = $googleUser->email;
 
+        $northstarUser = $this->registrar->resolve(['email' => $email]);
+
+        $firstName = data_get($googleUser->user, 'given_name');
+        $lastName = data_get($googleUser->user, 'family_name');
+
+        // If this is a new registration, ensure we've received the required profile fields.
+        if (! $northstarUser && (! $firstName || ! $lastName)) {
+            return $this->redirectUnsuccessfulRequest();
+        }
+
         $birthday = null;
-        // If birthdate is not set on the google profile, we won't receive a 'birthdays' attribute.
+        // If birthdate is not set on the google profile, we won't receive a 'birthdays' field.
         if (array_key_exists('birthdays', $googleProfile)) {
             // Some date properties in this array may not contain a year property.
             $birthdaysWithYear = array_filter($googleProfile->birthdays, function ($item) {
@@ -99,8 +102,8 @@ class GoogleController extends Controller
         // Aggregate Google profile fields.
         $fields = [
             'google_id' => $googleUser->id,
-            'first_name' => $googleUser->user['given_name'],
-            'last_name' => $googleUser->user['family_name'],
+            'first_name' => $firstName,
+            'last_name' => $lastName,
         ];
 
         if ($birthday) {
@@ -110,8 +113,6 @@ class GoogleController extends Controller
                 $birthday->day
             );
         }
-
-        $northstarUser = $this->registrar->resolve(['email' => $email]);
 
         if ($northstarUser) {
             $northstarUser->updateIfNotSet($fields);

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -96,7 +96,7 @@ class GoogleController extends Controller
             $birthdaysWithYear = array_filter($googleProfile->birthdays, function ($item) {
                 return isset($item->date->year);
             });
-            $birthday = Arr::first($birthdaysWithYear)->date;
+            $birthday = data_get(Arr::first($birthdaysWithYear), 'date');
         }
 
         // Aggregate Google profile fields.

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -190,7 +190,7 @@ class GoogleTest extends BrowserKitTestCase
         $this->mockSocialiteFromUser($abstractUser);
 
         $mockGoogleProfile = $this->mockGoogleProfile($googleId);
-        // Remove the borthdays attribute from the mocked Google Profile payload.
+        // Remove the birthdays attribute from the mocked Google Profile payload.
         unset($mockGoogleProfile->birthdays);
 
         $this->mock(Google::class)


### PR DESCRIPTION
#### What's this PR do?
Aborts the Google authentication flow if the Google API returns a user missing any key attributes.

This should help prevent any breakage resulting from a user missing any of these attributes we grab when creating new accounts. (E.g. you can unset your surname on your Google account and the `family_name` would be missing from the User payload).

It also moves the redirect logic into a `protected` function since we're using it twice now.

#### How should this be reviewed?
Does this make sense? Did I put the protected function in the right place?

#### Relevant Tickets
https://www.pivotaltracker.com/story/show/169398251

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
