### PR TITLE
Immediately delete users when running 'northstar:delete' command.

### DIFF
--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -44,7 +44,7 @@ class DeleteUsersCommand extends Command
                 continue;
             }
 
-            $user->requestDeletion();
+            $user->delete();
         }
 
         info('Done!');

--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -20,7 +20,7 @@ class DeleteUsersCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Queue users for deletion, given a CSV of IDs.';
+    protected $description = 'Delete users from our systems, given a CSV of IDs.';
 
     /**
      * Execute the console command.
@@ -33,7 +33,7 @@ class DeleteUsersCommand extends Command
         $csv = Reader::createFromString($input);
         $csv->setHeaderOffset(0);
 
-        info('Queueing '.count($csv).' users for deletion...');
+        info('Immediately deleting '.count($csv).' users...');
 
         foreach ($csv->getRecords() as $record) {
             $id = $record[$this->option('id_column')];

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Northstar\Models\User;
+use Northstar\Services\Rogue;
+use Northstar\Services\Gambit;
+use Northstar\Services\CustomerIo;
 
 class DeleteUsersCommandTest extends TestCase
 {
@@ -14,11 +17,16 @@ class DeleteUsersCommandTest extends TestCase
         $user1 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d4'])->first();
         $user2 = factory(User::class)->create(['_id' => '5d3630a0fdce2742ff6c64d5'])->first();
 
+        // Mock the external service APIs & assert that we make two "delete" requests:
+        $this->mock(Rogue::class)->shouldReceive('deleteUser')->twice();
+        $this->mock(Gambit::class)->shouldReceive('deleteUser')->twice();
+        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->twice();
+
         // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
         $this->artisan('northstar:delete', ['input' => $input]);
 
         // The command should remove
-        $this->assertEquals($user1->fresh()->deletion_requested_at, $now);
-        $this->assertEquals($user2->fresh()->deletion_requested_at, $now);
+        $this->assertAnonymized($user1);
+        $this->assertAnonymized($user2);
     }
 }

--- a/tests/Console/ProcessDeletionsCommandTest.php
+++ b/tests/Console/ProcessDeletionsCommandTest.php
@@ -33,33 +33,4 @@ class ProcessDeletionsCommandTest extends TestCase
         $this->assertArrayNotHasKey('deleted_at', $user3->fresh()->getAttributes());
         $this->assertArrayNotHasKey('deleted_at', $user4->fresh()->getAttributes());
     }
-
-    /**
-     * Assert that the given model has been anonymized.
-     *
-     * @param User $before
-     */
-    protected function assertAnonymized($before)
-    {
-        $after = $before->fresh();
-        $attributes = $after->getAttributes();
-
-        // The birthdate should be set to January 1st of the same year:
-        $this->assertEquals($before->birthdate->year, $after->birthdate->year);
-        $this->assertEquals(1, $after->birthdate->month);
-        $this->assertEquals(1, $after->birthdate->day);
-
-        // We should not see any fields with PII:
-        $this->assertArrayNotHasKey('email', $attributes);
-        $this->assertArrayNotHasKey('first_name', $attributes);
-        $this->assertArrayNotHasKey('last_name', $attributes);
-        $this->assertArrayNotHasKey('addr_street1', $attributes);
-        $this->assertArrayNotHasKey('addr_street2', $attributes);
-
-        // ...but we should still have some demographic fields:
-        $this->assertArrayHasKey('addr_zip', $attributes);
-
-        // We should also have set a "deleted at" flag:
-        $this->assertArrayHasKey('deleted_at', $attributes);
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,8 @@
 <?php
 
-use Tests\CreatesApplication;
 use Tests\WithMocks;
+use Northstar\Models\User;
+use Tests\CreatesApplication;
 use Tests\WithAuthentication;
 
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
@@ -86,5 +87,34 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
             'email' => $this->faker->unique->email,
             'password' => 'secret456',
         ]);
+    }
+
+    /**
+     * Assert that the given model has been anonymized.
+     *
+     * @param User $before
+     */
+    protected function assertAnonymized(User $before)
+    {
+        $after = $before->fresh();
+        $attributes = $after->getAttributes();
+
+        // The birthdate should be set to January 1st of the same year:
+        $this->assertEquals($before->birthdate->year, $after->birthdate->year);
+        $this->assertEquals(1, $after->birthdate->month);
+        $this->assertEquals(1, $after->birthdate->day);
+
+        // We should not see any fields with PII:
+        $this->assertArrayNotHasKey('email', $attributes);
+        $this->assertArrayNotHasKey('first_name', $attributes);
+        $this->assertArrayNotHasKey('last_name', $attributes);
+        $this->assertArrayNotHasKey('addr_street1', $attributes);
+        $this->assertArrayNotHasKey('addr_street2', $attributes);
+
+        // ...but we should still have some demographic fields:
+        $this->assertArrayHasKey('addr_zip', $attributes);
+
+        // We should also have set a "deleted at" flag:
+        $this->assertArrayHasKey('deleted_at', $attributes);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `northstar:delete` command to immediately delete the given users, rather than queueing them for deletion (where we'd have to either wait 14 days for it to take effect, or "fast-forward" any other queued users to be deleted as well).

### How should this be reviewed?

It's a one-line code change (sans tests and documentation)! I moved `assertAnonymized` into the top-level TestCase so that both of these deletion commands can share this helper method.

### Any background context you want to provide?

I realized when processing our account deletion backlog this morning that if we've got a big list of IDs to delete like this, we'll almost always want to delete them right away.

### Relevant tickets

References [Pivotal #170956497](https://www.pivotaltracker.com/story/show/170956497).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
