### PR TITLE
Adds User sms_subscription_topics field

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -63,6 +63,7 @@ class Registrar
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
             'sms_status' => 'nullable|in:active,less,stop,undeliverable,unknown,pending',
             'sms_paused' => 'boolean',
+            'sms_subscription_topics.*' => 'in:voting',
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
             'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -110,9 +110,10 @@ class UserTransformer extends BaseTransformer
         $response['language'] = $user->language;
         $response['country'] = $user->country;
 
-        // SMS subscription status
+        // SMS subscription
         $response['sms_status'] = $user->sms_status;
         $response['sms_paused'] = (bool) $user->sms_paused;
+        $response['sms_subscription_topics'] = $user->sms_subscription_topics;
 
         // Email subscription topics
         $response['email_subscription_topics'] = $user->email_subscription_topics;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -110,7 +110,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'google_id',
-        'sms_status', 'sms_paused', 'email_subscription_status', 'email_subscription_topics', 'last_messaged_at',
+
+        // SMS Subscription:
+        'sms_status', 'sms_paused', 'sms_subscription_topics', 'last_messaged_at',
+
+        // Email Subscription:
+        'email_subscription_status', 'email_subscription_topics',
 
         // Voting Plan:
         'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',
@@ -537,6 +542,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('community', $this->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
+            'voting_sms_subscription_status' => isset($this->sms_subscription_topics) ? in_array('voting', $this->sms_subscription_topics) : false,
             'animal_welfare' => in_array('animal_welfare', $this->causes) ? true : false,
             'bullying' => in_array('bullying', $this->causes) ? true : false,
             'education' => in_array('education', $this->causes) ? true : false,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -709,6 +709,17 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Mutator to ensure no duplicates in the SMS topics array.
+     *
+     * @param array $value
+     */
+    public function setSmsSubscriptionTopicsAttribute($value)
+    {
+        // Set de-duped array as sms_subscription_topics
+        $this->attributes['sms_subscription_topics'] = array_values(array_unique($value));
+    }
+
+    /**
      * Accessor for the `causes` attribute.
      *
      * @param  mixed value

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -67,6 +67,16 @@ class UserObserver
             $user->email_subscription_status = true;
         }
 
+        /**
+         * If we're unsubscribing from SMS, clear all topics.
+         *
+         * Note: We don't allow users to set their own SMS subscription topics yet, so there isn't a
+         * need to change sms_status if an unsubscribed user happened to add a SMS topic.
+         */
+        if (isset($changed['sms_status']) && $changed['sms_status'] == 'stop') {
+            $user->sms_subscription_topics = [];
+        }
+
         // Write profile changes to the log, with redacted values for hidden fields.
         if (! app()->runningInConsole()) {
             logger('updated user', ['id' => $user->id, 'changed' => $user->getChanged()]);

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -51,6 +51,14 @@ $factory->state(Northstar\Models\User::class, 'email-unsubscribed', function (Fa
     ];
 });
 
+$factory->state(Northstar\Models\User::class, 'sms-subscribed', function (Faker\Generator $faker) {
+    return [
+        'sms_status' => 'active',
+        // Note: Not all users will have SMS subscription topics, it was added in Mar 2020.
+        'sms_subscription_topics' => ['voting'],
+    ];
+});
+
 $factory->defineAs(Northstar\Models\User::class, 'staff', function (Faker\Generator $faker) {
     $faker->addProvider(new FakerPhoneNumber($faker));
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -54,7 +54,7 @@ $factory->state(Northstar\Models\User::class, 'email-unsubscribed', function (Fa
 $factory->state(Northstar\Models\User::class, 'sms-subscribed', function (Faker\Generator $faker) {
     return [
         'sms_status' => 'active',
-        // Note: Not all users will have SMS subscription topics, it was added in Mar 2020.
+        // Note: Not all users will have SMS subscription topics, it was added in March 2020.
         'sms_subscription_topics' => ['voting'],
     ];
 });

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -316,9 +316,10 @@ PUT /v1/users/drupal_id/<drupal_id>
   role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
-  sms_subscription_topics: Array;
+  sms_subscription_topics: Array; // Valid values: 'voting'
   email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
-  email_subscription_topics: Array; 
+  email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community'
+
 
   // Hidden fields (optional):
   race: String;

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -316,7 +316,9 @@ PUT /v1/users/drupal_id/<drupal_id>
   role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
-  email_subscription_status: Boolean; // Whether a user can recieve emails or not.
+  sms_subscription_topics: Array;
+  email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
+  email_subscription_topics: Array; 
 
   // Hidden fields (optional):
   race: String;

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -153,9 +153,11 @@ Either a mobile number or email is required.
   cgg_id: Number;
   slack_id: String;
   interests: String, Array; // CSV values or array will be appended to existing interests
-  sms_status: String; // Either 'active', 'stop', 'less', 'undeliverable', 'pending', or 'unknown'
+  sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
-  email_subscription_status: Boolean; // Whether a user can recieve emails or not.
+  sms_subscription_topics: Array; // Valid values: 'voting'
+  email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
+  email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community'
   source: String; // Immutable. Will only be set on new records.
   source_detail: String; // Only accepted alongside a valid 'source'.
   created_at: Number; // timestamp

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -649,7 +649,6 @@ class UserTest extends BrowserKitTestCase
         $this->assertResponseStatus(201);
     }
 
-
     /**
      * Test that the `mobile` field is validated.
      * POST /users/:id

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -529,7 +529,7 @@ class UserTest extends BrowserKitTestCase
 
     /**
      * Test that the `country` field is validated.
-     * GET /users/:id
+     * POST /users/:id
      *
      * @return void
      */
@@ -617,6 +617,36 @@ class UserTest extends BrowserKitTestCase
             'email' => 'alejandro@example.com',
             'created_at' => new MongoDB\BSON\UTCDateTime($date->getTimestamp() * 1000),
         ]);
+    }
+
+    /**
+     * Test that the `sms_subscription_topics` field is validated.
+     * POST /users/:id
+     *
+     * @return void
+     */
+    public function testV2ValidatesSmsSubscriptionTopics()
+    {
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'sms_subscription_topics' => ['bugs'],
+        ]);
+
+        $this->assertResponseStatus(422);
+
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'sms_subscription_topics' => 'bugs',
+        ]);
+
+        $this->assertResponseStatus(500);
+
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'sms_subscription_topics' => ['voting'],
+        ]);
+
+        $this->assertResponseStatus(201);
     }
 
     /**

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -872,6 +872,29 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that an admin cannot add duplicates to sms_subscription_topics.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testV2UpdateSmsSubscriptionTopicsWithNoDupesAsAdmin()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asAdminUser()->json('PUT', 'v2/users/'.$user->id, [
+            'sms_subscription_topics' => ['voting', 'voting'],
+        ]);
+
+        $this->assertResponseStatus(200);
+
+        // The email_subscription_topics should be updated with no duplicates
+        $this->seeInDatabase('users', [
+            '_id' => $user->id,
+            'sms_subscription_topics' => ['voting'],
+        ]);
+    }
+
+    /**
      * Test that email subscription status is true after adding topics to user with null status.
      * PUT /v2/users/:id
      *

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -649,6 +649,28 @@ class UserTest extends BrowserKitTestCase
         $this->assertResponseStatus(201);
     }
 
+
+    /**
+     * Test that the `mobile` field is validated.
+     * POST /users/:id
+     *
+     * @return void
+     */
+    public function testV2ValidatesMobile()
+    {
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'mobile' => '000-00-0000',
+        ]);
+
+        $this->assertResponseStatus(422);
+
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'mobile' => '212-254-2390',
+        ]);
+
+        $this->assertResponseStatus(201);
+    }
+
     /**
      * Test that we can only upsert with the ?upsert=true param
      * POST /v2/users/

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -951,4 +951,25 @@ class UserTest extends BrowserKitTestCase
             'email_subscription_topics' => null,
         ]);
     }
+
+    /**
+     * Test that user SMS subscription topics are cleared after setting SMS status to stop.
+     * PUT /v2/users/:id
+     *
+     * @return void
+     */
+    public function testSmsSubscriptionTopicsAreClearedWhenUnsubscribing()
+    {
+        $subscribedUser = factory(User::class)->states('sms-subscribed')->create();
+
+        $this->asUser($subscribedUser, ['user', 'write'])->json('PUT', 'v2/users/'.$subscribedUser->id, [
+            'sms_status' => 'stop',
+        ]);
+
+        $this->seeInDatabase('users', [
+            '_id' => $subscribedUser->id,
+            'sms_status' => 'stop',
+            'sms_subscription_topics' => null,
+        ]);
+    }
 }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -49,6 +49,7 @@ class UserModelTest extends BrowserKitTestCase
             'lifestyle_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('lifestyle', $user->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('community', $user->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('scholarships', $user->email_subscription_topics) : false,
+            'voting_sms_subscription_status' => isset($user->sms_subscription_topics) ? in_array('voting', $user->sms_subscription_topics) : false,
             'animal_welfare' => true,
             'bullying' => false,
             'education' => true,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `sms_subscription_topics` array field to our User model, similar to the `email_subscription_topics` field. We currently only have one topic defined, `voting`, which is what we'll set in the Chompy Rock The Vote import if a user opts-in to SMS messaging from DoSomething. We'll use this value for segmenting over in Customer.io -- to only send voting related broadcasts to these members (excluding them from general campaign, scholarship broadcasts we send).

### How should this be reviewed?

Create or update a user with valid `sms_subscription_topics`:
```
curl --location --request POST 'http://northstar.test/v2/users' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer [token]
--data-raw '{
"addr_state": "CA",
"email": "your-email@dosomething.org",
"sms_subscription_topics": ["voting"]
}'
```
and verify expected response:
```
{
    "data": {
        "id": "5e73eec9fdce2708bd2d4696",
        "email_preview": "asc...@dosomething.org",
        ...
        "sms_subscription_topics": [
            "voting"
        ],
        ...
        "updated_at": "2020-03-19T22:14:33+00:00",
        "created_at": "2020-03-19T22:14:33+00:00",
    }
}
```

### Any background context you want to provide?

This shouldn't block merge but I'm very confused about how these `POST /users` requests get validated. If I send an array with value other than `voting`, or a string value -- I don't get a 422 back but instead a 200 response with the HTML of the "Create Account" page. I'm also finding that if I create a user with an invalid mobile number, I can successfully create the user but their mobile is null. 

### Relevant tickets

References [Pivotal #171847123](https://www.pivotaltracker.com/story/show/171847123).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
