### PR TITLE
Include source_detail session params for FB/Google registrations

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -217,9 +217,15 @@ class Registrar
 
         $user->fill($input);
 
-        // The user's source_detail is often set via this customizer parameter.
         if (! is_null($customizer)) {
             $customizer($user);
+        }
+
+        // Set source_detail to the session source_detail if we haven't set one yet.
+        $sourceDetail = session('source_detail');
+
+        if ($sourceDetail && ! isset($user->source_detail)) {
+            $user->source_detail = stringify_object($sourceDetail);
         }
 
         // Set the user's country code by Fastly geo-location header.

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -208,26 +208,26 @@ class Registrar
      * Create a new user via web.
      *
      * @param array $input - Profile fields
-     * @param Closure $customizer - Customize the user instance before saving.
+     * @param string $authSource - Source of authentication
      * @return User|null
      */
-    public function registerViaWeb($input, Closure $customizer = null)
+    public function registerViaWeb($input, $authSource = null)
     {
         $user = new User;
 
         $user->fill($input);
 
-        if (! is_null($customizer)) {
-            $customizer($user);
+        $sourceDetail = [];
+
+        if ($authSource) {
+            $sourceDetail['auth_source'] = $authSource;
         }
 
-        // Set source_detail to the session source_detail if we haven't set one yet.
-        $sourceDetail = session('source_detail');
-
-        if ($sourceDetail && ! isset($user->source_detail)) {
-            $user->source_detail = stringify_object($sourceDetail);
+        if (session('source_detail')) {
+            $sourceDetail = array_merge(session('source_detail'), $sourceDetail);
         }
 
+        $user->setSource(null, $sourceDetail ? stringify_object($sourceDetail) : null);
         // Set the user's country code by Fastly geo-location header.
         $user->country = country_code();
         // Set language based on locale (either 'en', 'es-mx').

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -199,13 +199,7 @@ class AuthController extends Controller
 
         // Register and login the user.
         $editableFields = $request->except(User::$internal);
-        $user = $this->registrar->registerViaWeb($editableFields, function ($user) {
-            // Set source_detail, if applicable.
-            $sourceDetail = session('source_detail');
-            if ($sourceDetail) {
-                $user->source_detail = stringify_object($sourceDetail);
-            }
-        });
+        $user = $this->registrar->registerViaWeb($editableFields);
 
         convert('social-auth-position');
 

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -96,9 +96,7 @@ class FacebookController extends Controller
         } else {
             $fields['email'] = $email;
 
-            $northstarUser = $this->registrar->registerViaWeb($fields, function (User $user) {
-                $user->setSource(null, 'facebook');
-            });
+            $northstarUser = $this->registrar->registerViaWeb($fields, 'facebook');
 
             convert('social-auth-position');
 

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -125,9 +125,7 @@ class GoogleController extends Controller
         } else {
             $fields['email'] = $email;
 
-            $northstarUser = $this->registrar->registerViaWeb($fields, function (User $user) {
-                $user->setSource(null, 'google');
-            });
+            $northstarUser = $this->registrar->registerViaWeb($fields, 'google');
 
             convert('social-auth-position');
 

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -96,10 +96,17 @@ class FacebookTest extends BrowserKitTestCase
     public function testFacebookVerify()
     {
         $this->defaultMock();
+
         // Turn on the badges and refer-friends-scholarship test feature flags.
         config([
             'features.badges' => true,
             'features.refer-friends-scholarship' => true,
+        ]);
+        // Set session UTM parameters.
+        session([
+            'source_detail' => [
+                'utm_source' => 'phpunit',
+            ],
         ]);
 
         $this->visit('/facebook/verify')->seePageIs('/profile/about');
@@ -108,7 +115,7 @@ class FacebookTest extends BrowserKitTestCase
         $user = auth()->user();
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
-        $this->assertEquals($user->source_detail, 'auth_source:facebook');
+        $this->assertEquals($user->source_detail, 'utm_source:phpunit,auth_source:facebook');
         $this->assertEquals($user->country_code, country_code());
         $this->assertEquals($user->language, app()->getLocale());
         $this->assertEquals($user->email_subscription_status, true);

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -108,7 +108,7 @@ class FacebookTest extends BrowserKitTestCase
         $user = auth()->user();
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
-        $this->assertEquals($user->source_detail, 'facebook');
+        $this->assertEquals($user->source_detail, 'auth_source:facebook');
         $this->assertEquals($user->country_code, country_code());
         $this->assertEquals($user->language, app()->getLocale());
         $this->assertEquals($user->email_subscription_status, true);

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -125,14 +125,15 @@ class GoogleTest extends BrowserKitTestCase
             'features.badges' => true,
             'features.refer-friends-scholarship' => true,
         ]);
-
+        // @TODO: Test 
+        // $this->visit('/authorize?options=%7B%22utm_source%22%3A%22phpunit%22%7D');
         $this->visit('/google/verify')->seePageIs('/profile/about');
         $this->seeIsAuthenticated('web');
 
         $user = auth()->user();
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
-        $this->assertEquals($user->source_detail, 'google');
+        $this->assertEquals($user->source_detail, 'auth_source:google');
         $this->assertEquals($user->country_code, country_code());
         $this->assertEquals($user->language, app()->getLocale());
         $this->assertEquals($user->email_subscription_status, true);

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -120,20 +120,27 @@ class GoogleTest extends BrowserKitTestCase
     public function testGoogleVerify()
     {
         $this->defaultMock();
+
         // Turn on the badges and refer-friends-scholarship test feature flags.
         config([
             'features.badges' => true,
             'features.refer-friends-scholarship' => true,
         ]);
-        // @TODO: Test 
-        // $this->visit('/authorize?options=%7B%22utm_source%22%3A%22phpunit%22%7D');
+
+        // Set session UTM parameters.
+        session([
+            'source_detail' => [
+                'utm_source' => 'phpunit',
+            ],
+        ]);
+
         $this->visit('/google/verify')->seePageIs('/profile/about');
         $this->seeIsAuthenticated('web');
 
         $user = auth()->user();
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
-        $this->assertEquals($user->source_detail, 'auth_source:google');
+        $this->assertEquals($user->source_detail, 'utm_source:phpunit,auth_source:google');
         $this->assertEquals($user->country_code, country_code());
         $this->assertEquals($user->language, app()->getLocale());
         $this->assertEquals($user->email_subscription_status, true);


### PR DESCRIPTION
### What's this PR do?

This pull request moves the check for a session `source_detail` into the  `registerViaWeb` method , which has been refactored to accept an optional `auth_source` property via the Facebook and Google controllers.  This keeps the `source_detail` of users who authenticate via FB or Google to be consistent with users who register via the Northstar registration form (a stringified object with optional UTM, Contentful, Referrer params) .

### How should this be reviewed?

👀 

### Any background context you want to provide?

ℹ️ 

### Relevant tickets

References [Pivotal #169213761](https://www.pivotaltracker.com/n/projects/2401401/stories/169213761/).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, then the data team already knows about these changes.
