### PR TITLE
small VR prompt style updates

### DIFF
--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -7,14 +7,11 @@ const $ = require('jquery');
 
 function clickHandlerToggleContent(event) {
     const content = document.getElementById('voter-reg-cta');
-    const voterRegWrapper = document.getElementById('voter-reg-wrapper');
 
     if(event.target.value === 'unregistered') {
         content.classList.remove('hidden')
-        voterRegWrapper.classList.remove('form-item')
     } else {
         content.classList.add('hidden')
-        voterRegWrapper.classList.add('form-item')
     }
 
 }

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -7,11 +7,14 @@ const $ = require('jquery');
 
 function clickHandlerToggleContent(event) {
     const content = document.getElementById('voter-reg-cta');
+    const voterRegWrapper = document.getElementById('voter-reg-wrapper');
 
     if(event.target.value === 'unregistered') {
         content.classList.remove('hidden')
+        voterRegWrapper.classList.remove('form-item')
     } else {
         content.classList.add('hidden')
+        voterRegWrapper.classList.add('form-item')
     }
 
 }

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <div class="flex flex-wrap justify-between md:justify-start">
+        <div id="voter-reg-wrapper" class="form-item flex flex-wrap justify-between md:justify-start">
             <label for="voter_registration_status" class="field-label height-auto w-full">Are you registered to vote at your current address?</label>
             <div class="voter-reg-status w-1/5">
                 <label class="option -radio">

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -30,23 +30,23 @@
             </div>
         </div>
 
-        <div class="form-item flex flex-wrap justify-between md:justify-start">
+        <div class="flex flex-wrap justify-between md:justify-start">
             <label for="voter_registration_status" class="field-label height-auto w-full">Are you registered to vote at your current address?</label>
-            <div class="voter-reg-status form-item -reduced w-1/5">
+            <div class="voter-reg-status w-1/5">
                 <label class="option -radio">
                     <input type="radio" name="voter_registration_status" value="confirmed" {{ (old('voter_registration_status') ?: $user->voter_registration_status) === 'confirmed' ? 'checked' : '' }}>
                     <span class="option__indicator"></span>
                     <span>Yes</span>
                 </label>
             </div>
-            <div class="voter-reg-status form-item -reduced w-1/5">
+            <div class="voter-reg-status w-1/5">
                 <label class="option -radio">
                     <input type="radio" name="voter_registration_status" value="unregistered" {{ (old('voter_registration_status') ?: $user->voter_registration_status) === 'unregistered' ? 'checked' : '' }}>
                     <span class="option__indicator"></span>
                     <span>No</span>
                 </label>
             </div>
-            <div class="voter-reg-status form-item -reduced w-3/5 pr-0">
+            <div class="voter-reg-status w-3/5 pr-0">
                 <label class="option -radio">
                     <input type="radio" name="voter_registration_status" value="uncertain" {{ (old('voter_registration_status') ?: $user->voter_registration_status) === 'uncertain' ? 'checked' : '' }}>
                     <span class="option__indicator"></span>
@@ -55,7 +55,7 @@
             </div>
         </div>
 
-        <div id="voter-reg-cta" class="pb-4 hidden">
+        <div id="voter-reg-cta" class="form-item hidden">
             <p>Make your voice heard on the issues that matter to you. Take 2 minutes and 
                 <a id="voter-reg-link" target="_blank" rel="noopener noreferrer" href="https://register.rockthevote.com/registrants/new?partner=37187&email_address={{$user->email}}&home_zip_code={{$user->addr_zip}}&source=user:{{$user->id}},source:web,source_details:NewAccountCreationFlow">
                 register to vote at your current address!</a>

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <div id="voter-reg-wrapper" class="form-item flex flex-wrap justify-between md:justify-start">
+        <div class="form-item flex flex-wrap justify-between md:justify-start">
             <label for="voter_registration_status" class="field-label height-auto w-full">Are you registered to vote at your current address?</label>
             <div class="voter-reg-status w-1/5">
                 <label class="option -radio">
@@ -53,14 +53,13 @@
                     <span>I'm not sure</span>
                 </label>
             </div>
-        </div>
-
-        <div id="voter-reg-cta" class="form-item hidden">
-            <p>Make your voice heard on the issues that matter to you. Take 2 minutes and 
-                <a id="voter-reg-link" target="_blank" rel="noopener noreferrer" href="https://register.rockthevote.com/registrants/new?partner=37187&email_address={{$user->email}}&home_zip_code={{$user->addr_zip}}&source=user:{{$user->id}},source:web,source_details:NewAccountCreationFlow">
-                register to vote at your current address!</a>
-            </p>
-        </div>
+            <div id="voter-reg-cta" class="w-full hidden">
+                <p>Make your voice heard on the issues that matter to you. Take 2 minutes and 
+                    <a target="_blank" rel="noopener noreferrer" href="https://register.rockthevote.com/registrants/new?partner=37187&email_address={{$user->email}}&home_zip_code={{$user->addr_zip}}&source=user:{{$user->id}},source:web,source_details:NewAccountCreationFlow">
+                    register to vote at your current address!</a>
+                </p>
+            </div>
+        </div>        
 
         <div class="form-item">
             <p class="font-bold">What cause areas do you care about most?</p>


### PR DESCRIPTION
### What's this PR do?

This pull request cleans up some of the styling on the second step of the registration onboarding and specifically cleans up the spacing around the voter registration prompt!

### How should this be reviewed?

👀 

### Any background context you want to provide?
*spacing before:*
<img width="696" alt="Screen Shot 2020-04-23 at 10 38 12 AM" src="https://user-images.githubusercontent.com/15236023/80112083-b2af5600-854e-11ea-8d35-b2166df04d79.png">

<img width="702" alt="Screen Shot 2020-04-23 at 10 38 25 AM" src="https://user-images.githubusercontent.com/15236023/80112104-ba6efa80-854e-11ea-829a-020b894906f2.png">

*spacing after:*

<img width="645" alt="Screen Shot 2020-04-23 at 10 38 43 AM" src="https://user-images.githubusercontent.com/15236023/80112169-cd81ca80-854e-11ea-876f-1122364c14fe.png">

<img width="689" alt="Screen Shot 2020-04-23 at 10 38 52 AM" src="https://user-images.githubusercontent.com/15236023/80112187-d2df1500-854e-11ea-8714-a20916f16fc3.png">


### Relevant tickets

References [Pivotal # 172464993](https://www.pivotaltracker.com/story/show/172464993).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
