### PR TITLE
Set default SMS subscription topics

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -725,7 +725,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setSmsSubscriptionTopicsAttribute($value)
     {
-        // Set de-duped array as sms_subscription_topics
+        if (! is_array($value)) {
+            $value = [$value];
+        }
+
+        // Set de-duped array as sms_subscription_topics.
         $this->attributes['sms_subscription_topics'] = array_values(array_unique($value));
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -246,7 +246,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @return bool
      */
-    public function getIsSmsSubscribedAttribute()
+    public function isSmsSubscribed()
     {
         return isset($this->sms_status) && self::isSubscribedSmsStatus($this->sms_status);
     }
@@ -256,7 +256,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @return bool
      */
-    public function getHasSmsSubscriptionTopicsAttribute()
+    public function hasSmsSubscriptionTopics()
     {
         return isset($this->sms_subscription_topics) && count($this->sms_subscription_topics);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -248,7 +248,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function getIsSmsSubscribedAttribute()
     {
-        return isset($user->sms_status) && self::isSmsSubscribedStatus($user->sms_status);
+        return isset($this->sms_status) && self::isSubscribedSmsStatus($this->sms_status);
     }
 
     /**
@@ -258,7 +258,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function getHasSmsSubscriptionTopicsAttribute()
     {
-        return isset($user->sms_subscription_topics) && count($user->sms_subscription_topics);
+        return isset($this->sms_subscription_topics) && count($this->sms_subscription_topics);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -214,6 +214,33 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
+     * Constants for SMS subscriptions.
+     */
+    const DEFAULT_SMS_SUBSCRIPTION_TOPICS = ['general', 'voting'];
+    const SUBSCRIBED_SMS_STATUSES = ['active', 'less'];
+    const UNSUBSCRIBED_SMS_STATUSES = ['stop', 'undeliverable'];
+
+    /**
+     * Whether user has a subscribed SMS status.
+     *
+     * @return boolean
+     */
+    public function getIsSmsSubscribedAttribute()
+    {
+        return isset($user->sms_status) && in_array($user->sms_status, SUBSCRIBED_SMS_STATUSES);
+    }
+
+    /**
+     * Whether user has any SMS subscription topics.
+     *
+     * @return boolean
+     */
+    public function getHasSmsSubscriptionTopics()
+    {
+        return isset($user->sms_subscription_topics) && count($user->sms_subscription_topics);
+    }
+
+    /**
      * Computed last initial field, for public profiles.
      *
      * @return string

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -214,54 +214,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
-     * Default SMS subscription topics to assign when user is created or updated with a subscribed
-     * SMS status and topics have not been provided.
-     */
-    const DEFAULT_SMS_SUBSCRIPTION_TOPICS = ['general', 'voting'];
-
-    /**
-     * Whether a SMS status value is a subscribed SMS status.
-     *
-     * @param string $smsStatusValue
-     * @return bool
-     */
-    public static function isSubscribedSmsStatus($smsStatusValue)
-    {
-        return in_array($smsStatusValue, ['active', 'less']);
-    }
-
-    /**
-     * Whether a SMS status value is a unsubscribed SMS status.
-     *
-     * @param string $smsStatusValue
-     * @return bool
-     */
-    public static function isUnsubscribedSmsStatus($smsStatusValue)
-    {
-        return in_array($smsStatusValue, ['stop', 'undeliverable']);
-    }
-
-    /**
-     * Whether user has a subscribed SMS status.
-     *
-     * @return bool
-     */
-    public function isSmsSubscribed()
-    {
-        return isset($this->sms_status) && self::isSubscribedSmsStatus($this->sms_status);
-    }
-
-    /**
-     * Whether user has any SMS subscription topics.
-     *
-     * @return bool
-     */
-    public function hasSmsSubscriptionTopics()
-    {
-        return isset($this->sms_subscription_topics) && count($this->sms_subscription_topics);
-    }
-
-    /**
      * Computed last initial field, for public profiles.
      *
      * @return string
@@ -775,6 +727,64 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     {
         // Set de-duped array as sms_subscription_topics.
         $this->attributes['sms_subscription_topics'] = array_values(array_unique($value ?: []));
+    }
+
+    /**
+     * Sets default SMS subscription topics.
+     */
+    public function addDefaultSmsSubscriptionTopics()
+    {
+        $this->sms_subscription_topics = ['general', 'voting'];
+    }
+
+    /**
+     * Sets default SMS subscription topics.
+     */
+    public function clearSmsSubscriptionTopics()
+    {
+        $this->sms_subscription_topics = [];
+    }
+
+    /**
+     * Whether a SMS status value is a subscribed SMS status.
+     *
+     * @param string $smsStatusValue
+     * @return bool
+     */
+    public static function isSubscribedSmsStatus($smsStatusValue)
+    {
+        return in_array($smsStatusValue, ['active', 'less']);
+    }
+
+    /**
+     * Whether a SMS status value is a unsubscribed SMS status.
+     *
+     * @param string $smsStatusValue
+     * @return bool
+     */
+    public static function isUnsubscribedSmsStatus($smsStatusValue)
+    {
+        return in_array($smsStatusValue, ['stop', 'undeliverable']);
+    }
+
+    /**
+     * Whether user has a subscribed SMS status.
+     *
+     * @return bool
+     */
+    public function isSmsSubscribed()
+    {
+        return isset($this->sms_status) && self::isSubscribedSmsStatus($this->sms_status);
+    }
+
+    /**
+     * Whether user has any SMS subscription topics.
+     *
+     * @return bool
+     */
+    public function hasSmsSubscriptionTopics()
+    {
+        return isset($this->sms_subscription_topics) && count($this->sms_subscription_topics);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -214,28 +214,47 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     ];
 
     /**
-     * Constants for SMS subscriptions.
+     * Default SMS subscription topics to assign when user is created or updated with a subscribed
+     * SMS status and topics have not been provided.
      */
     const DEFAULT_SMS_SUBSCRIPTION_TOPICS = ['general', 'voting'];
-    const SUBSCRIBED_SMS_STATUSES = ['active', 'less'];
-    const UNSUBSCRIBED_SMS_STATUSES = ['stop', 'undeliverable'];
+
+    /**
+     * Whether a SMS status value is a subscribed SMS status.
+     *
+     * @param string $smsStatusValue
+     * @return boolean
+     */
+    public static function isSmsSubscribedStatus($smsStatusValue) {
+        return in_array($smsStatusValue, ['active', 'less']);
+    }
+
+    /**
+     * Whether a SMS status value is a unsubscribed SMS status.
+     *
+     * @param string $smsStatusValue
+     * @return boolean
+     */
+    public static function isSmsUnsubscribedStatus($smsStatusValue) {
+        return in_array($smsStatusValue, ['stop', 'undeliverable']);
+    }
 
     /**
      * Whether user has a subscribed SMS status.
      *
-     * @return boolean
+     * @return bool
      */
     public function getIsSmsSubscribedAttribute()
     {
-        return isset($user->sms_status) && in_array($user->sms_status, SUBSCRIBED_SMS_STATUSES);
+        return isset($user->sms_status) && self::isSmsSubscribedStatus($user->sms_status);
     }
 
     /**
      * Whether user has any SMS subscription topics.
      *
-     * @return boolean
+     * @return bool
      */
-    public function getHasSmsSubscriptionTopics()
+    public function getHasSmsSubscriptionTopicsAttribute()
     {
         return isset($user->sms_subscription_topics) && count($user->sms_subscription_topics);
     }
@@ -753,7 +772,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function setSmsSubscriptionTopicsAttribute($value)
     {
         // Set de-duped array as sms_subscription_topics.
-        $this->attributes['sms_subscription_topics'] = array_values(array_unique($value ? $value : []));
+        $this->attributes['sms_subscription_topics'] = array_values(array_unique($value ?: []));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -223,9 +223,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * Whether a SMS status value is a subscribed SMS status.
      *
      * @param string $smsStatusValue
-     * @return boolean
+     * @return bool
      */
-    public static function isSmsSubscribedStatus($smsStatusValue) {
+    public static function isSmsSubscribedStatus($smsStatusValue)
+    {
         return in_array($smsStatusValue, ['active', 'less']);
     }
 
@@ -233,9 +234,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * Whether a SMS status value is a unsubscribed SMS status.
      *
      * @param string $smsStatusValue
-     * @return boolean
+     * @return bool
      */
-    public static function isSmsUnsubscribedStatus($smsStatusValue) {
+    public static function isSmsUnsubscribedStatus($smsStatusValue)
+    {
         return in_array($smsStatusValue, ['stop', 'undeliverable']);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -236,7 +236,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @param string $smsStatusValue
      * @return bool
      */
-    public static function isSmsUnsubscribedStatus($smsStatusValue)
+    public static function isUnsubscribedSmsStatus($smsStatusValue)
     {
         return in_array($smsStatusValue, ['stop', 'undeliverable']);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -725,12 +725,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function setSmsSubscriptionTopicsAttribute($value)
     {
-        if (! is_array($value)) {
-            $value = [$value];
-        }
-
         // Set de-duped array as sms_subscription_topics.
-        $this->attributes['sms_subscription_topics'] = array_values(array_unique($value));
+        $this->attributes['sms_subscription_topics'] = array_values(array_unique($value ? $value : []));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -225,7 +225,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @param string $smsStatusValue
      * @return bool
      */
-    public static function isSmsSubscribedStatus($smsStatusValue)
+    public static function isSubscribedSmsStatus($smsStatusValue)
     {
         return in_array($smsStatusValue, ['active', 'less']);
     }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -23,7 +23,7 @@ class UserObserver
         }
 
         // Populate default topics if subscribing to SMS without providing any topics.
-        if ($user->is_sms_subscribed && ! $user->has_sms_subscription_topics) {
+        if ($user->isSmsSubscribed() && ! $user->hasSmsSubscriptionTopics()) {
             $user->sms_subscription_topics = User::DEFAULT_SMS_SUBSCRIPTION_TOPICS;
         }
 
@@ -82,7 +82,7 @@ class UserObserver
             if (User::isUnsubscribedSmsStatus($changed['sms_status'])) {
                 $user->sms_subscription_topics = [];
             // If resubscribing and not adding topics, add the default topics if user has none.
-            } elseif (User::isSubscribedSmsStatus($changed['sms_status']) && ! isset($changed['sms_subscription_topics']) && ! $user->has_sms_subscription_topics) {
+            } elseif (User::isSubscribedSmsStatus($changed['sms_status']) && ! isset($changed['sms_subscription_topics']) && ! $user->hasSmsSubscriptionTopics()) {
                 $user->sms_subscription_topics = User::DEFAULT_SMS_SUBSCRIPTION_TOPICS;
             }
         }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -22,9 +22,9 @@ class UserObserver
             $user->email_subscription_status = true;
         }
 
-        // Populate default topics if subscribing to SMS without providing any topics.
+        // Populate default topics if subscribing to SMS without any topics provided.
         if ($user->isSmsSubscribed() && ! $user->hasSmsSubscriptionTopics()) {
-            $user->sms_subscription_topics = User::DEFAULT_SMS_SUBSCRIPTION_TOPICS;
+            $user->addDefaultSmsSubscriptionTopics();
         }
 
         // Set source automatically if not provided.
@@ -80,10 +80,10 @@ class UserObserver
              * isn't a need to change sms_status if an unsubscribed user adds a SMS topic.
              */
             if (User::isUnsubscribedSmsStatus($changed['sms_status'])) {
-                $user->sms_subscription_topics = [];
+                $user->clearSmsSubscriptionTopics();
             // If resubscribing and not adding topics, add the default topics if user has none.
             } elseif (User::isSubscribedSmsStatus($changed['sms_status']) && ! isset($changed['sms_subscription_topics']) && ! $user->hasSmsSubscriptionTopics()) {
-                $user->sms_subscription_topics = User::DEFAULT_SMS_SUBSCRIPTION_TOPICS;
+                $user->addDefaultSmsSubscriptionTopics();
             }
         }
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -9,9 +9,6 @@ use Northstar\Jobs\DeleteUserFromOtherServices;
 
 class UserObserver
 {
-    public static $subscribedSmsStatuses = ['active', 'less'];
-    public static $defaultSmsSubscriptionTopics = ['general', 'voting'];
-
     /**
      * Handle the User "creating" event.
      *
@@ -82,10 +79,10 @@ class UserObserver
              * Note: We don't allow users to set their own SMS subscription topics yet, so there
              * isn't a need to change sms_status if an unsubscribed user adds a SMS topic.
              */
-            if (in_array($changed['sms_status'], User::UNSUBSCRIBED_SMS_STATUSES)) {
+            if (User::isUnsubscribedSmsStatus($changed['sms_status'])) {
                 $user->sms_subscription_topics = [];
             // If resubscribing and not adding topics, add the default topics if user has none.
-            } elseif (in_array($changed['sms_status'], User::SUBSCRIBED_SMS_STATUSES) && ! isset($changed['sms_subscription_topics']) && ! $user->has_sms_subscription_topics) {
+            } elseif (User::isSubscribedSmsStatus($changed['sms_status']) && ! isset($changed['sms_subscription_topics']) && ! $user->has_sms_subscription_topics) {
                 $user->sms_subscription_topics = User::DEFAULT_SMS_SUBSCRIPTION_TOPICS;
             }
         }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -84,10 +84,7 @@ class UserObserver
              */
             if (in_array($changed['sms_status'], ['stop', 'undeliverable'])) {
                 $user->sms_subscription_topics = [];
-            /**
-             * If resubscribing and not adding topics, add the default topics if none provided.
-             * @TODO: Check if topics were changed, don't clear topics if changing from less to active.
-             */
+            // If resubscribing and not adding topics, add the default topics if none provided.
             } elseif (in_array($changed['sms_status'], static::$subscribedSmsStatuses) && ! isset($changed['sms_subscription_topics'])) {
                 // Don't update if already set, e.g. status changes from less to active
                 $hasSmsSubscriptionTopics = isset($user->sms_subscription_topics) && count($user->sms_subscription_topics);

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -72,10 +72,9 @@ class UserObserver
             $user->email_subscription_status = true;
         }
 
-
         if (isset($changed['sms_status'])) {
             $updatedSmsStatus = $changed['sms_status'];
-            info('Changing status: ' . $updatedSmsStatus);
+            info('Changing status: '.$updatedSmsStatus);
 
             $unsubscribedStatuses = ['stop', 'undeliverable'];
 
@@ -84,7 +83,7 @@ class UserObserver
              *
              * Note: We don't allow users to set their own SMS subscription topics yet, so there
              * isn't a need to change sms_status if an unsubscribed user adds a SMS topic.
-              */
+             */
             if (in_array($updatedSmsStatus, $unsubscribedStatuses)) {
                 $user->sms_subscription_topics = [];
             /**

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -22,6 +22,11 @@ class UserObserver
             $user->email_subscription_status = true;
         }
 
+        // Populate default topics if subscribing to SMS without any topics provided.
+        if (isset($user->sms_status) && in_array($user->sms_status, ['active', 'less']) && ! isset($user->sms_subscription_topics)) {
+            $user->sms_subscription_topics = ['general', 'voting'];
+        }
+
         // Set source automatically if not provided.
         $user->source = $user->source ?: client_id();
     }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -59,6 +59,13 @@ $factory->state(Northstar\Models\User::class, 'sms-subscribed', function (Faker\
     ];
 });
 
+$factory->state(Northstar\Models\User::class, 'sms-unsubscribed', function (Faker\Generator $faker) {
+    return [
+        'sms_status' => 'stop',
+        'sms_subscription_topics' => null,
+    ];
+});
+
 $factory->defineAs(Northstar\Models\User::class, 'staff', function (Faker\Generator $faker) {
     $faker->addProvider(new FakerPhoneNumber($faker));
 

--- a/tests/Http/MergeTest.php
+++ b/tests/Http/MergeTest.php
@@ -62,6 +62,7 @@ class MergeTest extends BrowserKitTestCase
             'mobilecommons_id' => $duplicate->mobilecommons_id,
             'sms_status' => $duplicate->sms_status,
             'drupal_id' => '1234567',
+            'sms_subscription_topics' => ['general', 'voting'],
         ]);
 
         // The "duplicate" user should have the duplicate fields removed.

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -140,4 +140,21 @@ class UserModelTest extends BrowserKitTestCase
         $this->assertFalse(isset($result['email_subscription_status']));
         $this->assertFalse(isset($result['unsubscribed']));
     }
+
+    public function addsDefaultSmsSubscriptionTopicsIfSubscribed()
+    {
+        // By default our factory creates with SMS status active or less.
+        $subscribedUser = factory(User::class)->create();
+
+        $this->assertEquals($subscribedUser->sms_subscription_topics, ['general', 'voting']);
+    }
+
+    public function addsEmptySmsSubscriptionTopicsIfUnsubscribed()
+    {
+        $unsubscribedUser = factory(User::class)->create([
+            'sms_status' => 'stop',
+        ]);
+
+        $this->assertEquals($subscribedUser->sms_subscription_topics, []);
+    }
 }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -146,7 +146,16 @@ class UserModelTest extends BrowserKitTestCase
         $user = factory(User::class)->create([
             'sms_status' => 'active',
         ]);
-        // @TODO: Why have you forsaken me
+
+        $this->assertTrue($user->is_sms_subscribed);
+    }
+
+    public function testIsSmsSubscribedisTrueIfSmsStatusIsLess()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => 'less',
+        ]);
+
         $this->assertTrue($user->is_sms_subscribed);
     }
 
@@ -166,6 +175,20 @@ class UserModelTest extends BrowserKitTestCase
         ]);
 
         $this->assertFalse($user->is_sms_subscribed);
+    }
+
+    public function testHasSmsSubscriptionTopicsisTrueIfTopicsExist()
+    {
+        $user = factory(User::class)->states('sms-subscribed')->create();
+
+        $this->assertTrue($user->has_sms_subscription_topics);
+    }
+
+    public function testHasSmsSubscriptionTopicsisFalseIfTopicsIsNull()
+    {
+        $user = factory(User::class)->states('sms-unsubscribed')->create();
+
+        $this->assertFalse($user->has_sms_subscription_topics);
     }
 
     public function addsDefaultSmsSubscriptionTopicsIfSubscribed()

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -141,6 +141,33 @@ class UserModelTest extends BrowserKitTestCase
         $this->assertFalse(isset($result['unsubscribed']));
     }
 
+    public function testIsSmsSubscribedisTrueIfSmsStatusIsActive()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => 'active',
+        ]);
+        // @TODO: Why have you forsaken me
+        //$this->assertTrue($user->is_sms_subscribed);
+    }
+
+    public function testIsSmsSubscribedisFalseIfSmsStatusIsNull()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => null,
+        ]);
+
+        $this->assertFalse($user->is_sms_subscribed);
+    }
+
+    public function testIsSmsSubscribedisFalseIfSmsStatusIsStop()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => 'stop',
+        ]);
+
+        $this->assertFalse($user->is_sms_subscribed);
+    }
+
     public function addsDefaultSmsSubscriptionTopicsIfSubscribed()
     {
         // By default our factory creates with SMS status active or less.

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -147,7 +147,7 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => 'active',
         ]);
         // @TODO: Why have you forsaken me
-        //$this->assertTrue($user->is_sms_subscribed);
+        $this->assertTrue($user->is_sms_subscribed);
     }
 
     public function testIsSmsSubscribedisFalseIfSmsStatusIsNull()

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -157,4 +157,29 @@ class UserModelTest extends BrowserKitTestCase
 
         $this->assertEquals($subscribedUser->sms_subscription_topics, []);
     }
+
+    public function doesNotChangeSubscriptionTopicsIfExistsWhenChangingSubscribedStatus()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => 'less',
+            'sms_subscription_topics' => ['voting'],
+        ]);
+
+        $user->sms_status = 'active';
+        $user->save();
+
+        $this->assertEquals($user->sms_subscription_topics, ['voting']);
+    }
+
+    public function addsDefaultSmsSubscriptionTopicsIfChangingToSubscribed()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => 'stop',
+        ]);
+
+        $user->sms_status = 'active';
+        $user->save();
+
+        $this->assertEquals($user->sms_subscription_topics, ['general', 'voting']);
+    }
 }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -147,7 +147,7 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => 'active',
         ]);
 
-        $this->assertTrue($user->is_sms_subscribed);
+        $this->assertTrue($user->isSmsSubscribed());
     }
 
     public function testIsSmsSubscribedisTrueIfSmsStatusIsLess()
@@ -156,7 +156,7 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => 'less',
         ]);
 
-        $this->assertTrue($user->is_sms_subscribed);
+        $this->assertTrue($user->isSmsSubscribed());
     }
 
     public function testIsSmsSubscribedisFalseIfSmsStatusIsNull()
@@ -165,7 +165,7 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => null,
         ]);
 
-        $this->assertFalse($user->is_sms_subscribed);
+        $this->assertFalse($user->isSmsSubscribed());
     }
 
     public function testIsSmsSubscribedisFalseIfSmsStatusIsStop()
@@ -174,21 +174,21 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => 'stop',
         ]);
 
-        $this->assertFalse($user->is_sms_subscribed);
+        $this->assertFalse($user->isSmsSubscribed());
     }
 
     public function testHasSmsSubscriptionTopicsisTrueIfTopicsExist()
     {
         $user = factory(User::class)->states('sms-subscribed')->create();
 
-        $this->assertTrue($user->has_sms_subscription_topics);
+        $this->assertTrue($user->hasSmsSubscriptionTopics());
     }
 
     public function testHasSmsSubscriptionTopicsisFalseIfTopicsIsNull()
     {
         $user = factory(User::class)->states('sms-unsubscribed')->create();
 
-        $this->assertFalse($user->has_sms_subscription_topics);
+        $this->assertFalse($user->hasSmsSubscriptionTopics());
     }
 
     public function addsDefaultSmsSubscriptionTopicsIfSubscribed()


### PR DESCRIPTION
### What's this PR do?

This pull request adds the following changes: 

* Sets `general` and `topic` as the default values for `sms_subscription_topics` field if not provided when creating a user with a  subscribed `sms_status` value of `active` or `less`. 

* Sets `sms_subscription_topics` to empty if updating a user with an unsubscribed `sms_status` value of `stop` or `undeliverable`. 

* Sets default `sms_subscription_topics` as `general` and `topic` if updating a user's `sms_status` field to an subscribed value of `active` or `less` and user currently does not have any `sms_subscription_topics`


### How should this be reviewed?

👀 

### Any background context you want to provide?

I could not figure out how to get Aurora to stop from clearing the updated `sms_subscription_topics` when changing from unsubscribed to subscribed. To maintain sanity, I've removed it from the edit form and will open a PR accordingly.

### Relevant tickets

References [Pivotal #172209330](https://www.pivotaltracker.com/story/show/172209330).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
