### PR TITLE
Adds Causes Setter and helper mutator

### DIFF
--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -34,7 +34,9 @@ class CauseUpdateController extends Controller
             abort(404, 'That cause does not exist.');
         }
 
-        $user->push('causes', $cause, true);
+        $user->addCause($cause);
+
+        $user->save();
 
         return $this->item($user);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -760,12 +760,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setCausesAttribute($value)
     {
-        // convert causes object to an array
-        if (array_has($this->attributes, 'causes')) {
-            $this->attributes['causes'] = collect($this->attributes['causes'])->values()->all();
-        }
-
-        // Set de-duped array as causes array
+        // Convert causes to an array and de-dupe
         $this->attributes['causes'] = array_values(array_unique($value));
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -743,6 +743,33 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Add the given cause to the user's array of causes if it is not already there.
+     *
+     * @param string $cause
+     */
+    public function addCause($cause)
+    {
+        // Add the new cause to the existing array of causes
+        $this->causes = array_merge($this->causes ?: [], [$cause]);
+    }
+
+    /**
+     * Mutator to ensure causes attribute is the correct data type.
+     *
+     * @param array $value
+     */
+    public function setCausesAttribute($value)
+    {
+        // convert causes object to an array
+        if (array_has($this->attributes, 'causes')) {
+            $this->attributes['causes'] = collect($this->attributes['causes'])->values()->all();
+        }
+
+        // Set de-duped array as causes array
+        $this->attributes['causes'] = array_values(array_unique($value));
+    }
+
+    /**
      * Accessor for the `school_id_preview` attribute.
      *
      * @return string


### PR DESCRIPTION

### What's this PR do?

This pull request adds a setter for our Causes attribute that changes the attribute to an array and dedupes the contents.

Also adding a mutator to handle adding new causes and updates the cause update controller to account for the changes in expected data types. 

### How should this be reviewed?

Make sure all the additions make sense to work with the getter and covers all edge cases with this short term fix!

### Any background context you want to provide?

We updated the getter in #1003 and now we need to handle setting our causes as well!

### Relevant tickets

References [Pivotal # 172005166](https://www.pivotaltracker.com/story/show/172005166).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
