### PR TITLE
Adds new values for voter_registration_status

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -67,7 +67,11 @@ class Registrar
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
             'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',
-            'voter_registration_status' => 'nullable|in:uncertain,ineligible,unregistered,confirmed,registration_complete',
+            /**
+             * Includes current values sent from Rock The Vote import, as well as older values for
+             * backwards compatability.
+             */
+            'voter_registration_status' => 'nullable|in:uncertain,ineligible,unregistered,confirmed,registration_complete,rejected,under-18,step-1,step-2,step-3,step-4',
             'causes.*' => 'in:animal_welfare,bullying,education,environment,gender_rights_equality,homelessness_poverty,immigration_refugees,lgbtq_rights_equality,mental_health,physical_health,racial_justice_equity,sexual_harassment_assault',
         ];
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the validation rule for `voter_registration_status` with the new values we'll be passing from Chompy, once https://github.com/DoSomething/chompy/pull/153 is deployed to production.

### How should this be reviewed?

👀 

### Any background context you want to provide?

@DFurnes @katiecrane -- Do you think we should we be sending over these values with underscores (`step_1`) instead of hyphens (`step-1`) to keep Northstar values looking consistent?

 Rogue already saves hyphenated status values like `complete-OVR`, but I can see we're using underscores for cause values too -- would have guessed we'd be using hyphens though per what seems be our normal standard in other apps..

### Relevant tickets

References [Pivotal #171737617](https://www.pivotaltracker.com/story/show/171737617).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
