### PR TITLE
Transforming causes obj to array in the getter

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -732,7 +732,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function getCausesAttribute($value)
     {
-        return ! empty($value) ? $value : [];
+        return ! empty($value) ? collect($value)->values()->all() : [];
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -735,7 +735,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         if (empty($value)) {
             return [];
         }
-        
+
         // Fix formatting issue where some causes were saved as indexed objects
         // (e.g. {0: "animal_welfare", 1: "bullying"}) instead of an array.
         // Context: https://www.pivotaltracker.com/story/show/172005082

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -732,7 +732,14 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function getCausesAttribute($value)
     {
-        return ! empty($value) ? collect($value)->values()->all() : [];
+        if (empty($value)) {
+            return [];
+        }
+        
+        // Fix formatting issue where some causes were saved as indexed objects
+        // (e.g. {0: "animal_welfare", 1: "bullying"}) instead of an array.
+        // Context: https://www.pivotaltracker.com/story/show/172005082
+        return collect($value)->values()->all();
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request updates the causes getter method to transform the causes a user inputs from an object to an array. Now that we are pulling these via graphql, we need the data to be consistent across applications!

### How should this be reviewed?

👀 

### Any background context you want to provide?

I originally implemented this fix [in graphql](https://github.com/DoSomething/graphql/pull/210/files), but this feels like a better place to do it (thanks for the suggestions @mendelB) since we are going to use the causes in Aurora amongst other things. 

### Relevant tickets

References [Pivotal # 172005166](https://www.pivotaltracker.com/story/show/172005166).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
