### PR TITLE
fixes a space in the mental_health name that was breaking the mutation

### DIFF
--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -30,7 +30,7 @@ class CauseUpdateController extends Controller
     {
         $this->authorize('edit-profile', $user);
 
-        if (! in_array($cause, ['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', ' mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'])) {
+        if (! in_array($cause, ['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'])) {
             abort(404, 'That cause does not exist.');
         }
 
@@ -43,7 +43,7 @@ class CauseUpdateController extends Controller
     {
         $this->authorize('edit-profile', $user);
 
-        if (! in_array($cause, ['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', ' mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'])) {
+        if (! in_array($cause, ['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'])) {
             abort(404, 'That cause does not exist.');
         }
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a space I didn't notice before one of the cause names that is causing a break in profile page!

### How should this be reviewed?

👀 

### Any background context you want to provide?

naming needs to be an exact match in order for our mutations to work as expected.

### Relevant tickets

References [Pivotal # 171439769](https://www.pivotaltracker.com/story/show/171439769).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
