### PR TITLE
Email subscription resource

### DIFF
--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -27,7 +27,7 @@ class SubscriptionUpdateController extends Controller
         $this->middleware('scope:write');
     }
 
-    public function update(User $user, string $topic)
+    public function store(User $user, string $topic)
     {
       $this->authorize('edit-profile', $user);
 

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -8,16 +8,16 @@ use Northstar\Http\Transformers\UserTransformer;
 class SubscriptionUpdateController extends Controller
 {
     /**
-      * @var UserTransformer
-      */
+     * @var UserTransformer
+     */
     protected $transformer;
 
     /**
-      * Make a new SubpscriptionUpdateController, inject dependencies,
-      * and set middleware for this controller's methods.
-      *
-      * @param UserTransformer $transformer
-      */
+     * Make a new SubpscriptionUpdateController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param UserTransformer $transformer
+     */
     public function __construct(UserTransformer $transformer)
     {
         $this->transformer = $transformer;
@@ -51,5 +51,4 @@ class SubscriptionUpdateController extends Controller
 
         return $this->item($user);
     }
-
 }

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -8,16 +8,16 @@ use Northstar\Http\Transformers\UserTransformer;
 class SubscriptionUpdateController extends Controller
 {
     /**
-    * @var UserTransformer
-    */
+      * @var UserTransformer
+      */
     protected $transformer;
 
     /**
-     * Make a new SubpscriptionUpdateController, inject dependencies,
-     * and set middleware for this controller's methods.
-     *
-     * @param UserTransformer $transformer
-     */
+      * Make a new SubpscriptionUpdateController, inject dependencies,
+      * and set middleware for this controller's methods.
+      *
+      * @param UserTransformer $transformer
+      */
     public function __construct(UserTransformer $transformer)
     {
         $this->transformer = $transformer;
@@ -28,28 +28,28 @@ class SubscriptionUpdateController extends Controller
 
     public function store(User $user, string $topic)
     {
-      $this->authorize('edit-profile', $user);
+        $this->authorize('edit-profile', $user);
 
-      if (!in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
-        abort(404, 'That subscription does not exist.');
-      }
+        if (! in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
+            abort(404, 'That subscription does not exist.');
+        }
 
-      $user->push('email_subscription_topics', $topic, true);
+        $user->push('email_subscription_topics', $topic, true);
 
-      return $this->item($user);
+        return $this->item($user);
     }
 
     public function destroy(User $user, string $topic)
     {
-      $this->authorize('edit-profile', $user);
+        $this->authorize('edit-profile', $user);
 
-      if (!in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
-        abort(404, 'That subscription does not exist.');
-      }
+        if (! in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
+            abort(404, 'That subscription does not exist.');
+        }
 
-      $user->pull('email_subscription_topics', $topic);
+        $user->pull('email_subscription_topics', $topic);
 
-      return $this->item($user);
+        return $this->item($user);
     }
 
 }

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Northstar\Http\Controllers;
+
+use Northstar\Models\User;
+use Illuminate\Http\Request;
+use Northstar\Http\Transformers\UserTransformer;
+
+class SubscriptionUpdateController extends Controller 
+{
+    /**
+    * @var UserTransformer
+    */
+    protected $transformer;
+
+    /**
+     * Make a new UserController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param UserTransformer $transformer
+     */
+    public function __construct(UserTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+
+        $this->middleware('scope:user');
+        $this->middleware('scope:write');
+    }
+
+    public function update(User $user, string $topic)
+    {
+      $this->authorize('edit-profile', $user);
+
+      if (!in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
+        abort(404, 'That subscription does not exist.');
+      }
+
+      $user->push('email_subscription_topics', $topic, true);
+
+      return $this->item($user);
+    }
+
+    public function destroy(User $user, string $topic)
+    {
+      $this->authorize('edit-profile', $user);
+
+      if (!in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
+        abort(404, 'That subscription does not exist.');
+      }
+
+      $user->pull('email_subscription_topics', $topic);
+
+      return $this->item($user);
+    }
+
+}

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -3,10 +3,9 @@
 namespace Northstar\Http\Controllers;
 
 use Northstar\Models\User;
-use Illuminate\Http\Request;
 use Northstar\Http\Transformers\UserTransformer;
 
-class SubscriptionUpdateController extends Controller 
+class SubscriptionUpdateController extends Controller
 {
     /**
     * @var UserTransformer
@@ -14,7 +13,7 @@ class SubscriptionUpdateController extends Controller
     protected $transformer;
 
     /**
-     * Make a new UserController, inject dependencies,
+     * Make a new SubpscriptionUpdateController, inject dependencies,
      * and set middleware for this controller's methods.
      *
      * @param UserTransformer $transformer

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,10 @@ $router->group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     // Subscriptions
     $this->post('subscriptions', 'SubscriptionController@create');
 
+    // Email Subscriptions
+    $this->post('users/{user}/subscriptions/{topic}', 'SubscriptionUpdateController@update');
+    $this->delete('users/{user}/subscriptions/{topic}', 'SubscriptionUpdateController@destroy');
+
     // Profile
     // ...
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,7 +30,7 @@ $router->group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     $this->post('subscriptions', 'SubscriptionController@create');
 
     // Email Subscriptions
-    $this->post('users/{user}/subscriptions/{topic}', 'SubscriptionUpdateController@update');
+    $this->post('users/{user}/subscriptions/{topic}', 'SubscriptionUpdateController@store');
     $this->delete('users/{user}/subscriptions/{topic}', 'SubscriptionUpdateController@destroy');
 
     // Profile

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Carbon\Carbon;
+use Northstar\Models\User;
+
+class SubscriptionUpdateTest extends BrowserKitTestCase
+{
+  /**
+     * Test that a user can mark add email subscriptions.
+     * POST /v2/users/:id/subscriptions/:topic
+     *
+     * @return void
+     */
+    public function testAddSubscription()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonField('data.email_subscription_topics', ["news"]);
+    }
+
+    public function testAddExistingSubscription()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
+        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonField('data.email_subscription_topics', ["news"]);
+    }
+
+    /**
+     * Test that a user can mark remove email subscriptions.
+     * POST /v2/users/:id/subscriptions/:topic
+     *
+     * @return void
+     */
+    public function testRemoveSubscription()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
+        $this->asUser($user, ['user', 'write'])->delete('v2/users/'.$user->id.'/subscriptions/news');
+
+        $this->assertResponseStatus(200);
+        $this->seeJsonField('data.email_subscription_topics', []);
+    }
+
+
+    /**
+     * Test that a user can mark remove email subscriptions.
+     * POST /v2/users/:id/subscriptions/:topic
+     *
+     * @return void
+     */
+    public function testNormalUsersCantChangeOthersSubscriptions()
+    {
+        $villain = factory(User::class)->create();
+        $user = factory(User::class)->create();
+
+        $this->asUser($villain, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
+
+        $this->assertResponseStatus(403);
+    }
+
+}

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -1,11 +1,10 @@
 <?php
 
-use Carbon\Carbon;
 use Northstar\Models\User;
 
 class SubscriptionUpdateTest extends BrowserKitTestCase
 {
-  /**
+    /**
      * Test that a user can add email subscriptions.
      * POST /v2/users/:id/subscriptions/:topic
      *
@@ -13,12 +12,12 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
      */
     public function testAddSubscription()
     {
-      $user = factory(User::class)->create();
+        $user = factory(User::class)->create();
 
         $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
 
         $this->assertResponseStatus(200);
-        $this->seeJsonField('data.email_subscription_topics', ["news"]);
+        $this->seeJsonField('data.email_subscription_topics', ['news']);
     }
 
     /**
@@ -31,13 +30,13 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
     {
 
         $user = factory(User::class)->create([
-          'email_subscription_topics' => ['news'],
+            'email_subscription_topics' => ['news'],
         ]);
 
         $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
 
         $this->assertResponseStatus(200);
-        $this->seeJsonField('data.email_subscription_topics', ["news"]);
+        $this->seeJsonField('data.email_subscription_topics', ['news']);
     }
 
     /**
@@ -48,9 +47,9 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
      */
     public function testRemoveSubscription()
     {
-      $user = factory(User::class)->create([
-        'email_subscription_topics' => ['news'],
-      ]);
+        $user = factory(User::class)->create([
+            'email_subscription_topics' => ['news'],
+        ]);
 
         $this->asUser($user, ['user', 'write'])->delete('v2/users/'.$user->id.'/subscriptions/news');
 

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -72,5 +72,4 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(403);
     }
-
 }

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -6,14 +6,14 @@ use Northstar\Models\User;
 class SubscriptionUpdateTest extends BrowserKitTestCase
 {
   /**
-     * Test that a user can mark add email subscriptions.
+     * Test that a user can add email subscriptions.
      * POST /v2/users/:id/subscriptions/:topic
      *
      * @return void
      */
     public function testAddSubscription()
     {
-        $user = factory(User::class)->create();
+      $user = factory(User::class)->create();
 
         $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
 
@@ -21,11 +21,19 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
         $this->seeJsonField('data.email_subscription_topics', ["news"]);
     }
 
+    /**
+     * Test that a user cannot add a duplicate email subscription.
+     * POST /v2/users/:id/subscriptions/:topic
+     *
+     * @return void
+     */
     public function testAddExistingSubscription()
     {
-        $user = factory(User::class)->create();
 
-        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
+        $user = factory(User::class)->create([
+          'email_subscription_topics' => ['news'],
+        ]);
+
         $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
 
         $this->assertResponseStatus(200);
@@ -34,24 +42,24 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
 
     /**
      * Test that a user can mark remove email subscriptions.
-     * POST /v2/users/:id/subscriptions/:topic
+     * DELETE /v2/users/:id/subscriptions/:topic
      *
      * @return void
      */
     public function testRemoveSubscription()
     {
-        $user = factory(User::class)->create();
+      $user = factory(User::class)->create([
+        'email_subscription_topics' => ['news'],
+      ]);
 
-        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/news');
         $this->asUser($user, ['user', 'write'])->delete('v2/users/'.$user->id.'/subscriptions/news');
 
         $this->assertResponseStatus(200);
         $this->seeJsonField('data.email_subscription_topics', []);
     }
 
-
     /**
-     * Test that a user can mark remove email subscriptions.
+     * Test that a user can't edit another user's subscriptions.
      * POST /v2/users/:id/subscriptions/:topic
      *
      * @return void

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -28,7 +28,6 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
      */
     public function testAddExistingSubscription()
     {
-
         $user = factory(User::class)->create([
             'email_subscription_topics' => ['news'],
         ]);


### PR DESCRIPTION
### What's this PR do?

This PR adds a new Controller and routes that allows us to update and remove email topic subscriptions individually by sending requests to `/v2/users/:id/subscriptions/:topic`.

POST will add a topic to the array
DELETE will remove a topic to the array

### How should this be reviewed?

Normal 👀 and run the tests!

### Any background context you want to provide?

This sets us up to toggle subscriptions individually in the user profile, coming sooooon!

### Relevant tickets

References [Pivotal #171542935](https://www.pivotaltracker.com/story/show/171542935).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
