### PR TITLE
Fixes saving referrer_user_id to new user

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,6 +109,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip',
         'country', 'language', 'addr_source',
 
+        // Source info:
+        'referrer_user_id',
+
         // External profiles:
         'mobilecommons_id', 'mobilecommons_status', 'facebook_id', 'google_id',
 

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -352,6 +352,7 @@ class UserTest extends BrowserKitTestCase
             'first_name' => 'Wilhelmina',
             'last_name' => 'Grubbly-Plank',
             'school_id' => '11122019',
+            'referrer_user_id' => '5e7aa023fdce2754fc584dea',
         ]);
 
         $this->assertResponseStatus(200);
@@ -362,6 +363,7 @@ class UserTest extends BrowserKitTestCase
             'last_name' => 'Grubbly-Plank',
             '_id' => $user->id,
             'school_id' => '11122019',
+            'referrer_user_id' => '5e7aa023fdce2754fc584dea',
         ]);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug in #1000, where passing along a `referrer_user_id` to a  `POST /users` request wasn't saving. I'm not exactly sure why we need this (e.g. `source_detail` isn't fillable), or why the test passed -- but it seems to do the trick.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🤷‍♂ ?

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
