### PR TITLE
When deleting users, remove them from other services as well.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,6 @@ MAIL_DRIVER=log
 STORAGE_DRIVER=local
 QUEUE_DRIVER=sync
 
-# Phoenix:
-PHOENIX_URL=https://www-dev.dosomething.org
-
 # Blink
 BLINK_URL=http://blink.dev
 BLINK_USERNAME=username
@@ -48,6 +45,13 @@ FACEBOOK_APP_ID=FacebookAppId
 GOOGLE_CLIENT_ID=GoogleClientId
 GOOGLE_CLIENT_SECRET=GoogleSecret
 GOOGLE_REDIRECT_URL=https://northstar.dev/google/verify
+
+# Other DoSomething.org services:
+PHOENIX_URL=https://dev.dosomething.org
+ROGUE_URL=https://activity-dev.dosomething.org
+GAMBIT_URL=https://gambit-conversations-staging.herokuapp.com
+GAMBIT_USERNAME=
+GAMBIT_PASSWORD=
 
 # Customer.io:
 CUSTOMER_IO_URL=https://track.customer.io/api/v1/

--- a/app/Auth/Repositories/ScopeRepository.php
+++ b/app/Auth/Repositories/ScopeRepository.php
@@ -11,6 +11,20 @@ use Northstar\Auth\Scope;
 class ScopeRepository implements ScopeRepositoryInterface
 {
     /**
+     * Create ScopeEntities from a given list of identifiers.
+     *
+     * @return ScopeEntityInterface[]
+     */
+    public function create(...$identifiers)
+    {
+        $scopeEntities = array_map(function($identifier) {
+            return $this->getScopeEntityByIdentifier($identifier);
+        }, $identifiers);
+
+        return array_filter($scopeEntities);
+    }
+
+    /**
      * Return information about a scope.
      *
      * @param string $identifier The scope identifier

--- a/app/Auth/Repositories/ScopeRepository.php
+++ b/app/Auth/Repositories/ScopeRepository.php
@@ -17,7 +17,7 @@ class ScopeRepository implements ScopeRepositoryInterface
      */
     public function create(...$identifiers)
     {
-        $scopeEntities = array_map(function($identifier) {
+        $scopeEntities = array_map(function ($identifier) {
             return $this->getScopeEntityByIdentifier($identifier);
         }, $identifiers);
 

--- a/app/Jobs/DeleteUserFromOtherServices.php
+++ b/app/Jobs/DeleteUserFromOtherServices.php
@@ -45,6 +45,7 @@ class DeleteUserFromOtherServices implements ShouldQueue
         Redis::throttle('delete-apis')->allow(1)->every(1)->then(function () {
             app(CustomerIo::class)->deleteUser($this->id);
             app(Gambit::class)->deleteUser($this->id);
+            app(Rogue::class)->deleteUser($this->id);
         });
     }
 }

--- a/app/Jobs/DeleteUserFromOtherServices.php
+++ b/app/Jobs/DeleteUserFromOtherServices.php
@@ -44,6 +44,7 @@ class DeleteUserFromOtherServices implements ShouldQueue
         // Customer.io or any of our internal APIs with a deluge of requests).
         Redis::throttle('delete-apis')->allow(1)->every(1)->then(function () {
             app(CustomerIo::class)->deleteUser($this->id);
+            app(Gambit::class)->deleteUser($this->id);
         });
     }
 }

--- a/app/Jobs/DeleteUserFromOtherServices.php
+++ b/app/Jobs/DeleteUserFromOtherServices.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Northstar\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Northstar\Services\Rogue;
+use Northstar\Services\Gambit;
+use Northstar\Services\CustomerIo;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class DeleteUserFromOtherServices implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The user's ID.
+     *
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // For sanity, we'll rate limit these to 1/s (so we don't risk overloading
+        // Customer.io or any of our internal APIs with a deluge of requests).
+        Redis::throttle('delete-apis')->allow(1)->every(1)->then(function () {
+            // ...
+        });
+    }
+}

--- a/app/Jobs/DeleteUserFromOtherServices.php
+++ b/app/Jobs/DeleteUserFromOtherServices.php
@@ -43,7 +43,7 @@ class DeleteUserFromOtherServices implements ShouldQueue
         // For sanity, we'll rate limit these to 1/s (so we don't risk overloading
         // Customer.io or any of our internal APIs with a deluge of requests).
         Redis::throttle('delete-apis')->allow(1)->every(1)->then(function () {
-            // ...
+            app(CustomerIo::class)->deleteUser($this->id);
         });
     }
 }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -4,8 +4,8 @@ namespace Northstar\Observers;
 
 use Northstar\Models\User;
 use Northstar\Models\RefreshToken;
-use Northstar\Services\CustomerIo;
 use Northstar\Jobs\SendUserToCustomerIo;
+use Northstar\Jobs\DeleteUserFromOtherServices;
 
 class UserObserver
 {
@@ -114,8 +114,8 @@ class UserObserver
         // Delete refresh tokens to end any active sessions:
         $token = RefreshToken::where('user_id', $user->id)->delete();
 
-        // And finally, delete the user's profile in Customer.io:
-        app(CustomerIo::class)->deleteUser($user);
+        // And finally, delete the user from other services:
+        DeleteUserFromOtherServices::dispatch($user->id);
 
         info('Deleted: '.$user->id);
     }

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -53,12 +53,11 @@ class CustomerIo
      */
     public function deleteUser(string $id)
     {
-        if (!config('features.delete-api')) {
+        if (! config('features.delete-api')) {
             info('User '.$id.' would have been deleted in Customer.io.');
 
             return;
         }
-
 
         return $this->client->delete('customers/'.$id);
     }

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -2,8 +2,6 @@
 
 namespace Northstar\Services;
 
-use Northstar\Models\User;
-
 class CustomerIo
 {
     /**
@@ -51,10 +49,17 @@ class CustomerIo
      * Delete the given user's profile in Customer.io
      * @see https://customer.io/docs/api/#apitrackcustomerscustomers_delete
      *
-     * @param User $user
+     * @param string $id
      */
-    public function deleteUser(User $user)
+    public function deleteUser(string $id)
     {
-        return $this->client->delete('customers/'.$user->id);
+        if (!config('features.delete-api')) {
+            info('User '.$id.' would have been deleted in Customer.io.');
+
+            return;
+        }
+
+
+        return $this->client->delete('customers/'.$id);
     }
 }

--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -35,7 +35,7 @@ class Gambit
      */
     public function deleteUser(string $id)
     {
-        if (!config('features.delete-api')) {
+        if (! config('features.delete-api')) {
             info('User '.$id.' would have been deleted in Gambit.');
 
             return;

--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Northstar\Services;
+
+use Northstar\Models\User;
+
+class Gambit
+{
+    /**
+     * The HTTP client.
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Create a new Gambit API client.
+     */
+    public function __construct()
+    {
+        $config = config('services.gambit');
+
+        $this->client = new \GuzzleHttp\Client([
+            'base_uri' => $config['url'],
+            'auth' => [$config['username'], $config['password']],
+        ]);
+    }
+
+    /**
+     * Delete the given user's activity in Gambit.
+     *
+     * @see https://git.io/JvWb6
+     *
+     * @param string $id
+     */
+    public function deleteUser(string $id)
+    {
+        if (!config('features.delete-api')) {
+            info('User '.$id.' would have been deleted in Gambit.');
+
+            return;
+        }
+
+        return $this->client->delete('/api/v2/users/'.$id);
+    }
+}

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -37,7 +37,7 @@ class Rogue
      */
     public function deleteUser(string $id)
     {
-        if (!config('features.delete-api')) {
+        if (! config('features.delete-api')) {
             info('User '.$id.' would have been deleted in Rogue.');
 
             return;

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Northstar\Services;
+
+use Northstar\Models\User;
+
+class Rogue
+{
+    /**
+     * The HTTP client.
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Create a new Gambit API client.
+     */
+    public function __construct()
+    {
+        $config = config('services.gambit');
+
+        $this->client = new \GuzzleHttp\Client([
+            'base_uri' => $config['url'],
+            'headers' => [
+                'Authorization' => machine_token('activity', 'write', 'admin'),
+            ],
+        ]);
+    }
+
+    /**
+     * Delete the given user's activity in Rogue.
+     *
+     * @see https://git.io/JvWb6
+     *
+     * @param string $id
+     */
+    public function deleteUser(string $id)
+    {
+        if (!config('features.delete-api')) {
+            info('User '.$id.' would have been deleted in Rogue.');
+
+            return;
+        }
+
+        return $this->client->delete('/api/v3/users/'.$id);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,7 +1,6 @@
 <?php
 
 use Carbon\Carbon;
-use Northstar\Auth\Scope;
 use Illuminate\Support\Str;
 use Northstar\Models\Client;
 use Northstar\Auth\Normalizer;
@@ -10,7 +9,6 @@ use Illuminate\Support\HtmlString;
 use League\OAuth2\Server\CryptKey;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\PhoneNumberFormat;
-use Northstar\Auth\Entities\ScopeEntity;
 use Northstar\Auth\Entities\ClientEntity;
 use SeatGeek\Sixpack\Session\Base as Sixpack;
 use Northstar\Auth\Repositories\ScopeRepository;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,14 +1,20 @@
 <?php
 
 use Carbon\Carbon;
+use Northstar\Auth\Scope;
 use Illuminate\Support\Str;
 use Northstar\Models\Client;
 use Northstar\Auth\Normalizer;
 use libphonenumber\PhoneNumber;
 use Illuminate\Support\HtmlString;
+use League\OAuth2\Server\CryptKey;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\PhoneNumberFormat;
+use Northstar\Auth\Entities\ScopeEntity;
+use Northstar\Auth\Entities\ClientEntity;
 use SeatGeek\Sixpack\Session\Base as Sixpack;
+use Northstar\Auth\Repositories\ScopeRepository;
+use Northstar\Auth\Repositories\AccessTokenRepository;
 
 /**
  * Normalize the given value.
@@ -331,4 +337,25 @@ function format_mobile(PhoneNumber $number, $format): string
     $parser = PhoneNumberUtil::getInstance();
 
     return $parser->format($number, $format);
+}
+
+/**
+ * Create a "personal" access token that Northstar can use
+ * to make API calls to resource servers (like Rogue).
+ *
+ * @return string
+ */
+function machine_token(...$scopes)
+{
+    $client = new ClientEntity('northstar', config('app.name'), $scopes);
+    $scopeEntities = app(ScopeRepository::class)->create(...$scopes);
+
+    $accessToken = app(AccessTokenRepository::class)->getNewToken($client, $scopeEntities);
+    $accessToken->setPrivateKey(new CryptKey(storage_path('app/keys/private.key'), null, false));
+    $accessToken->setIdentifier(bin2hex(random_bytes(40)));
+
+    // Since this token is only used for Northstar's own API requests, we'll give it a very short TTL:
+    $accessToken->setExpiryDateTime((new \DateTimeImmutable())->add(new DateInterval('PT5M')));
+
+    return 'Bearer '.(string) $accessToken;
 }

--- a/config/features.php
+++ b/config/features.php
@@ -25,4 +25,8 @@ return [
     'refer-friends-scholarship' => env('DS_REFER_FRIENDS_SCHOLARSHIP_TEST', false),
 
     'no-badge-campaigns' => explode(',', env('DS_CONTENTFUL_IDS_FOR_CAMPAIGNS_WITH_NO_BADGES', null)),
+
+    // If this is enabled, we'll also make requests to Rogue, Gambit, and
+    // Customer.io's deletion APIs whenever a user model is deleted.
+    'delete-api' => env('DS_ENABLE_DELETE_APIS', false),
 ];


### PR DESCRIPTION
### What's this PR do?

This pull request updates our user deletion model event to also delete a user's data from Rogue, Gambit, and CustomerIo. This super-charges our existing Artisan commands to handle all of our services (sans Quasar) in one fell swoop!

### How should this be reviewed?

I split this work into individual commits for each component, which may be easier to review.

### Any background context you want to provide?

I'll set the new `ROGUE_URL`, `GAMBIT_URL`, `GAMBIT_USERNAME` and `GAMBIT_PASSWORD` environment variables on each environment before merging this, and then enable the `DS_ENABLE_DELETE_APIS` feature flag on dev & QA to test.

### Relevant tickets

References [Pivotal #170953571](https://www.pivotaltracker.com/story/show/170953571).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
