### PR TITLE
Unset 'last_name' from Customer.io profiles.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -514,6 +514,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'google_id' => $this->google_id,
             'first_name' => $this->first_name,
             'display_name' => $this->display_name,
+            'last_name' => null, // We want to unset this on Customer.io profiles.
             'birthdate' => optional($this->birthdate)->timestamp,
             'addr_city' => $this->addr_city,
             'addr_state' => $this->addr_state,

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -20,6 +20,7 @@ class UserModelTest extends BrowserKitTestCase
             'id' => $user->id,
             'first_name' => $user->first_name,
             'display_name' => $user->display_name,
+            'last_name' => null,
             'birthdate' => '631238400',
             'email' => $user->email,
             'mobile' => $user->mobile,


### PR DESCRIPTION
#### What's this PR do?
This pull request explicitly sets the `last_name` field to `null` on Customer.io, unsetting it if we'd previously sent it (before #933 was deployed). It turns out we can't zero out a field like we've done before, so we'll have to run a full backfill ourselves to remove this on existing profiles.

#### How should this be reviewed?
👀

#### Relevant Tickets
[#167596958](https://www.pivotaltracker.com/story/show/167596958)

#### Checklist

- [ ] Documentation added for new or changed endpoints.
- [ ] Tests added for new features/bug fixes/API updates.
- [ ] Post a message in #dev-northstar if this includes something that causes a rebuild!
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
- [ ] This PR has been added to the relevant Pivotal card.
