### PR TITLE
Adds a "general" SMS subscription topic

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -63,7 +63,7 @@ class Registrar
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
             'sms_status' => 'nullable|in:active,less,stop,undeliverable,unknown,pending',
             'sms_paused' => 'boolean',
-            'sms_subscription_topics.*' => 'in:voting',
+            'sms_subscription_topics.*' => 'in:general,voting',
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
             'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -543,11 +543,15 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'last_authenticated_at' => iso8601($this->last_authenticated_at), // TODO: Update Blink to just accept timestamp.
             'updated_at' => iso8601($this->updated_at), // TODO: Update Blink to just accept timestamp.
             'created_at' => iso8601($this->created_at), // TODO: Update Blink to just accept timestamp.
+            // Email subscription topics:
             'news_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('news', $this->email_subscription_topics) : false,
             'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('community', $this->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
+            // SMS subscription topics:
+            'general_sms_subscription_status' => isset($this->sms_subscription_topics) ? in_array('general', $this->sms_subscription_topics) : false,
             'voting_sms_subscription_status' => isset($this->sms_subscription_topics) ? in_array('voting', $this->sms_subscription_topics) : false,
+            // Causes:
             'animal_welfare' => in_array('animal_welfare', $this->causes) ? true : false,
             'bullying' => in_array('bullying', $this->causes) ? true : false,
             'education' => in_array('education', $this->causes) ? true : false,
@@ -560,6 +564,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'physical_health' => in_array('physical_health', $this->causes) ? true : false,
             'racial_justice_equity' => in_array('racial_justice_equity', $this->causes) ? true : false,
             'sexual_harassment_assault' => in_array('sexual_harassment_assault', $this->causes) ? true : false,
+            // Voting plan:
             'voting_plan_status' => $this->voting_plan_status,
             'voting_plan_method_of_transport' => $this->voting_plan_method_of_transport,
             'voting_plan_time_of_day' => $this->voting_plan_time_of_day,

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -316,7 +316,7 @@ PUT /v1/users/drupal_id/<drupal_id>
   role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
-  sms_subscription_topics: Array; // Valid values: 'voting'
+  sms_subscription_topics: Array; // Valid values: 'general', 'voting'
   email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
   email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community'
 

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -155,7 +155,7 @@ Either a mobile number or email is required.
   interests: String, Array; // CSV values or array will be appended to existing interests
   sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
-  sms_subscription_topics: Array; // Valid values: 'voting'
+  sms_subscription_topics: Array; // Valid values: 'general', voting'
   email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
   email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community'
   source: String; // Immutable. Will only be set on new records.

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -50,6 +50,7 @@ class UserModelTest extends BrowserKitTestCase
             'lifestyle_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('lifestyle', $user->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('community', $user->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('scholarships', $user->email_subscription_topics) : false,
+            'general_sms_subscription_status' => isset($user->sms_subscription_topics) ? in_array('general', $user->sms_subscription_topics) : false,
             'voting_sms_subscription_status' => isset($user->sms_subscription_topics) ? in_array('voting', $user->sms_subscription_topics) : false,
             'animal_welfare' => true,
             'bullying' => false,


### PR DESCRIPTION
### What's this PR do?

This pull request adds `general` to the list of valid SMS subscription topics, in addition to `voting` (added in #998). 

### How should this be reviewed?

👀 

### Any background context you want to provide?

This will be used to better segment users who may only want to receive SMS broadcasts about voting. The [SMS Subscription Topics one-pager](https://docs.google.com/document/d/1Ir5BYkyBp1J3izShBvk51B-JQZiVif1G9XtiN_FR5AM/edit?usp=sharing) goes into details about how this will be used, if you're interested to know.

Next up for a future PR: give users the `general` and `voting` SMS subscription topics by default if their `sms_status` is created/changed to `active` or `less`. Opened this as-is to keep things easier to review.

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
