### PR TITLE
Add sms frequency to reg

### DIFF
--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -55,7 +55,7 @@ class ProfileSubscriptionsController extends Controller
             if ($user->mobile && $user->mobile !== $currentMobile) {
                 if ($user->sms_status !== 'less') {
                     $user->sms_status = 'active';
-                };
+                }
             }
         });
 

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -48,6 +48,8 @@ class ProfileSubscriptionsController extends Controller
 
         $currentMobile = $user->mobile;
 
+        // dd($currentMobile);
+
         $this->registrar->register($request->all(), $user, function ($user) use ($currentMobile) {
             // Set the sms_status if we're adding or updating the user's mobile.
             if ($user->mobile && $user->mobile !== $currentMobile) {

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -51,7 +51,9 @@ class ProfileSubscriptionsController extends Controller
         $this->registrar->register($request->all(), $user, function ($user) use ($currentMobile) {
             // Set the sms_status if we're adding or updating the user's mobile.
             if ($user->mobile && $user->mobile !== $currentMobile) {
-                $user->sms_status = 'active';
+                if($user->sms_status !== 'less') {
+                    $user->sms_status = 'active';
+                };
             }
         });
 

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -53,7 +53,7 @@ class ProfileSubscriptionsController extends Controller
         $this->registrar->register($request->all(), $user, function ($user) use ($currentMobile) {
             // Set the sms_status if we're adding or updating the user's mobile.
             if ($user->mobile && $user->mobile !== $currentMobile) {
-                if($user->sms_status !== 'less') {
+                if ($user->sms_status !== 'less') {
                     $user->sms_status = 'active';
                 };
             }

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -48,8 +48,6 @@ class ProfileSubscriptionsController extends Controller
 
         $currentMobile = $user->mobile;
 
-        // dd($currentMobile);
-
         $this->registrar->register($request->all(), $user, function ($user) use ($currentMobile) {
             // Set the sms_status if we're adding or updating the user's mobile.
             if ($user->mobile && $user->mobile !== $currentMobile) {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -16,7 +16,7 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'email' => $faker->unique()->safeEmail,
         'mobile' => $faker->unique()->phoneNumber,
         'mobilecommons_id' => $faker->randomNumber(5),
-        'sms_status' => $faker->randomElement(['active', 'undeliverable']),
+        'sms_status' => $faker->randomElements(['active', 'less']),
         'facebook_id' => $faker->unique()->randomNumber(),
         'google_id' => $faker->unique()->randomNumber(),
         'password' => $faker->password,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -16,7 +16,7 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'email' => $faker->unique()->safeEmail,
         'mobile' => $faker->unique()->phoneNumber,
         'mobilecommons_id' => $faker->randomNumber(5),
-        'sms_status' => $faker->randomElements(['active', 'less']),
+        'sms_status' => $faker->randomElement(['active', 'less']),
         'facebook_id' => $faker->unique()->randomNumber(),
         'google_id' => $faker->unique()->randomNumber(),
         'password' => $faker->password,

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -29,6 +29,7 @@
         <div class="w-full flex justify-start">
             <div class="form-item pr-6">
                 <label class="option -radio">
+                    {{-- we need to basically also check if the mobile input is populated when setting checked --}}
                     <input type="radio" name="sms_status" value="active" {{ (old('sms_status') ?: $user->sms_status) === 'active' ? 'checked' : '' }}>
                     <span class="option__indicator"></span>
                     <span>Weekly Texts</span>

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -26,19 +26,21 @@
             <label for="mobile" class="field-label">Cell number to receive texts (Optional)</label>
             <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') ?: $user->mobile }}" data-validate="phone" autofocus />
         </div>
-        <div class="form-item">
-            <label class="option -radio">
-                <input type="radio" name="sms_status" value="active" {{ (old('sms_status') ?: $user->sms_status) === 'active' ? 'checked' : '' }}>
-                <span class="option__indicator"></span>
-                <span>Weekly Texts</span>
-            </label>
-        </div>
-        <div class="form-item">
-            <label class="option -radio">
-                <input type="radio" name="sms_status" value="less" {{ (old('sms_status') ?: $user->sms_status) === 'less' ? 'checked' : '' }}>
-                <span class="option__indicator"></span>
-                <span>Monthly Texts</span>
-            </label>
+        <div class="w-full flex justify-start">
+            <div class="form-item pr-6">
+                <label class="option -radio">
+                    <input type="radio" name="sms_status" value="active" {{ (old('sms_status') ?: $user->sms_status) === 'active' ? 'checked' : '' }}>
+                    <span class="option__indicator"></span>
+                    <span>Weekly Texts</span>
+                </label>
+            </div>
+            <div class="form-item">
+                <label class="option -radio">
+                    <input type="radio" name="sms_status" value="less" {{ (old('sms_status') ?: $user->sms_status) === 'less' ? 'checked' : '' }}>
+                    <span class="option__indicator"></span>
+                    <span>Monthly Texts</span>
+                </label>
+            </div>
         </div>
         <div class="form-item">
             <p class="footnote"><em>DoSomething.org will send you updates about different social change actions and scholarship opportunities from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text <strong>HELP</strong>  to 38383 for support. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages. T-Mobile is not liable for delayed or undelivered messages.</em></p>

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -44,7 +44,7 @@
             </div>
         </div>
         <div class="form-item">
-            <p class="footnote"><em>DoSomething.org will send you updates about different social change actions and scholarship opportunities from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text <strong>HELP</strong>  to 38383 for support. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages. T-Mobile is not liable for delayed or undelivered messages.</em></p>
+            <p class="footnote"><em>By providing your number, DoSomething.org will send you Weekly (up to 8 msgs/month) or Monthly (up to 4 msgs/month) updates about different social change actions and scholarship opportunities from our number, 38383. Message and data rates may apply. Text <strong>HELP</strong> to 38383 for support; text <strong>STOP</strong> to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a>. Carriers are not liable for delayed or undelivered messages.</em></p>
         </div>
 
         <p class="font-bold mt-6">Our Email Newsletters</p>

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -29,7 +29,6 @@
         <div class="w-full flex justify-start">
             <div class="form-item pr-6">
                 <label class="option -radio">
-                    {{-- we need to basically also check if the mobile input is populated when setting checked --}}
                     <input type="radio" name="sms_status" value="active" {{ (old('sms_status') ?: $user->sms_status) === 'active' ? 'checked' : '' }}>
                     <span class="option__indicator"></span>
                     <span>Weekly Texts</span>

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -23,8 +23,22 @@
         {{ csrf_field() }}
 
         <div class="form-item">
-            <label for="mobile" class="field-label">Cell Phone # (Optional)</label>
+            <label for="mobile" class="field-label">Cell number to receive texts (Optional)</label>
             <input name="mobile" type="text" id="mobile" class="text-field js-validate" placeholder="(555) 555-5555" value="{{ old('mobile') ?: $user->mobile }}" data-validate="phone" autofocus />
+        </div>
+        <div class="form-item">
+            <label class="option -radio">
+                <input type="radio" name="sms_status" value="active" {{ (old('sms_status') ?: $user->sms_status) === 'active' ? 'checked' : '' }}>
+                <span class="option__indicator"></span>
+                <span>Weekly Texts</span>
+            </label>
+        </div>
+        <div class="form-item">
+            <label class="option -radio">
+                <input type="radio" name="sms_status" value="less" {{ (old('sms_status') ?: $user->sms_status) === 'less' ? 'checked' : '' }}>
+                <span class="option__indicator"></span>
+                <span>Monthly Texts</span>
+            </label>
         </div>
         <div class="form-item">
             <p class="footnote"><em>DoSomething.org will send you updates about different social change actions and scholarship opportunities from our number, 38383. You can expect to receive up to 8 messages per month from us. Message and data rates may apply. Text <strong>HELP</strong>  to 38383 for support. Text <strong>STOP</strong> to 38383 to opt out. Please review our <a href="https://www.dosomething.org/us/about/terms-service">Terms of Service​</a> and <a href="https://www.dosomething.org/us/about/privacy-policy">Privacy Policy</a> pages. T-Mobile is not liable for delayed or undelivered messages.</em></p>

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Northstar\Models\User;
+
 class ProfileSubscriptionsTest extends BrowserKitTestCase
 {
     /**
@@ -14,11 +16,15 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that users can update their contect methods successfully
+     * Test that users can update their contact methods successfully
      */
     public function testUpdatingContactFields()
     {
-        $user = $this->makeAuthWebUser();
+        $user = factory(User::class)->create([
+            'sms_status' => null
+        ]);
+
+        $this->be($user, 'web');
 
         $this->visit('/profile/subscriptions')
              ->type('(555) 555-5555', 'mobile')
@@ -27,6 +33,31 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
              ->check('email_subscription_topics[3]')
              ->press('Finish')
              ->followRedirects();
+
+        $updatedUser = $user->fresh();
+
+        $this->assertEquals('less', $updatedUser->sms_status);
+    }
+
+      /**
+     * Test that users can update their contact methods successfully
+     */
+    public function testUpdatingContactFieldsWithAutoSelectSMS()
+    {
+        $user = factory(User::class)->create();
+
+        $this->be($user, 'web');
+
+        $this->visit('/profile/subscriptions')
+             ->type('(555) 555-5555', 'mobile')
+             ->check('email_subscription_topics[1]')
+             ->check('email_subscription_topics[2]')
+             ->press('Finish')
+             ->followRedirects();
+
+        $updatedUser = $user->fresh();
+
+        $this->assertEquals('active', $updatedUser->sms_status);
     }
 
     /**

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -17,12 +17,11 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
 
     /**
      * Test that users can update their contact methods successfully
-     * 
      */
     public function testUpdatingContactFields()
     {
         $user = factory(User::class)->create([
-            'sms_status' => null
+            'sms_status' => null,
         ]);
 
         $this->be($user, 'web');
@@ -41,12 +40,11 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
 
       /**
      * Test that users can update their contact methods successfully
-     * 
      */
     public function testUpdatingContactFieldsWithAutoSelectSMS()
     {
         $user = factory(User::class)->create([
-            'sms_status' => null
+            'sms_status' => null,
         ]);
 
         $this->be($user, 'web');

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -17,6 +17,7 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
 
     /**
      * Test that users can update their contact methods successfully
+     * 
      */
     public function testUpdatingContactFields()
     {
@@ -27,12 +28,11 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
         $this->be($user, 'web');
 
         $this->visit('/profile/subscriptions')
-             ->type('(555) 555-5555', 'mobile')
+             ->type('(123) 456-7890', 'mobile')
              ->select('less', 'sms_status')
              ->check('email_subscription_topics[1]')
              ->check('email_subscription_topics[3]')
-             ->press('Finish')
-             ->followRedirects();
+             ->press('Finish');
 
         $updatedUser = $user->fresh();
 
@@ -41,19 +41,21 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
 
       /**
      * Test that users can update their contact methods successfully
+     * 
      */
     public function testUpdatingContactFieldsWithAutoSelectSMS()
     {
-        $user = factory(User::class)->create();
+        $user = factory(User::class)->create([
+            'sms_status' => null
+        ]);
 
         $this->be($user, 'web');
 
         $this->visit('/profile/subscriptions')
-             ->type('(555) 555-5555', 'mobile')
+             ->type('(123) 456-7890', 'mobile')
              ->check('email_subscription_topics[1]')
              ->check('email_subscription_topics[2]')
-             ->press('Finish')
-             ->followRedirects();
+             ->press('Finish');
 
         $updatedUser = $user->fresh();
 

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -38,7 +38,7 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
         $this->assertEquals('less', $updatedUser->sms_status);
     }
 
-      /**
+    /**
      * Test that users can update their contact methods successfully
      */
     public function testUpdatingContactFieldsWithAutoSelectSMS()

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -22,6 +22,7 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
 
         $this->visit('/profile/subscriptions')
              ->type('(555) 555-5555', 'mobile')
+             ->select('less', 'sms_status')
              ->check('email_subscription_topics[1]')
              ->check('email_subscription_topics[3]')
              ->press('Finish')


### PR DESCRIPTION
### What's this PR do?

This pull request adds the sms preferences to our subscriptions page of registration in northstar, updates the controller to properly check what preference a user has selected and updates our tests to check that this has been updated correctly.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Quick note about our subscription tests. While I was adding `sms_status` to the list of form fields that get updated, I noticed that the test wasn't correctly updating the user. And it turns out the old phone number we were passing in the test was actually not passing our validation tests, and consequently not updating our sms_status!! This PR should cover the updates needed to resolve that.

### Relevant tickets

References [Pivotal # 168908600](https://www.pivotaltracker.com/story/show/168908600).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
