### PR TITLE
Fixes an issue deserializing date-times before 1970.

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -3,6 +3,8 @@
 namespace Northstar\Models;
 
 use Carbon\Carbon;
+use MongoDB\BSON\UTCDateTime;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Database\Eloquent\Builder;
 use Jenssegers\Mongodb\Eloquent\Model as BaseModel;
 
@@ -140,5 +142,25 @@ class Model extends BaseModel
         $this->save($options);
 
         self::setEventDispatcher($dispatcher);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function asDateTime($value)
+    {
+        // Fixes an issue where 'jenssegers/laravel-mongodb' would incorrectly parse
+        // millisecond timestamps for dates before 1970 <https://git.io/JfIfu>:
+        if ($value instanceof UTCDateTime) {
+            $date = $value->toDateTime();
+
+            $seconds = $date->format('U');
+            $milliseconds = abs($date->format('v'));
+            $timestampMs = sprintf('%d%03d', $seconds, $milliseconds);
+
+            return Date::createFromTimestampMs($timestampMs);
+        }
+
+        return parent::asDateTime($value);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue where any users whose birthdates were before 1970 would not be able to load their profile – requests to `v2/users/{id}` would explode with a 500 error! 💣

When representing a date before [January 1st 1970](https://en.wikipedia.org/wiki/Unix_time), the UNIX timestamp is a negative number (e.g. August 8th 1965 turns into `-138844800`). So far, so good. The bug we're running into here is introduced when _milliseconds_ come into the picture...

For some reason, milliseconds (before 1970) are _also_ a negative number in PHP, so the package would [write the millisecond timestamp](https://github.com/jenssegers/laravel-mongodb/blob/master/src/Jenssegers/Mongodb/Eloquent/Model.php#L102) as `-138844800-324` (rather than `-138844800324`).

### How should this be reviewed?

I added a failing test test case for this bug in jenssegers/laravel-mongodb#2028. If that gets reviewed and merged, we can remove this overridden method on our own `Model` class.

### Any background context you want to provide?

I don't really understand why these dates have milliseconds on them at all, to be honest. My best guess is that was due to some sort of quirk either in this library or our application code once upon a time. We should probably write a quick script to clean these up sometime.

### Relevant tickets

References [Pivotal #172439494](https://www.pivotaltracker.com/story/show/172439494).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
