### PR TITLE
Adds SMS status argument for SMS subscription topics backfill

### DIFF
--- a/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
+++ b/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
@@ -13,7 +13,7 @@ class SetDefaultSmsSubscriptionTopics extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:default-sms-topics {status}';
+    protected $signature = 'northstar:default-sms-topics {smsStatus}';
 
     /**
      * The console command description.
@@ -46,10 +46,10 @@ class SetDefaultSmsSubscriptionTopics extends Command
      */
     public function handle()
     {
-        $smsStatus = $this->argument('status');
+        $smsStatus = $this->argument('smsStatus');
 
         if (! in_array($smsStatus, ['active', 'less', 'pending'])) {
-            $this->line('northstar:default-sms-topics - Invalid status argument: '.$smsStatus);
+            $this->line('northstar:default-sms-topics - Invalid smsStatus argument "'.$smsStatus.'".');
 
             return;
         }
@@ -65,13 +65,13 @@ class SetDefaultSmsSubscriptionTopics extends Command
         $totalCount = $query->count();
 
         if ($totalCount === 0) {
-            $this->line('northstar:default-sms-topics - No users need updating.');
+            $this->line('northstar:default-sms-topics - No users with smsStatus "'.$smsStatus.'" need updating.');
 
             return;
         }
 
-        $query->chunkById(200, function (Collection $users) use ($totalCount) {
-            $users->each(function (User $user) use ($totalCount) {
+        $query->chunkById(200, function (Collection $users) use ($totalCount, $smsStatus) {
+            $users->each(function (User $user) use ($totalCount, $smsStatus) {
                 $user->sms_subscription_topics = ['general', 'voting'];
                 $user->save();
             });
@@ -79,9 +79,9 @@ class SetDefaultSmsSubscriptionTopics extends Command
             // Logging to track progress (may read over 100% at the end when there are less than 200 users in the last chunk)
             $this->currentCount += 200;
             $percentDone = ($this->currentCount / $totalCount) * 100;
-            $this->line('northstar:default-sms-topics - status update - '.$this->currentCount.'/'.$totalCount.' - '.$percentDone.'% done');
+            $this->line('northstar:default-sms-topics - smsStatus "'.$smsStatus.'" - '.$this->currentCount.'/'.$totalCount.' - '.$percentDone.'% done');
         });
 
-        $this->line('northstar:default-sms-topics - Added "general" and "voting" to each appropriate user.');
+        $this->line('northstar:default-sms-topics - Added "general" and "voting" to each appropriate user with smsStatus "'.$smsStatus.'".');
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request requires passing a `status` parameter to the `default-sms-topics` console command, and uses it to determine which users to backfill, instead of running the backfill on all users with all subscribed status values. 

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

The aim here is to get the backfill done for` active` values first, then `less` values. These backfills should hopefully complete within hours, whereas a `pending` backfill might take days.

### Relevant tickets

References [Pivotal #172425111](https://www.pivotaltracker.com/story/show/172425111).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
