### PR TITLE
Add an index on 'deletion_requested_at'.

### DIFF
--- a/database/migrations/2020_02_21_212702_AddIndexToDeletionRequestedAt.php
+++ b/database/migrations/2020_02_21_212702_AddIndexToDeletionRequestedAt.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexToDeletionRequestedAt extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('deletion_requested_at', null, null, ['sparse' => true]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('deletion_requested_at');
+        });
+    }
+}


### PR DESCRIPTION
### What's this PR do?

I noticed that the [`northstar:process-deletions`](https://github.com/DoSomething/northstar/blob/master/app/Console/Commands/ProcessDeletionsCommand.php) command is a little sluggish when testing it out on QA. Adding an index should make things nice and snappy!

### How should this be reviewed?

👀

### Any background context you want to provide?

This is a [sparse index](https://docs.mongodb.com/manual/core/index-sparse/) because most documents will not have this property, and we only care about ones that do!

### Relevant tickets

References [Pivotal #170953571](https://www.pivotaltracker.com/story/show/170953571).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
