### PR TITLE
Adds referrer_user_id to User model

### DIFF
--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -82,6 +82,7 @@ class UserTransformer extends BaseTransformer
             // Signup source (e.g. cgg, mobile...)
             $response['source'] = $user->source;
             $response['source_detail'] = $user->source_detail;
+            $response['referrer_user_id'] = $user->referrer_user_id;
 
             // Internal & third-party service IDs:
             $response['slack_id'] = null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,6 +35,7 @@ use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
  * @property Carbon $birthdate
  * @property string $source
  * @property string $source_detail
+ * @property string $referrer_user_id
  * @property string $voter_registration_status
  * @property string $school_id
  * @property string $role - The user's role, e.g. 'user', 'staff', or 'admin'
@@ -133,7 +134,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public static $internal = [
         'drupal_id', 'role', 'facebook_id', 'google_id',
         'mobilecommons_id', 'mobilecommons_status', 'sms_status', 'sms_paused',
-        'last_messaged_at', 'feature_flags', 'totp',
+        'last_messaged_at', 'feature_flags', 'totp', 'referrer_user_id',
     ];
 
     /**
@@ -533,6 +534,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'voter_registration_status' => $this->voter_registration_status,
             'source' => $this->source,
             'source_detail' => $this->source_detail,
+            'referrer_user_id' => $this->referrer_user_id,
             'deletion_requested_at' => optional($this->deletion_requested_at)->timestamp,
             'last_messaged_at' => optional($this->last_messaged_at)->timestamp,
             'last_authenticated_at' => iso8601($this->last_authenticated_at), // TODO: Update Blink to just accept timestamp.

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -149,6 +149,7 @@ class UserTest extends BrowserKitTestCase
             'email' => 'puppet.sloth@dosomething.org',
             'mobile' => '+18602035512',
             'birthdate' => '01/01/1993',
+            'referrer_user_id' => '559442cca59dbfca578b4bed',
         ]);
 
         $this->asStaffUser()->get('v2/users/'.$user->id);
@@ -164,6 +165,7 @@ class UserTest extends BrowserKitTestCase
         $this->seeJsonField('data.mobile_preview', '(860) 203-XXXX');
         $this->seeJsonField('data.school_id', '12500012');
         $this->seeJsonField('data.school_id_preview', '125XXXXX');
+        $this->seeJsonField('data.referrer_user_id', '559442cca59dbfca578b4bed');
     }
 
     /**

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -40,6 +40,7 @@ class UserModelTest extends BrowserKitTestCase
             'language' => $user->language,
             'source' => $user->source,
             'source_detail' => $user->source_detail,
+            'referrer_user_id' => $user->referrer_user_id,
             'deletion_requested_at' => null,
             'last_authenticated_at' => null,
             'last_messaged_at' => null,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new internal `referrer_user_id` field to store a referring user when creating a  new user. This will be used by our Rock The Vote (RTV) import for processing voter registration referrals, in tandem with https://github.com/DoSomething/rogue/pull/1003.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This field should also eventually get populated for Refer A Friend referrals on the web - but not in scope for the voter reg work. See [Slack thread](https://dosomething.slack.com/archives/CP2D7UGAU/p1584989421005700?thread_ts=1584987535.004000&cid=CP2D7UGAU) about potentially taking this on in Q2.

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
