### PR TITLE
Automatically collect state and zip on new users via Fastly headers

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -231,6 +231,10 @@ class Registrar
         $user->setSource(null, $sourceDetail ? stringify_object($sourceDetail) : null);
         // Set the user's country code by Fastly geo-location header.
         $user->country = country_code();
+        // Set the user's zip code by Fastly geo-location header.
+        $user->addr_zip = postal_code();
+        // Set the user's state by Fastly geo-location header.
+        $user->addr_state = region_code();
         // Set language based on locale (either 'en', 'es-mx').
         $user->language = app()->getLocale();
         // Subscribe user to the community email topic.

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -142,6 +142,30 @@ function country_code()
 }
 
 /**
+ * Get the postal code from the `X-Fastly-Postal-Code` header.
+ *
+ * @return string|null
+ */
+function postal_code()
+{
+    $code = request()->header('X-Fastly-Postal-Code');
+
+    return $code ? Str::upper($code) : null;
+}
+
+/**
+ * Get the region code from the `X-Fastly-Region-Code` header.
+ *
+ * @return string|null
+ */
+function region_code()
+{
+    $code = request()->header('X-Fastly-Region-Code');
+
+    return $code ? Str::upper($code) : null;
+}
+
+/**
  * Replace the given keys with a value.
  *
  * @param $array

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -178,6 +178,8 @@ class WebAuthenticationTest extends BrowserKitTestCase
     public function testRegisterBeta()
     {
         $this->withHeader('X-Fastly-Country-Code', 'US')
+            ->withHeader('X-Fastly-Postal-Code', '10010')
+            ->withHeader('X-Fastly-Region-Code', 'CA')
             ->registerUpdated();
 
         $this->seeIsAuthenticated('web');
@@ -187,6 +189,8 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         $this->assertEquals('US', $user->country);
         $this->assertEquals('en', $user->language);
+        $this->assertEquals('10010', $user->addr_zip);
+        $this->assertEquals('CA', $user->addr_state);
 
         // The user should be signed up for email messaging.
         $this->assertEquals(true, $user->email_subscription_status);
@@ -233,6 +237,8 @@ class WebAuthenticationTest extends BrowserKitTestCase
         // Mock a session for the user with a ?utm_source=clubs param, indicating a clubs referral
         $this->withSession(['source_detail' => ['utm_source' => 'clubs']])
             ->withHeader('X-Fastly-Country-Code', 'US')
+            ->withHeader('X-Fastly-Postal-Code', '10010')
+            ->withHeader('X-Fastly-Region-Code', 'CA')
             ->registerUpdated();
 
         $this->seeIsAuthenticated('web');
@@ -242,6 +248,8 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         $this->assertEquals('US', $user->country);
         $this->assertEquals('en', $user->language);
+        $this->assertEquals('10010', $user->addr_zip);
+        $this->assertEquals('CA', $user->addr_state);
 
         // The user should not have any `feature_flags`.
         $this->assertEquals(true, is_null($user->feature_flags));
@@ -312,6 +320,8 @@ class WebAuthenticationTest extends BrowserKitTestCase
         ]);
 
         $this->withHeader('X-Fastly-Country-Code', 'US')
+            ->withHeader('X-Fastly-Postal-Code', '10010')
+            ->withHeader('X-Fastly-Region-Code', 'CA')
             ->registerUpdated();
 
         $this->seeIsAuthenticated('web');
@@ -321,6 +331,8 @@ class WebAuthenticationTest extends BrowserKitTestCase
 
         $this->assertEquals('US', $user->country);
         $this->assertEquals('en', $user->language);
+        $this->assertEquals('10010', $user->addr_zip);
+        $this->assertEquals('CA', $user->addr_state);
 
         // The user should not have any `feature_flags`.
         $this->assertEquals(true, is_null($user->feature_flags));


### PR DESCRIPTION
### What's this PR do?

This pull request starts automatically collecting state and zip, the same way we do for country already, on new users! These 2 new headers are now surface via Fastly, and when a new user registers we go ahead and store state and zip on their user profile.

### How should this be reviewed?

Do we need any other tests?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #171522881](https://www.pivotaltracker.com/story/show/171522881).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
