### PR TITLE
Subscriptions endpoint

### DIFF
--- a/app/Http/Controllers/ResetController.php
+++ b/app/Http/Controllers/ResetController.php
@@ -37,26 +37,8 @@ class ResetController extends Controller
         /** @var \Northstar\Models\User $user */
         $user = User::findOrFail($request['id']);
 
-        $tokenRepository = $this->createTokenRepository();
-        $token = $tokenRepository->create($user);
-        $message = $user->sendPasswordReset($request['type'], $token);
+        $user->sendPasswordReset($request['type']);
 
         return $this->respond('Message sent.');
-    }
-
-    /**
-     * Create a token repository instance based on the given configuration.
-     *
-     * @return DatabaseTokenRepository
-     */
-    protected function createTokenRepository()
-    {
-        return new DatabaseTokenRepository(
-            app('db')->connection(),
-            app('hash'),
-            config('auth.passwords.users.table'),
-            config('app.key'),
-            config('auth.passwords.users.expire')
-        );
     }
 }

--- a/app/Http/Controllers/ResetController.php
+++ b/app/Http/Controllers/ResetController.php
@@ -39,7 +39,7 @@ class ResetController extends Controller
 
         $tokenRepository = $this->createTokenRepository();
         $token = $tokenRepository->create($user);
-        $message = $user->sendPasswordReset($token, $request['type']);
+        $message = $user->sendPasswordReset($request['type'], $token);
 
         return $this->respond('Message sent.');
     }

--- a/app/Http/Controllers/ResetController.php
+++ b/app/Http/Controllers/ResetController.php
@@ -3,10 +3,9 @@
 namespace Northstar\Http\Controllers;
 
 use Northstar\Models\User;
-use Northstar\PasswordResetType;
-use Illuminate\Validation\Rule;
 use Illuminate\Http\Request;
-use Jenssegers\Mongodb\Auth\DatabaseTokenRepository;
+use Illuminate\Validation\Rule;
+use Northstar\PasswordResetType;
 
 class ResetController extends Controller
 {

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -42,7 +42,7 @@ class SubscriptionController extends Controller
      * @param Request $request
      * @return array
      */
-    public function create(Request $request) 
+    public function create(Request $request)
     {
         $this->validate($request, [
             'email' => 'required|email',
@@ -57,7 +57,7 @@ class SubscriptionController extends Controller
         // If the user already exists, only update the email topics
         if ($existingUser) {
             foreach ($request->get('email_subscription_topics') as $topic) {
-                $existingUser->addEmailSubscriptionTopic($topic);   
+                $existingUser->addEmailSubscriptionTopic($topic);
             }
 
             $existingUser->save();

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -46,8 +46,7 @@ class SubscriptionController extends Controller
     {
         $this->validate($request, [
             'email' => 'required|email',
-            'email_subscription_topics' => 'required',
-            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',
+            'email_subscription_topic' => 'required|in:news,scholarships,lifestyle,community',
             'source' => 'required',
             'source_detail' => 'required',
         ]);
@@ -56,9 +55,7 @@ class SubscriptionController extends Controller
 
         // If the user already exists, only update the email topics
         if ($existingUser) {
-            foreach ($request->get('email_subscription_topics') as $topic) {
-                $existingUser->addEmailSubscriptionTopic($topic);
-            }
+            $existingUser->addEmailSubscriptionTopic($request->get('email_subscription_topic'));
 
             $existingUser->save();
 
@@ -67,6 +64,7 @@ class SubscriptionController extends Controller
 
         $newUser = $this->registrar->register($request->all());
 
+        $newUser->email_subscription_topics = [$request->get('email_subscription_topic')];
         $newUser->email_subscription_status = true;
         $newUser->source = $request->get('source');
         $newUser->source_detail = $request->get('source_detail');

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -6,7 +6,6 @@ use Northstar\Models\User;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
 use Northstar\Http\Transformers\UserTransformer;
-use Jenssegers\Mongodb\Auth\DatabaseTokenRepository;
 
 class SubscriptionController extends Controller
 {
@@ -90,21 +89,5 @@ class SubscriptionController extends Controller
         }
 
         return $this->item($newUser, 201);
-    }
-
-    /**
-     * Create a token repository instance based on the given configuration.
-     *
-     * @return DatabaseTokenRepository
-     */
-    protected function createTokenRepository()
-    {
-        return new DatabaseTokenRepository(
-            app('db')->connection(),
-            app('hash'),
-            config('auth.passwords.users.table'),
-            config('app.key'),
-            config('auth.passwords.users.expire')
-        );
     }
 }

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -23,8 +23,8 @@ class SubscriptionController extends Controller
      */
     protected $transformer;
 
-     /**
-     * Make a new ResetController, inject dependencies,
+    /**
+     * Make a new SubscriptionController, inject dependencies,
      * and set middleware for this controller's methods.
      */
     public function __construct(Registrar $registrar, UserTransformer $transformer)
@@ -42,7 +42,8 @@ class SubscriptionController extends Controller
      * @param Request $request
      * @return array
      */
-    public function create(Request $request) {
+    public function create(Request $request) 
+    {
         $this->validate($request, [
             'email' => 'required|email',
             'email_subscription_topics' => 'required',
@@ -50,12 +51,12 @@ class SubscriptionController extends Controller
             'source' => 'required',
             'source_detail' => 'required',
         ]);
-        
+
         $existingUser = $this->registrar->resolve($request->only('email'));
 
         // If the user already exists, only update the email topics
         if ($existingUser) {
-            foreach($request->get('email_subscription_topics') as $topic) {
+            foreach ($request->get('email_subscription_topics') as $topic) {
                 $existingUser->addEmailSubscriptionTopic($topic);   
             }
 
@@ -68,7 +69,7 @@ class SubscriptionController extends Controller
 
         $newUser->email_subscription_status = true;
         $newUser->source = $request->get('source');
-        $newUser->source_detail =  $request->get('source_detail');
+        $newUser->source_detail = $request->get('source_detail');
 
         $newUser->save();
 

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+use Northstar\Models\User;
+use Illuminate\Http\Request;
+use Northstar\Auth\Registrar;
+use Northstar\Http\Transformers\UserTransformer;
+
+class SubscriptionController extends Controller
+{
+    /**
+     * The registrar handles creating, updating, and
+     * validating user accounts.
+     *
+     * @var Registrar
+     */
+    protected $registrar;
+
+    /**
+     * @var UserTransformer
+     */
+    protected $transformer;
+
+     /**
+     * Make a new ResetController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
+    public function __construct(Registrar $registrar, UserTransformer $transformer)
+    {
+        $this->registrar = $registrar;
+        $this->transformer = $transformer;
+
+        $this->middleware('throttle:10,60');
+    }
+
+    /**
+     * Creates a new user with given email subscription topic, or adds the given topic to an existing user.
+     * POST v2/subscriptions
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function create(Request $request) {
+        $this->validate($request, [
+            'email' => 'required|email',
+            'email_subscription_topics' => 'required',
+            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',
+            'source' => 'required',
+            'source_detail' => 'required',
+        ]);
+        
+        $existingUser = $this->registrar->resolve($request->only('email'));
+
+        // If the user already exists, only update the email topics
+        if ($existingUser) {
+            foreach($request->get('email_subscription_topics') as $topic) {
+                $existingUser->addEmailSubscriptionTopic($topic);   
+            }
+
+            $existingUser->save();
+
+            return $this->item($existingUser, 200);
+        }
+
+        $newUser = $this->registrar->register($request->all());
+
+        $newUser->source = $request->get('source');
+        $newUser->source_detail =  $request->get('source_detail');
+
+        $newUser->save();
+
+        return $this->item($newUser, 201);
+    }
+}

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -5,6 +5,7 @@ namespace Northstar\Http\Controllers;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
+use Northstar\PasswordResetType;
 use Northstar\Http\Transformers\UserTransformer;
 
 class SubscriptionController extends Controller
@@ -75,16 +76,16 @@ class SubscriptionController extends Controller
         // Send activate account email to new user
         switch ($topic) {
             case 'scholarships':
-                $newUser->sendPasswordReset('pays-to-do-good-activate-account');
+                $newUser->sendPasswordReset(PasswordResetType::$paysToDoGoodActivateAccount);
                 break;
             case 'news':
-                $newUser->sendPasswordReset('breakdown-activate-account');
+                $newUser->sendPasswordReset(PasswordResetType::$breakdownActivateAccount);
                 break;
             case 'lifestyle':
-                $newUser->sendPasswordReset('boost-activate-account');
+                $newUser->sendPasswordReset(PasswordResetType::$boostActivateAccount);
                 break;
             case 'community':
-                $newUser->sendPasswordReset('wyd-activate-account');
+                $newUser->sendPasswordReset(PasswordResetType::$wydActivateAccount);
                 break;
         }
 

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -85,9 +85,8 @@ class UserTransformer extends BaseTransformer
             // Internal & third-party service IDs:
             $response['slack_id'] = null;
 
-            // Email subscription statuses
+            // Email subscription status
             $response['email_subscription_status'] = (bool) $user->email_subscription_status;
-            $response['email_subscription_topics'] = $user->email_subscription_topics;
 
             //Cause Areas
             $response['causes'] = $user->causes;
@@ -113,6 +112,9 @@ class UserTransformer extends BaseTransformer
         // SMS subscription status
         $response['sms_status'] = $user->sms_status;
         $response['sms_paused'] = (bool) $user->sms_paused;
+
+        // Email subscription topics
+        $response['email_subscription_topics'] = $user->email_subscription_topics;
 
         $response['role'] = $user->role;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -647,7 +647,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function sendPasswordReset($type, $token = null)
     {
-        if (!$token) {
+        if (! $token) {
             $tokenRepository = new DatabaseTokenRepository(
                 app('db')->connection(),
                 app('hash'),

--- a/documentation/endpoints/subscriptions.md
+++ b/documentation/endpoints/subscriptions.md
@@ -6,9 +6,9 @@ This endpoint has no authentication, but is rate limited to 10 requests per hour
 
 Tries to find a user by email, and creates a new user if one is not found.
 
-If the user already exists, the given `email_subscription_topics` are added to the user.
+If the user already exists, the given `email_subscription_topic` is added to the user.
 
-If a new user was created, the given `email_subscription_topics`, `source`, and `source_detail` are set on the user. _A new user is also sent an activate account email, corresponding to the newsletter that they have just signed up for._
+If a new user was created, the given `email_subscription_topic`, `source`, and `source_detail` are set on the user. _A new user is also sent an activate account email, corresponding to the newsletter that they have just signed up for._
 
 ```
 POST /v2/subscriptions
@@ -21,7 +21,7 @@ POST /v2/subscriptions
   /* The email of the user to find or create. */
   email: String;
 
-  /* The email subscription topics to add to the user.
+  /* The email subscription topic to add to the user.
    *
    * Valid topics:
    * - 'lifestyle'
@@ -29,7 +29,7 @@ POST /v2/subscriptions
    * - 'scholarships'
    * - `community`
    */
-  email_subscription_topics: Array;
+  email_subscription_topic: String;
 
   /* These fields will only be set on new users. */
   source: String;
@@ -47,9 +47,7 @@ POST /v2/subscriptions
      -d $'{
   "email": "funner@dosomething.org",
   "source_details": "subscription-page",
-  "email_subscription_topics": [
-    "lifestyle"
-  ],
+  "email_subscription_topic": "lifestyle",
   "source": "phoenix-next"
 }'
 ```

--- a/documentation/endpoints/subscriptions.md
+++ b/documentation/endpoints/subscriptions.md
@@ -4,7 +4,11 @@ This endpoint has no authentication, but is rate limited to 10 requests per hour
 
 ## Add a subscription topic to a user by email
 
-Tries to find a user by email, and creates a new user if one is not found. If the user already exists, the given `email_subscription_topics` are added to the user. If a new user was created, the given `email_subscription_topics`, `source`, and `source_detail` are set on the user.
+Tries to find a user by email, and creates a new user if one is not found.
+
+If the user already exists, the given `email_subscription_topics` are added to the user.
+
+If a new user was created, the given `email_subscription_topics`, `source`, and `source_detail` are set on the user. _A new user is also sent an activate account email, corresponding to the newsletter that they have just signed up for._
 
 ```
 POST /v2/subscriptions

--- a/documentation/endpoints/subscriptions.md
+++ b/documentation/endpoints/subscriptions.md
@@ -1,0 +1,85 @@
+# Subscriptions Endpoint
+
+This endpoint has no authentication, but is rate limited to 10 requests per hour per IP.
+
+## Add a subscription topic to a user by email
+
+Tries to find a user by email, and creates a new user if one is not found. If the user already exists, the given `email_subscription_topics` are added to the user. If a new user was created, the given `email_subscription_topics`, `source`, and `source_detail` are set on the user.
+
+```
+POST /v2/subscriptions
+```
+
+**Request Parameters:**
+
+```js
+{
+  /* The email of the user to find or create. */
+  email: String;
+
+  /* The email subscription topics to add to the user.
+   *
+   * Valid topics:
+   * - 'lifestyle'
+   * - `news`
+   * - 'scholarships'
+   * - `community`
+   */
+  email_subscription_topics: Array;
+
+  /* These fields will only be set on new users. */
+  source: String;
+  source_detail: String;
+}
+```
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```sh
+  curl -X "POST" "http://northstar.test/v2/subscriptions" \
+     -H 'Accept: application/json' \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+  "email": "funner@dosomething.org",
+  "source_details": "subscription-page",
+  "email_subscription_topics": [
+    "lifestyle"
+  ],
+  "source": "phoenix-next"
+}'
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```js
+// 200 OK
+
+{
+  "data": {
+    "id": "5dc5fd76fdce2717885506a2",
+    "display_name": null,
+    "first_name": null,
+    "last_initial": "",
+    "photo": null,
+    "voting_plan_method_of_transport": null,
+    "voting_plan_time_of_day": null,
+    "voting_plan_attending_with": null,
+    "language": null,
+    "country": null,
+    "sms_status": null,
+    "sms_paused": false,
+    "email_subscription_topics": [
+      "lifestyle"
+    ],
+    "role": "user",
+    "updated_at": "2019-11-12T00:11:20+00:00",
+    "created_at": "2019-11-08T23:42:46+00:00"
+  }
+}
+```
+
+</details>

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,9 @@ $router->group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     $this->get('mobile/{mobile}', 'MobileController@show');
     $this->get('email/{email}', 'EmailController@show');
 
+    // Subscriptions
+    $this->post('subscriptions', 'SubscriptionController@create');
+
     // Profile
     // ...
 

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -201,4 +201,25 @@ class SubscriptionsTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(429);
     }
+
+    /**
+     * Test that a new user gets a password reset email.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testNewUserGetsActivateAccountEmail()
+    {
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => 'topics@dosomething.org',
+            'email_subscription_topics' => ['scholarships'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(201);
+        $this->blinkMock->shouldHaveReceived('userCallToActionEmail')->once();
+
+        $this->seeInDatabase('password_resets', ['email' => 'topics@dosomething.org']);
+    }
 }

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+
+class SubscriptionsTest extends BrowserKitTestCase
+{
+    /**
+     * Test adding a subscription topic to an existing user.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testAddSubscriptionToExistingUser()
+    {
+        $user = factory(User::class)->create(['email_subscription_topics' => []]);
+
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['scholarships'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The email_subscription_topics should be added, but the source and source_detail should not change
+        $this->seeInDatabase('users', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['scholarships'],
+            'source' => $user->source,
+            'source_detail' => $user->source_detail
+        ]);
+    }
+
+    /**
+     * Test adding multiple subscription topics to an existing user.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testAddMultipleSubscriptionsToExistingUser()
+    {
+        $user = factory(User::class)->create(['email_subscription_topics' => []]);
+
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['scholarships', 'lifestyle'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The email_subscription_topics should be updated, but the source and source_detail should not change
+        $this->seeInDatabase('users', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['scholarships', 'lifestyle'],
+            'source' => $user->source,
+            'source_detail' => $user->source_detail
+        ]);
+    }
+
+    /**
+     * Test adding a subscription topics to an existing user with no duplicates.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testAddSubscriptionToExistingUserWithNoDuplicates()
+    {
+        // Create a user who already has a subscription topic
+        $user = factory(User::class)->create(['email_subscription_topics' => ['news']]);
+
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['news'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The email_subscription_topics should have no duplicates
+        $this->seeInDatabase('users', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['news'],
+            'source' => $user->source,
+            'source_detail' => $user->source_detail
+        ]);
+    }
+
+    /**
+     * Test adding multiple subscription topics to an existing user with no duplicates.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testAddMultipleSubscriptionsToExistingUserWithNoDuplicates()
+    {
+        // Create a user who already has subscription topics
+        $user = factory(User::class)->create(['email_subscription_topics' => ['news', 'lifestyle']]);
+
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['news', 'community'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The email_subscription_topics should be updated with no duplicates
+        $this->seeInDatabase('users', [
+            'email' => $user->email,
+            'email_subscription_topics' => ['news', 'lifestyle', 'community'],
+            'source' => $user->source,
+            'source_detail' => $user->source_detail
+        ]);
+    }
+
+    /**
+     * Test adding a subscription topic to a new user.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testAddSubscriptionToNewUser()
+    {
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => 'topics@dosomething.org',
+            'email_subscription_topics' => ['scholarships'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(201);
+
+        // The user should be created with the given email_subscription_topics, source, and source_detail
+        $this->seeInDatabase('users', [
+            'email' => 'topics@dosomething.org',
+            'email_subscription_topics' => ['scholarships'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+    }
+
+    /**
+     * Test adding multiple subscription topics to a new user.
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testAddMultipleSubscriptionsToNewUser()
+    {
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => 'topics@dosomething.org',
+            'email_subscription_topics' => ['scholarships', 'news'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(201);
+
+        // The user should be created with the given email_subscription_topics
+        $this->seeInDatabase('users', [
+            'email' => 'topics@dosomething.org',
+            'email_subscription_topics' => ['scholarships', 'news'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+    }
+
+    /**
+     * Test rate limiting (10 posts per hour)
+     * POST /v2/subscriptions
+     *
+     * @return void
+     */
+    public function testSubscriptionsThrottle()
+    {
+        // Post to /subscriptions 10 times
+        for ($i = 0; $i < 10; $i++) {
+            $this->json('POST', 'v2/subscriptions', [
+                'email' => 'topics' . $i . '@dosomething.org',
+                'email_subscription_topics' => ['scholarships', 'news'],
+                'source' => 'phoenix-next',
+                'source_detail' => 'test_source_detail'
+            ]);
+            
+            $this->assertResponseStatus(201);
+        }
+
+        // Get a "Too Many Attempts" response when trying for an 11th post within an hour
+        $this->json('POST', 'v2/subscriptions', [
+            'email' => 'topics11@dosomething.org',
+            'email_subscription_topics' => ['scholarships', 'news'],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail'
+        ]);
+
+        $this->assertResponseStatus(429);
+    }
+}

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -181,12 +181,12 @@ class SubscriptionsTest extends BrowserKitTestCase
         // Post to /subscriptions 10 times
         for ($i = 0; $i < 10; $i++) {
             $this->json('POST', 'v2/subscriptions', [
-                'email' => 'topics' . $i . '@dosomething.org',
+                'email' => 'topics'.$i.'@dosomething.org',
                 'email_subscription_topics' => ['scholarships', 'news'],
                 'source' => 'phoenix-next',
                 'source_detail' => 'test_source_detail',
             ]);
-            
+
             $this->assertResponseStatus(201);
         }
 

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Carbon\Carbon;
 use Northstar\Models\User;
 
 class SubscriptionsTest extends BrowserKitTestCase
@@ -19,7 +18,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['scholarships'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(200);
@@ -29,7 +28,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['scholarships'],
             'source' => $user->source,
-            'source_detail' => $user->source_detail
+            'source_detail' => $user->source_detail,
         ]);
     }
 
@@ -47,7 +46,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['scholarships', 'lifestyle'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(200);
@@ -57,7 +56,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['scholarships', 'lifestyle'],
             'source' => $user->source,
-            'source_detail' => $user->source_detail
+            'source_detail' => $user->source_detail,
         ]);
     }
 
@@ -76,7 +75,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['news'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(200);
@@ -86,7 +85,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['news'],
             'source' => $user->source,
-            'source_detail' => $user->source_detail
+            'source_detail' => $user->source_detail,
         ]);
     }
 
@@ -105,7 +104,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['news', 'community'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(200);
@@ -115,7 +114,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => $user->email,
             'email_subscription_topics' => ['news', 'lifestyle', 'community'],
             'source' => $user->source,
-            'source_detail' => $user->source_detail
+            'source_detail' => $user->source_detail,
         ]);
     }
 
@@ -131,7 +130,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => 'topics@dosomething.org',
             'email_subscription_topics' => ['scholarships'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(201);
@@ -141,7 +140,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => 'topics@dosomething.org',
             'email_subscription_topics' => ['scholarships'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
     }
 
@@ -157,7 +156,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => 'topics@dosomething.org',
             'email_subscription_topics' => ['scholarships', 'news'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(201);
@@ -167,7 +166,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => 'topics@dosomething.org',
             'email_subscription_topics' => ['scholarships', 'news'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
     }
 
@@ -185,7 +184,7 @@ class SubscriptionsTest extends BrowserKitTestCase
                 'email' => 'topics' . $i . '@dosomething.org',
                 'email_subscription_topics' => ['scholarships', 'news'],
                 'source' => 'phoenix-next',
-                'source_detail' => 'test_source_detail'
+                'source_detail' => 'test_source_detail',
             ]);
             
             $this->assertResponseStatus(201);
@@ -196,7 +195,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => 'topics11@dosomething.org',
             'email_subscription_topics' => ['scholarships', 'news'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(429);
@@ -214,7 +213,7 @@ class SubscriptionsTest extends BrowserKitTestCase
             'email' => 'topics@dosomething.org',
             'email_subscription_topics' => ['scholarships'],
             'source' => 'phoenix-next',
-            'source_detail' => 'test_source_detail'
+            'source_detail' => 'test_source_detail',
         ]);
 
         $this->assertResponseStatus(201);


### PR DESCRIPTION
#### What's this PR do?
Creates the `/subscriptions` endpoint in Northstar!

- This endpoint is public, no auth
- Rate-limited to 10 requests per hour per IP
- Accepts: `email`, `email_subscription_topics`, `source`, `source_detail`
    - Tries to find a user with the `email` and if it does adds the given `email_subscription_topics`
    - If no user is found, creates a user with the given `email`, `email_subscription_topics`, `source`, `source_detail`
 
New users also receive an activate account email of type `pays-to-do-good-activate-account`. In order to send the account activation email, I had to steal the `createTokenRepository()` function from the `ResetController`. I considered extracting it out to a trait, but I find traits kind of hard to use because it can be tricky to find where the functions are defined. I also considered pull it out as a helper, but not sure it makes sense as a helper either? I'd love thoughts on this!

There are tests and docs added for this endpoint as well!

For use with Newsletter CTAs in Phoenix!

#### How should this be reviewed?
There is a question in the area above, but I think the tests should have us covered so make sure those get a good 👀 

#### Relevant Tickets
[Card](https://www.pivotaltracker.com/story/show/169330972)

#### Checklist
- [X] Documentation added for changed endpoints.
- [X] Tests added for new features/bug fixes.
