### PR TITLE
Set email subscription status to true if adding topics

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -199,6 +199,16 @@ class Registrar
             $customizer($user);
         }
 
+        /**
+         * If any email subscription topics exist, ensure that email subscription status is true.
+         *
+         * Note: We're explicitly not yet checking for inverse of unsubscribing when topics is empty.
+         * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
+         */
+        if (isset($user->email_subscription_topics) && count($user->email_subscription_topics) && ! $user->email_subscription_status) {
+            $user->email_subscription_status = true;
+        }
+
         $user->save();
 
         return $user;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -202,7 +202,7 @@ class Registrar
         /**
          * If any email subscription topics exist, ensure that email subscription status is true.
          *
-         * Note: We're explicitly not yet checking for inverse of unsubscribing when topics is empty.
+         * Note: We're intentionally not checking for inverse of unsubscribing if topics is empty,
          * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
          */
         if (isset($user->email_subscription_topics) && count($user->email_subscription_topics) && ! $user->email_subscription_status) {

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -199,16 +199,6 @@ class Registrar
             $customizer($user);
         }
 
-        /**
-         * If any email subscription topics exist, ensure that email subscription status is true.
-         *
-         * Note: We're intentionally not checking for inverse of unsubscribing if topics is empty,
-         * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
-         */
-        if (isset($user->email_subscription_topics) && count($user->email_subscription_topics) && ! $user->email_subscription_status) {
-            $user->email_subscription_status = true;
-        }
-
         $user->save();
 
         return $user;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -226,9 +226,8 @@ class Registrar
         $user->country = country_code();
         // Set language based on locale (either 'en', 'es-mx').
         $user->language = app()->getLocale();
-        // Sign the user up for email messaging & give them the "community" topic.
-        $user->email_subscription_status = true;
-        $user->email_subscription_topics = ['community'];
+        // Subscribe user to the community email topic.
+        $user->addEmailSubscriptionTopic('community');
 
         // Exclude any 'clubs' referrals from our feature flag tests.
         if (! str_contains($user->source_detail, 'utm_source:clubs')) {

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -66,8 +66,7 @@ class SubscriptionController extends Controller
 
         $newUser = $this->registrar->register($request->all());
 
-        $newUser->email_subscription_topics = [$topic];
-        $newUser->email_subscription_status = true;
+        $newUser->addEmailSubscriptionTopic($topic);
         $newUser->source = $request->get('source');
         $newUser->source_detail = $request->get('source_detail');
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -15,6 +15,11 @@ class UserObserver
      */
     public function creating(User $user)
     {
+        // Subscribe user to email if topics have been provided.
+        if (isset($user->email_subscription_topics) && count($user->email_subscription_topics)) {
+            $user->email_subscription_status = true;
+        }
+
         // Set source automatically if not provided.
         $user->source = $user->source ?: client_id();
     }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -45,6 +45,16 @@ class UserObserver
      */
     public function updating(User $user)
     {
+        /**
+         * If any email subscription topics exist, ensure that email subscription status is true.
+         *
+         * Note: We're intentionally not checking for inverse of unsubscribing if topics is empty,
+         * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
+         */
+        if (isset($user->email_subscription_topics) && count($user->email_subscription_topics) && ! $user->email_subscription_status) {
+            $user->email_subscription_status = true;
+        }
+
         // Write profile changes to the log, with redacted values for hidden fields.
         $changed = $user->getChanged();
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -44,22 +44,25 @@ class UserObserver
      * @return void
      */
     public function updating(User $user)
-    {
+    {        
+        $changed = $user->getDirty();
+
+        // If we're unsubscribing from email, clear all topics.
+        if (isset($changed['email_subscription_status']) && ! $changed['email_subscription_status']) {
+            $user->email_subscription_topics = [];
         /**
-         * If any email subscription topics exist, ensure that email subscription status is true.
+         * Else if we are updating topics with at least item, ensure email subscription status is true.
          *
          * Note: We're intentionally not checking for inverse of unsubscribing if topics is empty,
          * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
          */
-        if (isset($user->email_subscription_topics) && count($user->email_subscription_topics) && ! $user->email_subscription_status) {
+        } elseif (isset($changed['email_subscription_topics']) && count($changed['email_subscription_topics']) && ! $user->email_subscription_status) {
             $user->email_subscription_status = true;
         }
 
         // Write profile changes to the log, with redacted values for hidden fields.
-        $changed = $user->getChanged();
-
         if (! app()->runningInConsole()) {
-            logger('updated user', ['id' => $user->id, 'changed' => $changed]);
+            logger('updated user', ['id' => $user->id, 'changed' => $user->getChanged()]);
         }
     }
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -56,9 +56,9 @@ class UserObserver
         if (isset($changed['email_subscription_status']) && ! $changed['email_subscription_status']) {
             $user->email_subscription_topics = [];
         /**
-         * Else if we are updating topics with at least item, ensure email subscription status is true.
+         * Else if we are updating topics, ensure email subscription status is true.
          *
-         * Note: We're intentionally not checking for inverse of unsubscribing if topics is empty,
+         * Note: We intentionally do not auto-unsubscribe if we're updating topics with an empty array.
          * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
          */
         } elseif (isset($changed['email_subscription_topics']) && count($changed['email_subscription_topics']) && ! $user->email_subscription_status) {

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -44,7 +44,7 @@ class UserObserver
      * @return void
      */
     public function updating(User $user)
-    {        
+    {
         $changed = $user->getDirty();
 
         // If we're unsubscribing from email, clear all topics.

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -29,9 +29,20 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'language' => $faker->languageCode,
         'source' => 'factory',
         'school_id' => '12500012',
+        'causes' => $faker->randomElements(['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'], $faker->numberBetween(0, 6)),
+    ];
+});
+
+$factory->state(Northstar\Models\User::class, 'email-subscribed', function (Faker\Generator $faker) {
+    return [
         'email_subscription_status' => true,
         'email_subscription_topics' => $faker->randomElements(['news', 'lifestyle', 'actions', 'scholarships'], $faker->numberBetween(1, 4)),
-        'causes' => $faker->randomElements(['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'], $faker->numberBetween(0, 6)),
+    ];
+});
+
+$factory->state(Northstar\Models\User::class, 'email-unsubscribed', function (Faker\Generator $faker) {
+    return [
+        'email_subscription_status' => false,
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -30,6 +30,8 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'source' => 'factory',
         'school_id' => '12500012',
         'causes' => $faker->randomElements(['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'], $faker->numberBetween(0, 6)),
+        // Make email subscripion null by default, as it won't be set for all users (e.g. source SMS)
+        'email_subscription_status' => null,
     ];
 });
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -29,7 +29,8 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'language' => $faker->languageCode,
         'source' => 'factory',
         'school_id' => '12500012',
-        'email_subscription_topics' => $faker->randomElements(['news', 'lifestyle', 'actions', 'scholarships'], $faker->numberBetween(0, 4)),
+        'email_subscription_status' => true,
+        'email_subscription_topics' => $faker->randomElements(['news', 'lifestyle', 'actions', 'scholarships'], $faker->numberBetween(1, 4)),
         'causes' => $faker->randomElements(['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'], $faker->numberBetween(0, 6)),
     ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -30,7 +30,10 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'source' => 'factory',
         'school_id' => '12500012',
         'causes' => $faker->randomElements(['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'], $faker->numberBetween(0, 6)),
-        // Make email subscripion null by default, as it won't be set for all users (e.g. source SMS)
+        /**
+         * Set email subscription status to null by default, as it won't be set for all users.
+         * e.g. when source is 'sms'
+         */
         'email_subscription_status' => null,
     ];
 });

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -477,3 +477,10 @@ curl -X DELETE \
 ```
 
 </details>
+
+## Notes
+
+* Northstar will automatically set the  `email_subscription_status` field to `true` if a user is created or updated with one or more `email_subscription_topics`.
+
+* Northstar will automatically set the  `email_subscription_topics` field to an empty array if a user is updated with a  `email_subscription_status` value of `false`.
+

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -26,6 +26,7 @@ class SubscriptionsTest extends BrowserKitTestCase
         // The email_subscription_topics should be added, but the source and source_detail should not change
         $this->seeInDatabase('users', [
             'email' => $user->email,
+            'email_subscription_status' => true,
             'email_subscription_topics' => ['scholarships'],
             'source' => $user->source,
             'source_detail' => $user->source_detail,
@@ -81,6 +82,7 @@ class SubscriptionsTest extends BrowserKitTestCase
         // The user should be created with the given email_subscription_topics, source, and source_detail
         $this->seeInDatabase('users', [
             'email' => 'topics@dosomething.org',
+            'email_subscription_status' => true,
             'email_subscription_topics' => ['scholarships'],
             'source' => 'phoenix-next',
             'source_detail' => 'test_source_detail',

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -863,4 +863,24 @@ class UserTest extends BrowserKitTestCase
             'email_subscription_topics' => ['news'],
         ]);
     }
+
+    /**
+     * Test that user email_subcription_status is set to true if adding email_subscription_topics.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateEmailSubscriptionStatusWhenAddingTopics()
+    {
+        $nullStatusUser = factory(User::class)->create();
+
+        $this->asUser($nullStatusUser, ['user', 'write'])->json('PUT', 'v2/users/'.$nullStatusUser->id, [
+            'email_subscription_topics' => ['news'],
+        ]);
+
+        $this->seeInDatabase('users', [
+            '_id' => $nullStatusUser->id,
+            'email_subscription_status' => true,
+        ]);
+    }
 }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -865,7 +865,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subscription_status is set to true if email_subscription_topics is null.
+     * Test that email subscription status is true after adding topics to user with null status.
      * PUT /v2/users/:id
      *
      * @return void
@@ -885,7 +885,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subscription_status is set to true if email_subscription_topics is null.
+     * Test that email subscription status is true after adding topics to user with false status.
      * PUT /v2/users/:id
      *
      * @return void
@@ -905,7 +905,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subscription_status remains true if unsetting email_subscription_topics.
+     * Test that email subscription status remains true after unsetting topics.
      * PUT /v2/users/:id
      *
      * @return void
@@ -925,7 +925,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subscription_topics are cleared if setting email_subscription_status false.
+     * Test that user email subscription topics are cleared after setting email subscription status to false.
      * PUT /v2/users/:id
      *
      * @return void

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -865,7 +865,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subcription_status is set to true if email_subscription_topics is null.
+     * Test that user email_subscription_status is set to true if email_subscription_topics is null.
      * PUT /v2/users/:id
      *
      * @return void
@@ -885,7 +885,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subcription_status is set to true if email_subscription_topics is null.
+     * Test that user email_subscription_status is set to true if email_subscription_topics is null.
      * PUT /v2/users/:id
      *
      * @return void
@@ -905,7 +905,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subcription_status remains true if unsetting email_subscription_topics.
+     * Test that user email_subscription_status remains true if unsetting email_subscription_topics.
      * PUT /v2/users/:id
      *
      * @return void
@@ -921,6 +921,27 @@ class UserTest extends BrowserKitTestCase
         $this->seeInDatabase('users', [
             '_id' => $subscribedUser->id,
             'email_subscription_status' => true,
+        ]);
+    }
+
+    /**
+     * Test that user email_subscription_topics are cleared if setting email_subscription_status false.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testEmailSubscriptionTopicsAreClearedWhenUnsubscribing()
+    {
+        $subscribedUser = factory(User::class)->states('email-subscribed')->create();
+
+        $this->asUser($subscribedUser, ['user', 'write'])->json('PUT', 'v2/users/'.$subscribedUser->id, [
+            'email_subscription_status' => false,
+        ]);
+
+        $this->seeInDatabase('users', [
+            '_id' => $subscribedUser->id,
+            'email_subscription_status' => false,
+            'email_subscription_topics' => null,
         ]);
     }
 }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -865,16 +865,14 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that user email_subcription_status is set to true if adding email_subscription_topics.
+     * Test that user email_subcription_status is set to true if email_subscription_topics is null.
      * PUT /v2/users/:id
      *
      * @return void
      */
-    public function testEmailSubscriptionStatusWhenAddingTopics()
+    public function testNullEmailSubscriptionStatusChangesWhenAddingTopics()
     {
-        $nullStatusUser = factory(User::class)->create([
-            'email_subscription_topics' => null,
-        ]);
+        $nullStatusUser = factory(User::class)->create();
 
         $this->asUser($nullStatusUser, ['user', 'write'])->json('PUT', 'v2/users/'.$nullStatusUser->id, [
             'email_subscription_topics' => ['news'],
@@ -884,10 +882,17 @@ class UserTest extends BrowserKitTestCase
             '_id' => $nullStatusUser->id,
             'email_subscription_status' => true,
         ]);
+    }
 
-        $unsubscribeStatusUser = factory(User::class)->create([
-            'email_subscription_topics' => false,
-        ]);
+    /**
+     * Test that user email_subcription_status is set to true if email_subscription_topics is null.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testFalseEmailSubscriptionStatusChangesWhenAddingTopics()
+    {
+        $unsubscribeStatusUser = factory(User::class)->states('email-unsubscribed')->create();
 
         $this->asUser($unsubscribeStatusUser, ['user', 'write'])->json('PUT', 'v2/users/'.$unsubscribeStatusUser->id, [
             'email_subscription_topics' => ['news'],
@@ -905,10 +910,9 @@ class UserTest extends BrowserKitTestCase
      *
      * @return void
      */
-    public function testEmailSubscriptionStatusWhenClearingTopics()
+    public function testEmailSubscriptionStatusRemainsTrueWhenClearingTopics()
     {
-        // Our user factory creates an email subscriber with topic(s) by default.
-        $subscribedUser = factory(User::class)->create();
+        $subscribedUser = factory(User::class)->states('email-subscribed')->create();
 
         $this->asUser($subscribedUser, ['user', 'write'])->json('PUT', 'v2/users/'.$subscribedUser->id, [
             'email_subscription_topics' => null,

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -892,14 +892,14 @@ class UserTest extends BrowserKitTestCase
      */
     public function testFalseEmailSubscriptionStatusChangesWhenAddingTopics()
     {
-        $unsubscribeStatusUser = factory(User::class)->states('email-unsubscribed')->create();
+        $unsubscribedUser = factory(User::class)->states('email-unsubscribed')->create();
 
-        $this->asUser($unsubscribeStatusUser, ['user', 'write'])->json('PUT', 'v2/users/'.$unsubscribeStatusUser->id, [
+        $this->asUser($unsubscribedUser, ['user', 'write'])->json('PUT', 'v2/users/'.$unsubscribedUser->id, [
             'email_subscription_topics' => ['news'],
         ]);
 
         $this->seeInDatabase('users', [
-            '_id' => $unsubscribeStatusUser->id,
+            '_id' => $unsubscribedUser->id,
             'email_subscription_status' => true,
         ]);
     }

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -907,7 +907,7 @@ class UserTest extends BrowserKitTestCase
      */
     public function testEmailSubscriptionStatusWhenClearingTopics()
     {
-        // Our user factory creates an email subscriber with topic(s) by default. 
+        // Our user factory creates an email subscriber with topic(s) by default.
         $subscribedUser = factory(User::class)->create();
 
         $this->asUser($subscribedUser, ['user', 'write'])->json('PUT', 'v2/users/'.$subscribedUser->id, [

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -870,7 +870,7 @@ class UserTest extends BrowserKitTestCase
      *
      * @return void
      */
-    public function testV2UpdateEmailSubscriptionStatusWhenAddingTopics()
+    public function testEmailSubscriptionStatusWhenAddingTopics()
     {
         $nullStatusUser = factory(User::class)->create();
 
@@ -880,6 +880,29 @@ class UserTest extends BrowserKitTestCase
 
         $this->seeInDatabase('users', [
             '_id' => $nullStatusUser->id,
+            'email_subscription_status' => true,
+        ]);
+    }
+
+    /**
+     * Test that user email_subcription_status remains true if clearing email_subscription_topics.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testEmailSubscriptionStatusWhenClearingTopics()
+    {
+        $subscribedUser = factory(User::class)->create([
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['news'],
+        ]);
+
+        $this->asUser($subscribedUser, ['user', 'write'])->json('PUT', 'v2/users/'.$subscribedUser->id, [
+            'email_subscription_topics' => null,
+        ]);
+
+        $this->seeInDatabase('users', [
+            '_id' => $subscribedUser->id,
             'email_subscription_status' => true,
         ]);
     }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -110,9 +110,7 @@ class UserModelTest extends BrowserKitTestCase
     /** @test */
     public function it_should_include_unsubscribed_false_in_customerio_payload_if_email_subscription_status_true()
     {
-        $subscribedStatusUser = factory(User::class)->create([
-            'email_subscription_status' => true,
-        ]);
+        $subscribedStatusUser = factory(User::class)->states('email-subscribed')->create();
         $result = $subscribedStatusUser->toCustomerIoPayload();
 
         $this->assertTrue($result['email_subscription_status']);
@@ -122,9 +120,7 @@ class UserModelTest extends BrowserKitTestCase
     /** @test */
     public function it_should_include_unsubscribed_true_in_customerio_payload_if_email_subscription_status_false()
     {
-        $unsubscribedStatusUser = factory(User::class)->create([
-            'email_subscription_status' => false,
-        ]);
+        $unsubscribedStatusUser = factory(User::class)->states('email-unsubscribed')->create();
         $result = $unsubscribedStatusUser->toCustomerIoPayload();
 
         $this->assertFalse($result['email_subscription_status']);


### PR DESCRIPTION
### What's this PR do?

This pull request ensures that if a user is created or updated via API request and has any `email_subscription_topics` array items, their `email_subscription_status` is set as `true`.

### How should this be reviewed?

- 👀 
- Could also pull this branch down and test expected updates via Aurora or API requests

### Any background context you want to provide?

`app/Auth/Registar` seemed like an appropriate place to add the check, especially since we're explicitly setting these fields below in the `registerViaWeb` method. The tests felt a little more home in the User HTTP test vs the Auth Registar test though... but the logic didn't feel like it'd make sense to add only into an API controller (wasn't sure about a post-save type of check in the Model, like [Mongoose middleware](https://mongoosejs.com/docs/middleware.html#pre)).

### Relevant tickets

References [Pivotal #170599403](https://www.pivotaltracker.com/n/projects/2401401/stories/170599403).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
