### PR TITLE
Split 'northstar:delete' into two commands for self-serve deletion flow.

### DIFF
--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -44,8 +44,7 @@ class DeleteUsersCommand extends Command
                 continue;
             }
 
-            $user->deletion_requested_at = now();
-            $user->save();
+            $user->requestDeletion();
         }
 
         info('Done!');

--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -5,8 +5,6 @@ namespace Northstar\Console\Commands;
 use League\Csv\Reader;
 use Northstar\Models\User;
 use Illuminate\Console\Command;
-use Northstar\Services\CustomerIo;
-use Northstar\Models\RefreshToken;
 
 class DeleteUsersCommand extends Command
 {
@@ -22,20 +20,20 @@ class DeleteUsersCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Delete (anonymize) users, given a CSV of IDs.';
+    protected $description = 'Queue users for deletion, given a CSV of IDs.';
 
     /**
      * Execute the console command.
      *
      * @return mixed
      */
-    public function handle(CustomerIo $customerIo)
+    public function handle()
     {
         $input = file_get_contents($this->argument('input'));
         $csv = Reader::createFromString($input);
         $csv->setHeaderOffset(0);
 
-        info('Anonymizing '.count($csv).' users...');
+        info('Queueing '.count($csv).' users for deletion...');
 
         foreach ($csv->getRecords() as $record) {
             $id = $record[$this->option('id_column')];
@@ -46,33 +44,8 @@ class DeleteUsersCommand extends Command
                 continue;
             }
 
-            // Anonymize birthdate so we can see demographics of deleted users:
-            if ($user->birthdate) {
-                $user->birthdate = $user->birthdate->year.'-01-01';
-            }
-
-            // Remove all fields except some non-identifiable demographics:
-            $fields = array_keys(array_except($user->getAttributes(), [
-                '_id', 'birthdate', 'language', 'source', 'source_detail',
-                'addr_city', 'addr_state', 'addr_zip', 'country',
-                'created_at', 'updated_at',
-            ]));
-
-            if ($fields) {
-                $user->drop($fields);
-            }
-
-            // Set a flag so we know this user was deleted:
-            $user->deleted_at = now();
-            $user->saveQuietly();
-
-            // Delete refresh tokens to end any active sessions:
-            $token = RefreshToken::where('user_id', $user->id)->delete();
-
-            // And finally, delete the user's profile in Customer.io:
-            $customerIo->deleteUser($user);
-
-            info('Deleted: '.$user->id);
+            $user->deletion_requested_at = now();
+            $user->save();
         }
 
         info('Done!');

--- a/app/Console/Commands/ProcessDeletionsCommand.php
+++ b/app/Console/Commands/ProcessDeletionsCommand.php
@@ -6,8 +6,6 @@ use Carbon\Carbon;
 use Northstar\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Northstar\Services\CustomerIo;
-use Northstar\Models\RefreshToken;
 
 class ProcessDeletionsCommand extends Command
 {
@@ -30,7 +28,7 @@ class ProcessDeletionsCommand extends Command
      *
      * @return mixed
      */
-    public function handle(CustomerIo $customerIo)
+    public function handle()
     {
         $offset = $this->option('offset');
 
@@ -38,36 +36,9 @@ class ProcessDeletionsCommand extends Command
 
         info('Anonymizing '.$query->count().' users...');
 
-        $query->chunkById(200, function (Collection $users) use ($customerIo) {
-            $users->each(function (User $user) use ($customerIo) {
-                // Anonymize birthdate so we can see demographics of deleted users:
-                if ($user->birthdate) {
-                    $user->birthdate = $user->birthdate->year.'-01-01';
-                }
-
-                // Remove all fields except some non-identifiable demographics:
-                $fields = array_keys(array_except($user->getAttributes(), [
-                    '_id', 'birthdate', 'language', 'source', 'source_detail',
-                    'addr_city', 'addr_state', 'addr_zip', 'country',
-                    'created_at', 'updated_at',
-                ]));
-
-                if ($fields) {
-                    $user->drop($fields);
-                }
-
-                // Set a flag so we know this user was deleted:
-                // TODO: This should be done via the soft deletion trait!
-                $user->deleted_at = now();
-                $user->saveQuietly();
-
-                // Delete refresh tokens to end any active sessions:
-                $token = RefreshToken::where('user_id', $user->id)->delete();
-
-                // And finally, delete the user's profile in Customer.io:
-                $customerIo->deleteUser($user);
-
-                info('Deleted: '.$user->id);
+        $query->chunkById(200, function (Collection $users) {
+            $users->each(function (User $user) {
+                $user->delete();
             });
         });
 

--- a/app/Console/Commands/ProcessDeletionsCommand.php
+++ b/app/Console/Commands/ProcessDeletionsCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Northstar\Services\CustomerIo;
+use Northstar\Models\RefreshToken;
+
+class ProcessDeletionsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:process-deletions {--offset=14 days}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Process users that have been queued for deletion.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(CustomerIo $customerIo)
+    {
+        $offset = $this->option('offset');
+
+        $query = User::where('deletion_requested_at', '<', new Carbon($offset.'ago'));
+
+        info('Anonymizing '.$query->count().' users...');
+
+        $query->chunkById(200, function (Collection $users) use ($customerIo) {
+            $users->each(function (User $user) use ($customerIo) {
+                // Anonymize birthdate so we can see demographics of deleted users:
+                if ($user->birthdate) {
+                    $user->birthdate = $user->birthdate->year.'-01-01';
+                }
+
+                // Remove all fields except some non-identifiable demographics:
+                $fields = array_keys(array_except($user->getAttributes(), [
+                    '_id', 'birthdate', 'language', 'source', 'source_detail',
+                    'addr_city', 'addr_state', 'addr_zip', 'country',
+                    'created_at', 'updated_at',
+                ]));
+
+                if ($fields) {
+                    $user->drop($fields);
+                }
+
+                // Set a flag so we know this user was deleted:
+                // TODO: This should be done via the soft deletion trait!
+                $user->deleted_at = now();
+                $user->saveQuietly();
+
+                // Delete refresh tokens to end any active sessions:
+                $token = RefreshToken::where('user_id', $user->id)->delete();
+
+                // And finally, delete the user's profile in Customer.io:
+                $customerIo->deleteUser($user);
+
+                info('Deleted: '.$user->id);
+            });
+        });
+
+        info('Done!');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -184,6 +184,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     protected $dates = [
         'birthdate',
+        'deletion_requested_at',
         'last_accessed_at',
         'last_authenticated_at',
         'last_messaged_at',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use Northstar\PasswordResetType;
 use Illuminate\Auth\Authenticatable;
 use libphonenumber\PhoneNumberFormat;
 use Illuminate\Notifications\Notifiable;
+use Jenssegers\Mongodb\Eloquent\SoftDeletes;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Northstar\Jobs\SendPasswordResetToCustomerIo;
 use Illuminate\Foundation\Auth\Access\Authorizable;
@@ -81,7 +82,7 @@ use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
  */
 class User extends Model implements AuthenticatableContract, AuthorizableContract, ResetPasswordContract
 {
-    use Authenticatable, Authorizable, Notifiable, CanResetPassword;
+    use Authenticatable, Authorizable, CanResetPassword, Notifiable, SoftDeletes;
 
     /**
      * Should changes to this model's attributes be stored
@@ -729,5 +730,16 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         }
 
         return substr($schoolId, 0, 3).'XXXXX';
+    }
+
+    /**
+     * Mark this account for deletion.
+     *
+     * @return void
+     */
+    public function requestDeletion(): void
+    {
+        $this->deletion_requested_at = now();
+        $this->save();
     }
 }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -3,6 +3,8 @@
 namespace Northstar\Observers;
 
 use Northstar\Models\User;
+use Northstar\Models\RefreshToken;
+use Northstar\Services\CustomerIo;
 use Northstar\Jobs\SendUserToCustomerIo;
 
 class UserObserver
@@ -65,5 +67,38 @@ class UserObserver
         $queueLevel = config('queue.jobs.users');
         $queue = config('queue.names.'.$queueLevel);
         SendUserToCustomerIo::dispatch($user)->onQueue($queue);
+    }
+
+    /**
+     * Handle the User "deleting" event.
+     *
+     * @param  \Northstar\Models\User  $user
+     * @return void
+     */
+    public function deleting(User $user)
+    {
+        // Anonymize birthdate so we can see demographics of deleted users:
+        if ($user->birthdate) {
+            $user->update(['birthdate' => $user->birthdate->year.'-01-01']);
+        }
+
+        // Remove all fields except some non-identifiable demographics:
+        $fields = array_keys(array_except($user->getAttributes(), [
+            '_id', 'birthdate', 'language', 'source', 'source_detail',
+            'addr_city', 'addr_state', 'addr_zip', 'country',
+            'created_at', 'updated_at',
+        ]));
+
+        if ($fields) {
+            $user->drop($fields);
+        }
+
+        // Delete refresh tokens to end any active sessions:
+        $token = RefreshToken::where('user_id', $user->id)->delete();
+
+        // And finally, delete the user's profile in Customer.io:
+        app(CustomerIo::class)->deleteUser($user);
+
+        info('Deleted: '.$user->id);
     }
 }

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -1,56 +1,24 @@
 <?php
 
 use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
 
 class DeleteUsersCommandTest extends TestCase
 {
     /** @test */
     public function it_should_delete_users()
     {
+        $now = $this->mockTime();
         $input = 'tests/Console/example-identify-output.csv';
 
         // Create the expected users we're going to destroy:
         $user1 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d4'])->first();
         $user2 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d5'])->first();
 
-        // Mock the Customer.io API & assert that we make two "delete" requests:
-        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->twice();
-
         // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
         $this->artisan('northstar:delete', ['input' => $input]);
 
         // The command should remove
-        $this->assertAnonymized($user1);
-        $this->assertAnonymized($user2);
-    }
-
-    /**
-     * Assert that the given model has been anonymized.
-     *
-     * @param User $before
-     */
-    protected function assertAnonymized($before)
-    {
-        $after = $before->fresh();
-        $attributes = $after->getAttributes();
-
-        // The birthdate should be set to January 1st of the same year:
-        $this->assertEquals($before->birthdate->year, $after->birthdate->year);
-        $this->assertEquals(1, $after->birthdate->month);
-        $this->assertEquals(1, $after->birthdate->day);
-
-        // We should not see any fields with PII:
-        $this->assertArrayNotHasKey('email', $attributes);
-        $this->assertArrayNotHasKey('first_name', $attributes);
-        $this->assertArrayNotHasKey('last_name', $attributes);
-        $this->assertArrayNotHasKey('addr_street1', $attributes);
-        $this->assertArrayNotHasKey('addr_street2', $attributes);
-
-        // ...but we should still have some demographic fields:
-        $this->assertArrayHasKey('addr_zip', $attributes);
-
-        // We should also have set a "deleted at" flag:
-        $this->assertArrayHasKey('deleted_at', $attributes);
+        $this->assertEquals($user1->fresh()->deletion_requested_at, $now);
+        $this->assertEquals($user2->fresh()->deletion_requested_at, $now);
     }
 }

--- a/tests/Console/ProcessDeletionsCommandTest.php
+++ b/tests/Console/ProcessDeletionsCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+use Northstar\Services\CustomerIo;
+
+class ProcessDeletionsCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_delete_users()
+    {
+        // Create the expected users we're going to destroy:
+        $user1 = factory(User::class)->create(['deletion_requested_at' => new Carbon('15 days ago')]);
+        $user2 = factory(User::class)->create(['deletion_requested_at' => new Carbon('20 days ago')]);
+        $user3 = factory(User::class)->create(['deletion_requested_at' => new Carbon('3 days ago')]);
+        $user4 = factory(User::class)->create();
+
+        // Mock the Customer.io API & assert that we make two "delete" requests:
+        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->twice();
+
+        // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
+        $this->artisan('northstar:process-deletions');
+
+        // The command should remove the users queued for > 14 days:
+        $this->assertAnonymized($user1);
+        $this->assertAnonymized($user2);
+
+        // ...but not the one that was queued more recently, or not at all:
+        $this->assertArrayNotHasKey('deleted_at', $user3->fresh()->getAttributes());
+        $this->assertArrayNotHasKey('deleted_at', $user4->fresh()->getAttributes());
+    }
+
+    /**
+     * Assert that the given model has been anonymized.
+     *
+     * @param User $before
+     */
+    protected function assertAnonymized($before)
+    {
+        $after = $before->fresh();
+        $attributes = $after->getAttributes();
+
+        // The birthdate should be set to January 1st of the same year:
+        $this->assertEquals($before->birthdate->year, $after->birthdate->year);
+        $this->assertEquals(1, $after->birthdate->month);
+        $this->assertEquals(1, $after->birthdate->day);
+
+        // We should not see any fields with PII:
+        $this->assertArrayNotHasKey('email', $attributes);
+        $this->assertArrayNotHasKey('first_name', $attributes);
+        $this->assertArrayNotHasKey('last_name', $attributes);
+        $this->assertArrayNotHasKey('addr_street1', $attributes);
+        $this->assertArrayNotHasKey('addr_street2', $attributes);
+
+        // ...but we should still have some demographic fields:
+        $this->assertArrayHasKey('addr_zip', $attributes);
+
+        // We should also have set a "deleted at" flag:
+        $this->assertArrayHasKey('deleted_at', $attributes);
+    }
+}

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Northstar\Models\User;
+use Northstar\Services\CustomerIo;
 
 class UserTest extends BrowserKitTestCase
 {
@@ -830,6 +831,8 @@ class UserTest extends BrowserKitTestCase
     public function testV2AdminCanDeleteUser()
     {
         $userToDelete = factory(User::class)->create();
+
+        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->once();
 
         $response = $this->asAdminUser()->json('DELETE', 'v2/users/'.$userToDelete->id, [
             'first_name' => 'Hercules',

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Northstar\Models\User;
+use Northstar\Services\CustomerIo;
 
 class LegacyUserTest extends BrowserKitTestCase
 {
@@ -764,6 +765,8 @@ class LegacyUserTest extends BrowserKitTestCase
     public function testDelete()
     {
         $user = User::create(['email' => 'delete-me@example.com']);
+
+        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->once();
 
         // Only 'admin' scoped keys should be able to delete users.
         $this->withLegacyApiKeyScopes(['user', 'write'])->delete('v1/users/'.$user->id);


### PR DESCRIPTION
### What's this PR do?

This pull request splits `northstar:delete` into two commands – a new `northstar:delete` that marks users for deletion, and a `northstar:process-deletions` that we can then use to delete anyone who was marked more than 14 days ago.

I've also extracted the bulk of the logic for these two commands into the model/observer, so that it''ll be easy for us to perform this same behavior via a web API.

### How should this be reviewed?

I split this into one commit per command, and a third commit for the refactoring to extract logic into the model and observer classes. It may be easier to read the full diff though – your call!

### Any background context you want to provide?

I'll update this to hit the "delete" endpoints in Rogue & Gambit in a follow-up PR!

### Relevant tickets

References [Pivotal #170953571](https://www.pivotaltracker.com/story/show/170953571).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
