### PR TITLE
Adds console command to set default SMS subscription topics

### DIFF
--- a/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
+++ b/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Northstar\Console\Commands;
+
+use Northstar\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class SetDefaultSmsSubscriptionTopics extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:default-sms-topics';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add "general" and "voting" SMS topics for each user who is subscribed to SMS.';
+
+    /**
+     * The number of users updated so far.
+     *
+     * @var string
+     */
+    protected $currentCount = 0;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Use low priority queue for these updates
+        config(['queue.jobs.users' => 'low']);
+
+        // Grab users who are subscribers and do not have topics set.
+        $query = (new User)->newQuery();
+        $query = $query->whereIn('sms_status', ['active', 'less', 'pending']);
+        $query = $query->where('sms_subscription_topics', null);
+
+        $totalCount = $query->count();
+
+        if ($totalCount === 0) {
+            $this->line('northstar:default-sms-topics - No users need updating.');
+
+            return;
+        }
+
+        $query->chunkById(200, function (Collection $users) use ($totalCount) {
+            $users->each(function (User $user) use ($totalCount) {
+                $user->sms_subscription_topics = ['general', 'voting'];
+                $user->save();
+
+                $this->line('northstar:default-sms-topics - User '.$user->id.' given "general" and "voting" topics.');
+            });
+
+            // Logging to track progress (may read over 100% at the end when there are less than 200 users in the last chunk)
+            $this->currentCount += 200;
+            $percentDone = ($this->currentCount / $totalCount) * 100;
+            $this->line('northstar:default-sms-topics - status update - '.$this->currentCount.'/'.$totalCount.' - '.$percentDone.'% done');
+        });
+
+        $this->line('northstar:default-sms-topics - Added "general" and "voting" to each appropriate user.');
+    }
+}

--- a/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
+++ b/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
@@ -66,8 +66,6 @@ class SetDefaultSmsSubscriptionTopics extends Command
             $users->each(function (User $user) use ($totalCount) {
                 $user->sms_subscription_topics = ['general', 'voting'];
                 $user->save();
-
-                $this->line('northstar:default-sms-topics - User '.$user->id.' given "general" and "voting" topics.');
             });
 
             // Logging to track progress (may read over 100% at the end when there are less than 200 users in the last chunk)


### PR DESCRIPTION
### What's this PR do?

This pull request follows #857 and #861 by example to add a `northstar:default-sms-topics` console command, used to populate the `sms_subscription_topics` with `general` and `voting` values for all users with `sms_status` equal to a subscribed value (`active`, `less`, and `pending`).

### How should this be reviewed?

👀 

### Any background context you want to provide?

We want to run this backfill before we start updating user SMS subscriptions via the Chompy Rock the Vote import (see https://github.com/DoSomething/chompy/pull/156) -- which may remove the `voting` topic from existing subscribers if they choose to opt-out of voting messaging from DS on the voter registration form (the checkbox is hidden on the RTV site until this backfill is done and the Chompy feature flag is removed to begin updating existing users' SMS preferences).

We'll also likely need to wait until we upgrade Laravel in #1006 to avoid database timeouts.

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
