### PR TITLE
Add new "deletion request" APIs.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -77,6 +77,8 @@ class Handler extends ExceptionHandler
             return $this->invalidated($request, $e);
         } elseif ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException('That resource could not be found.');
+        } elseif ($e instanceof AuthorizationException) {
+            $e = new AccessDeniedHttpException($e->getMessage(), $e);
         }
 
         // If request has 'Accepts: application/json' header or we're on a route that

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -7,12 +7,13 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Northstar\Exceptions\NorthstarValidationException;
 use Northstar\Http\Controllers\Traits\FiltersRequests;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Northstar\Http\Controllers\Traits\TransformsResponses;
 use Illuminate\Http\Request;
 
 abstract class Controller extends BaseController
 {
-    use DispatchesJobs, ValidatesRequests, FiltersRequests, TransformsResponses;
+    use DispatchesJobs, AuthorizesRequests, ValidatesRequests, FiltersRequests, TransformsResponses;
 
     /**
      * Throw the failed validation exception with our custom formatting. Overrides the

--- a/app/Http/Controllers/DeletionRequestController.php
+++ b/app/Http/Controllers/DeletionRequestController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+use Northstar\Models\User;
+use Illuminate\Http\Request;
+use Northstar\Http\Transformers\UserTransformer;
+
+class DeletionRequestController extends Controller
+{
+    /**
+     * @var UserTransformer
+     */
+    protected $transformer;
+
+    /**
+     * Make a new UserController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param UserTransformer $transformer
+     */
+    public function __construct(UserTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+
+        $this->middleware('scope:user');
+        $this->middleware('scope:write');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  User $user
+     * @param  Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(User $user, Request $request)
+    {
+        $this->authorize('request-deletion', $user);
+
+        $user->deletion_requested_at = now();
+        $user->save();
+
+        return $this->item($user);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  User $user
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(User $user)
+    {
+        $this->authorize('request-deletion', $user);
+
+        $user->deletion_requested_at = null;
+        $user->save();
+
+        return $this->item($user);
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -178,15 +178,19 @@ class UserController extends Controller
      * Delete a user resource.
      * DELETE /users/:id
      *
-     * @param $id - User ID
+     * @param User $user
      * @return \Illuminate\Http\Response
      * @throws NotFoundHttpException
      */
-    public function destroy($id)
+    public function destroy(User $user)
     {
-        $user = User::findOrFail($id);
+        $this->authorize('delete', $user);
+
+        // @see: UserObserver@deleting
         $user->delete();
 
-        return $this->respond('No Content.');
+        // We'll return the deleted user since that may be helpful
+        // for some applications to update their local state.
+        return $this->item($user);
     }
 }

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -120,6 +120,7 @@ class UserTransformer extends BaseTransformer
         $response['role'] = $user->role;
 
         if (Gate::allows('view-full-profile', $user)) {
+            $response['deletion_requested_at'] = iso8601($user->deletion_requested_at);
             $response['last_accessed_at'] = iso8601($user->last_accessed_at);
             $response['last_authenticated_at'] = iso8601($user->last_authenticated_at);
             $response['last_messaged_at'] = iso8601($user->last_messaged_at);

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -75,4 +75,16 @@ class UserPolicy
     {
         return $this->isSuperuser($viewer) || $this->isOwner($viewer, $target);
     }
+
+    /**
+     * Determine if the authorized user can request deletion for the target user.
+     *
+     * @param User $viewer
+     * @param User $target
+     * @return bool
+     */
+    public function delete(?User $viewer, User $target)
+    {
+        return $this->isSuperuser($viewer);
+    }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -77,7 +77,7 @@ class UserPolicy
     }
 
     /**
-     * Determine if the authorized user can immediately delete the target user.
+     * Determine if the authorized user can request deletion for the target user.
      *
      * @param User $viewer
      * @param User $target
@@ -89,7 +89,7 @@ class UserPolicy
     }
 
     /**
-     * Determine if the authorized user can request deletion for the target user.
+     * Determine if the authorized user can immediately delete the target user.
      *
      * @param User $viewer
      * @param User $target

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -77,6 +77,18 @@ class UserPolicy
     }
 
     /**
+     * Determine if the authorized user can immediately delete the target user.
+     *
+     * @param User $viewer
+     * @param User $target
+     * @return bool
+     */
+    public function requestDeletion(?User $viewer, User $target)
+    {
+        return $this->isSuperuser($viewer) || $this->isOwner($viewer, $target);
+    }
+
+    /**
      * Determine if the authorized user can request deletion for the target user.
      *
      * @param User $viewer

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -11,52 +11,68 @@ class UserPolicy
     use HandlesAuthorization;
 
     /**
-     * Determine if the authorized user can see full profile details
-     * for the given user account.
+     * Is the current user a staffer/administrator?
      *
-     * @param User $user
-     * @param User $profile
+     * @param User $viewer
      * @return bool
      */
-    public function viewFullProfile(?User $user, User $profile)
+    protected function isSuperuser(?User $viewer)
     {
+        // If this is a machine client, it's a "superuser" even
+        // though there isn't actually a _user_ authenticated:
         if (Scope::allows('admin')) {
             return true;
         }
 
-        if (! $user) {
+        // But if this isn't a machine client & anonymous, they
+        // certainly can't be a superuser, now can they?!
+        if (! $viewer) {
             return false;
         }
 
-        if (in_array($user->role, ['admin', 'staff'])) {
-            return true;
+        // Superusers are folks with 'admin' or 'staff' role:
+        return in_array($viewer->role, ['admin', 'staff']);
+    }
+
+    /**
+     * Is the current user the same person as this profile?
+     *
+     * @param User $viewer
+     * @param User $target
+     * @return bool
+     */
+    protected function isOwner(?User $viewer, User $target)
+    {
+        if (! $viewer) {
+            return false;
         }
 
-        return $user->id === $profile->id;
+        return $viewer->is($target);
+    }
+
+    /**
+     * Determine if the authorized user can see full profile details
+     * for the given user account.
+     *
+     * @param User $viewer
+     * @param User $target
+     * @return bool
+     */
+    public function viewFullProfile(?User $viewer, User $target)
+    {
+        return $this->isSuperuser($viewer) || $this->isOwner($viewer, $target);
     }
 
     /**
      * Determine if the authorized user can edit the profile details
      * for the given user account.
      *
-     * @param User $user
-     * @param User $profile
+     * @param User $viewer
+     * @param User $target
      * @return bool
      */
-    public function editProfile(?User $user, User $profile)
+    public function editProfile(?User $viewer, User $target)
     {
-        if (Scope::allows('admin')) {
-            return true;
-        }
-
-        if (! $user) {
-            return false;
-        }
-
-        if (in_array($user->role, ['admin', 'staff'])) {
-            return true;
-        }
-
-        return $user->id === $profile->id;
+        return $this->isSuperuser($viewer) || $this->isOwner($viewer, $target);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,8 @@ $router->group(['prefix' => 'v2', 'as' => 'v2.'], function () {
 
     // Users
     $this->resource('users', 'UserController');
+    $this->post('users/{user}/deletion', 'DeletionRequestController@store');
+    $this->delete('users/{user}/deletion', 'DeletionRequestController@destroy');
 
     // User (by email or mobile number)
     $this->get('mobile/{mobile}', 'MobileController@show');

--- a/tests/Http/DeletionRequestTest.php
+++ b/tests/Http/DeletionRequestTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+
+class DeletionRequestTest extends BrowserKitTestCase
+{
+    /**
+     * Test that a user can mark themselves for deletion.
+     * POST /v2/users/:id/deletion
+     *
+     * @return void
+     */
+    public function testMarkingSelfForDeletion()
+    {
+        $this->mockTime('April 26 2019 7:00pm');
+
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/deletion');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonField('data.deletion_requested_at', '2019-04-26T19:00:00+00:00');
+    }
+
+    /**
+     * Test that a user can un-mark themselves for deletion.
+     * DELETE /v2/users/:id/deletion
+     *
+     * @return void
+     */
+    public function testUnmarkingSelfForDeletion()
+    {
+        $user = factory(User::class)->create([
+            'deletion_requested_at' => new Carbon('2019-04-26T19:00:00+00:00'),
+        ]);
+
+        $this->asUser($user, ['user', 'write'])->delete('v2/users/'.$user->id.'/deletion');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonField('data.deletion_requested_at', null);
+    }
+
+    /**
+     * Test that a staffer can mark users for deletion.
+     * DELETE /v2/users/:id/deletion
+     *
+     * @return void
+     */
+    public function testStaffCanMarkUsersForDeletion()
+    {
+        $this->mockTime('April 26 2019 7:00pm');
+
+        $staffer = factory(User::class)->create(['role' => 'staff']);
+        $user = factory(User::class)->create();
+
+        $this->asUser($staffer, ['user', 'write'])->post('v2/users/'.$user->id.'/deletion');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonField('data.deletion_requested_at', '2019-04-26T19:00:00+00:00');
+    }
+
+    /**
+     * Test that a normal user can't delete someone else.
+     * DELETE /v2/users/:id/deletion
+     *
+     * @return void
+     */
+    public function testNormalUsersCantMarkOthersForDeletion()
+    {
+        $villain = factory(User::class)->create();
+        $user = factory(User::class)->create();
+
+        $this->asUser($villain, ['user', 'write'])->delete('v2/users/'.$user->id.'/deletion');
+
+        $this->assertResponseStatus(403);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds new endpoints to allow users to mark their account for deletion (or if they change their mind, unmark it) via new `/v2/users/{id}/deletion` endpoints. These can also be used by staffers to mark any arbitrary account for deletion. 🔥 

### How should this be reviewed?

It may be easier to review commit-by-commit – up to you! I added tests in ae7f8e1.

### Any background context you want to provide?

This simply sets a "flag" on the user, and the cron job introduced in #980 actually deletes them.

### Relevant tickets

References [Pivotal #170953317](https://www.pivotaltracker.com/story/show/170953317).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
