### PR TITLE
Unsubscribe from marketing upon deletion request.

### DIFF
--- a/app/Http/Controllers/DeletionRequestController.php
+++ b/app/Http/Controllers/DeletionRequestController.php
@@ -39,6 +39,12 @@ class DeletionRequestController extends Controller
         $this->authorize('request-deletion', $user);
 
         $user->deletion_requested_at = now();
+
+        // We'll also automatically unsubscribe users from marketing:
+        $user->email_subscription_status = false;
+        $user->email_subscription_topics = [];
+        $user->sms_status = 'stop';
+
         $user->save();
 
         return $this->item($user);

--- a/tests/Http/DeletionRequestTest.php
+++ b/tests/Http/DeletionRequestTest.php
@@ -20,6 +20,8 @@ class DeletionRequestTest extends BrowserKitTestCase
         $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/deletion');
 
         $this->assertResponseStatus(200);
+        $this->seeJsonField('data.sms_status', 'stop');
+        $this->seeJsonField('data.email_subscription_status', false);
         $this->seeJsonField('data.deletion_requested_at', '2019-04-26T19:00:00+00:00');
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates Northstar's user-facing deletion request endpoint to automatically unsubscribe users from messaging (so they won't receive any more emails or texts during their 14-day deletion "grace period").

### How should this be reviewed?

👀

### Any background context you want to provide?

This was a suggestion from @mshmsh5000 in [this thread](https://dosomething.slack.com/archives/C8P2VSF32/p1582817621001300?thread_ts=1582750900.011100&cid=C8P2VSF32)!

### Relevant tickets

References [Pivotal #170953839](https://www.pivotaltracker.com/story/show/170953839).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
