### PR TITLE
Log deletion requests & send deletion timestamp to Customer.io.

### DIFF
--- a/app/Http/Controllers/DeletionRequestController.php
+++ b/app/Http/Controllers/DeletionRequestController.php
@@ -40,14 +40,14 @@ class DeletionRequestController extends Controller
 
         $user->deletion_requested_at = now();
 
-        info('created_deletion_request', ['id' => $user->id]);
-
         // We'll also automatically unsubscribe users from marketing:
         $user->email_subscription_status = false;
         $user->email_subscription_topics = [];
         $user->sms_status = 'stop';
 
         $user->save();
+
+        info('created_deletion_request', ['id' => $user->id]);
 
         return $this->item($user);
     }
@@ -62,10 +62,11 @@ class DeletionRequestController extends Controller
     {
         $this->authorize('request-deletion', $user);
 
-        info('undo_deletion_request', ['id' => $user->id]);
 
         $user->deletion_requested_at = null;
         $user->save();
+
+        info('revoked_deletion_request', ['id' => $user->id]);
 
         return $this->item($user);
     }

--- a/app/Http/Controllers/DeletionRequestController.php
+++ b/app/Http/Controllers/DeletionRequestController.php
@@ -62,7 +62,6 @@ class DeletionRequestController extends Controller
     {
         $this->authorize('request-deletion', $user);
 
-
         $user->deletion_requested_at = null;
         $user->save();
 

--- a/app/Http/Controllers/DeletionRequestController.php
+++ b/app/Http/Controllers/DeletionRequestController.php
@@ -40,6 +40,8 @@ class DeletionRequestController extends Controller
 
         $user->deletion_requested_at = now();
 
+        info('created_deletion_request', ['id' => $user->id]);
+
         // We'll also automatically unsubscribe users from marketing:
         $user->email_subscription_status = false;
         $user->email_subscription_topics = [];
@@ -59,6 +61,8 @@ class DeletionRequestController extends Controller
     public function destroy(User $user)
     {
         $this->authorize('request-deletion', $user);
+
+        info('undo_deletion_request', ['id' => $user->id]);
 
         $user->deletion_requested_at = null;
         $user->save();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -528,6 +528,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'voter_registration_status' => $this->voter_registration_status,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
+            'deletion_requested_at' => optional($this->deletion_requested_at)->timestamp,
             'last_messaged_at' => optional($this->last_messaged_at)->timestamp,
             'last_authenticated_at' => iso8601($this->last_authenticated_at), // TODO: Update Blink to just accept timestamp.
             'updated_at' => iso8601($this->updated_at), // TODO: Update Blink to just accept timestamp.

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -40,6 +40,7 @@ class UserModelTest extends BrowserKitTestCase
             'language' => $user->language,
             'source' => $user->source,
             'source_detail' => $user->source_detail,
+            'deletion_requested_at' => null,
             'last_authenticated_at' => null,
             'last_messaged_at' => null,
             'updated_at' => $user->updated_at->toIso8601String(),


### PR DESCRIPTION
### What's this PR do?

This pull request adds some logging when users request to delete their accounts (or change their mind) so that we can alert ourselves if there are any unexpected spikes!

I've also added `deletion_requested_at` to our Customer.io payload so we can use it to send "your account will be deleted" reminder messaging.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🔥

### Relevant tickets

References Pivotal [#170957143](https://www.pivotaltracker.com/story/show/170957143) and [#170956399](https://www.pivotaltracker.com/story/show/170956399)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
