### PR TITLE
Social Auth Sixpack

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -190,7 +190,7 @@ class AuthController extends Controller
     public function postRegister(Request $request)
     {
         convert('social-auth-first');
-        
+    
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',
             'last_name' => 'required|max:50',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -177,6 +177,7 @@ class AuthController extends Controller
     public function getRegister()
     {
         $showSocialAuthFirst = participate('social-auth-first', ['normal_form', 'social_first_form']);
+
         return view('auth.register-beta', ['social_auth_first' => $showSocialAuthFirst]);
     }
 
@@ -190,7 +191,7 @@ class AuthController extends Controller
     public function postRegister(Request $request)
     {
         convert('social-auth-first');
-    
+
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',
             'last_name' => 'required|max:50',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -176,7 +176,8 @@ class AuthController extends Controller
      */
     public function getRegister()
     {
-        return view('auth.register-beta');
+        $showSocialAuthFirst = participate('social-auth-first', ['normal_form', 'social_first_form']);
+        return view('auth.register-beta', ['social_auth_first' => $showSocialAuthFirst]);
     }
 
     /**
@@ -188,6 +189,8 @@ class AuthController extends Controller
      */
     public function postRegister(Request $request)
     {
+        convert('social-auth-first');
+        
         $this->registrar->validate($request, null, [
             'first_name' => 'required|max:50',
             'last_name' => 'required|max:50',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -176,9 +176,9 @@ class AuthController extends Controller
      */
     public function getRegister()
     {
-        $showSocialAuthFirst = participate('social-auth-first', ['normal_form', 'social_first_form']);
+        $positionSocialAuth = participate('social-auth-position', ['position_bottom', 'position_top']);
 
-        return view('auth.register-beta', ['social_auth_first' => $showSocialAuthFirst]);
+        return view('auth.register-beta', ['social_auth_position' => $positionSocialAuth]);
     }
 
     /**

--- a/resources/assets/scss/_components/_facebook-login.scss
+++ b/resources/assets/scss/_components/_facebook-login.scss
@@ -11,7 +11,6 @@ $facebook-blue: #4267b2;
   background: $facebook-blue;
   border: 1px solid $facebook-blue;
   text-transform: none;
-  margin: $base-spacing / 2 0;
   
   &:hover, &:active, &:focus {
     background: darken($facebook-blue, 10%);

--- a/resources/assets/scss/_components/_google-login.scss
+++ b/resources/assets/scss/_components/_google-login.scss
@@ -13,7 +13,6 @@ $google-gray: #EEE;
   background: $google-blue;
   color: #FFF;
   text-transform: none;
-  margin: 12px 0;
 
   svg {
     display: inline-block;

--- a/resources/views/auth/register-beta.blade.php
+++ b/resources/views/auth/register-beta.blade.php
@@ -20,7 +20,7 @@
 
     @if ($social_auth_position === 'position_top')
         <div class="md:flex items-start">
-            <div class="md:w-1/2">
+            <div class="mb-4 md:m-0 md:w-1/2">
                 @include('auth.google')
             </div>
             <div class="md:w-1/2">
@@ -75,8 +75,8 @@
             <hr class="ml-2 mt-2 w-full border-gray-600 border-t-2 border-solid">
         </div>
 
-        <div class="md:flex ">
-            <div class="md:w-1/2">
+        <div class="md:flex">
+            <div class="mb-4 md:m-0 md:w-1/2">
                 @include('auth.google')
             </div>
             <div class="md:w-1/2">

--- a/resources/views/auth/register-beta.blade.php
+++ b/resources/views/auth/register-beta.blade.php
@@ -18,6 +18,22 @@
         @include('forms.errors', ['errors' => $errors])
     @endif
 
+    @if ($social_auth_first === 'social_first_form')
+        <div class="md:flex ">
+            <div class="md:w-1/2">
+                @include('auth.google')
+            </div>
+            <div class="md:w-1/2">
+                @include('auth.facebook')
+            </div>
+        </div>
+
+        <div class="my-6 flex">
+            <p class="ml-2 footnote">or</p>
+            <hr class="ml-2 mt-2 w-full border-gray-600 border-t-2 border-solid">
+        </div>
+    @endif
+
     <form id="profile-register-form" method="POST" action="{{ url('register')}}">
         {{ csrf_field() }}
 
@@ -53,19 +69,21 @@
         </div>
     </form>
 
-    <div class="my-6 flex">
-        <p class="ml-2 footnote">or</p>
-        <hr class="ml-2 mt-2 w-full border-gray-600 border-t-2 border-solid">
-    </div>
+    @if ($social_auth_first === 'normal_form')
+        <div class="my-6 flex">
+            <p class="ml-2 footnote">or</p>
+            <hr class="ml-2 mt-2 w-full border-gray-600 border-t-2 border-solid">
+        </div>
 
-    <div class="md:flex ">
-        <div class="md:w-1/2">
-            @include('auth.google')
+        <div class="md:flex ">
+            <div class="md:w-1/2">
+                @include('auth.google')
+            </div>
+            <div class="md:w-1/2">
+                @include('auth.facebook')
+            </div>
         </div>
-        <div class="md:w-1/2">
-            @include('auth.facebook')
-        </div>
-    </div>
+    @endif
 
     <p class="text-gray-500 mt-5">
         Already have an account? <a class="login-link" href="{{ url('login') }}" data-target="link">Log In</a>

--- a/resources/views/auth/register-beta.blade.php
+++ b/resources/views/auth/register-beta.blade.php
@@ -18,8 +18,8 @@
         @include('forms.errors', ['errors' => $errors])
     @endif
 
-    @if ($social_auth_first === 'social_first_form')
-        <div class="md:flex ">
+    @if ($social_auth_position === 'position_top')
+        <div class="md:flex items-start">
             <div class="md:w-1/2">
                 @include('auth.google')
             </div>
@@ -69,7 +69,7 @@
         </div>
     </form>
 
-    @if ($social_auth_first === 'normal_form')
+    @if ($social_auth_position === 'position_bottom')
         <div class="my-6 flex">
             <p class="ml-2 footnote">or</p>
             <hr class="ml-2 mt-2 w-full border-gray-600 border-t-2 border-solid">


### PR DESCRIPTION
### What's this PR do?

This pull request adds the sixpack experiment for where to place our social auth buttons to the registration page. 

### How should this be reviewed?

Does the naming make sense for the experiment? And is there anything glaringly missing that would effect the test running properly

### Any background context you want to provide?

Following along on the basic structure of past NS sixpack tests.

Normal Form View - `?sixpack-force-social-auth-first=normal_form`
![Screen Shot 2020-01-28 at 12 25 51 PM](https://user-images.githubusercontent.com/15236023/73288659-63fd5480-41c9-11ea-8437-465d5e1f5937.png)

![Screen Shot 2020-01-28 at 12 25 43 PM](https://user-images.githubusercontent.com/15236023/73288668-68c20880-41c9-11ea-82ec-6d27eec79651.png)

Experiment View - `?sixpack-force-social-auth-first=social_first_form`
![Screen Shot 2020-01-28 at 12 25 14 PM](https://user-images.githubusercontent.com/15236023/73288681-6eb7e980-41c9-11ea-9436-b1cda0a4a252.png)

![Screen Shot 2020-01-28 at 12 25 28 PM](https://user-images.githubusercontent.com/15236023/73288690-71b2da00-41c9-11ea-949b-3ee520d49c8f.png)


### Relevant tickets

References [Pivotal #170666913](https://www.pivotaltracker.com/story/show/170666913).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
