### PR TITLE
Correctly load private key if using S3.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,11 +6,11 @@ use Northstar\Models\Client;
 use Northstar\Auth\Normalizer;
 use libphonenumber\PhoneNumber;
 use Illuminate\Support\HtmlString;
-use League\OAuth2\Server\CryptKey;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\PhoneNumberFormat;
 use Northstar\Auth\Entities\ClientEntity;
 use SeatGeek\Sixpack\Session\Base as Sixpack;
+use Northstar\Auth\Repositories\KeyRepository;
 use Northstar\Auth\Repositories\ScopeRepository;
 use Northstar\Auth\Repositories\AccessTokenRepository;
 
@@ -349,7 +349,7 @@ function machine_token(...$scopes)
     $scopeEntities = app(ScopeRepository::class)->create(...$scopes);
 
     $accessToken = app(AccessTokenRepository::class)->getNewToken($client, $scopeEntities);
-    $accessToken->setPrivateKey(new CryptKey(storage_path('app/keys/private.key'), null, false));
+    $accessToken->setPrivateKey(app(KeyRepository::class)->getPrivateKey());
     $accessToken->setIdentifier(bin2hex(random_bytes(40)));
 
     // Since this token is only used for Northstar's own API requests, we'll give it a very short TTL:


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue where the Rogue API requests from [`DeleteUserFromOtherServices`](https://github.com/DoSomething/northstar/blob/master/app/Jobs/DeleteUserFromOtherServices.php) were working because we couldn't load the private key (used to sign them).

This was happening because this file is stored on S3, and so wouldn't exist at the given `app/keys/private.key` path until we'd used [`KeyRepository`](https://github.com/DoSomething/northstar/blob/master/app/Auth/Repositories/KeyRepository.php) to fetch it.

### How should this be reviewed?

👀

### Any background context you want to provide?

The [`KeyRepository`](https://github.com/DoSomething/northstar/blob/master/app/Auth/Repositories/KeyRepository.php) is used to load this file remotely from S3 (if necessary), and then cache it on the Heroku instance so we don't have to continually make network round-trips for every request.

### Relevant tickets

References [Pivotal #171441834](https://www.pivotaltracker.com/story/show/171441834).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
