### PR TITLE
Adds sms_subscription_topics to GET /v1/users/:id response

### DIFF
--- a/app/Http/Transformers/Legacy/UserTransformer.php
+++ b/app/Http/Transformers/Legacy/UserTransformer.php
@@ -87,6 +87,7 @@ class UserTransformer extends TransformerAbstract
         // SMS subscription status
         $response['sms_status'] = $user->sms_status;
         $response['sms_paused'] = (bool) $user->sms_paused;
+        $response['sms_subscription_topics'] = $user->sms_subscription_topics;
 
         if (Gate::allows('view-full-profile', $user)) {
             $response['last_accessed_at'] = iso8601($user->last_accessed_at);

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -152,7 +152,7 @@ class LegacyUserTest extends BrowserKitTestCase
         // Check that public & private profile fields are visible
         $this->seeJsonStructure([
             'data' => [
-                'id', 'email', 'first_name', 'last_name',
+                'id', 'email', 'first_name', 'last_name', 'sms_subscription_topics',
             ],
         ]);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `sms_subscription_topics` field added in #998, fixing the Chompy bug flagged in https://github.com/DoSomething/chompy/pull/157#discussion_r410443726.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

It'd be ideal to update Chompy's Gateway version to fix the bug, but we'd need to change all of the import jobs. This is a quick win and also future-proofs us should Gambit need access to this field (it's also in need of an update as it uses our [northstar-js package](http://github.com/dosomething/northstar-js), which also queries the v1 API)

### Relevant tickets

References [Pivotal #171848124](https://www.pivotaltracker.com/story/show/171848124).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
