### PR TITLE
Cause preference errors

### DIFF
--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -49,7 +49,13 @@ class CauseUpdateController extends Controller
             abort(404, 'That cause does not exist.');
         }
 
-        $user->pull('causes', $cause);
+        $causesArray = $user->causes;
+
+        $causesArray->pull($cause);
+
+        $user->causes = $causesArray;
+
+        $user->save();
 
         return $this->item($user);
     }

--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -50,8 +50,7 @@ class CauseUpdateController extends Controller
         }
 
         $causesArray = $user->causes;
-
-        $causesArray->pull($cause);
+        collect($causesArray)->pull($cause);
 
         $user->causes = $causesArray;
 

--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -53,7 +53,7 @@ class CauseUpdateController extends Controller
         $causesArray = $user->causes;
 
         // reassigning it to be an array with the item removed
-        $user->causes = array_diff($causesArray, array($cause));
+        $user->causes = array_diff($causesArray, [$cause]);
 
         $user->save();
 

--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -50,9 +50,8 @@ class CauseUpdateController extends Controller
         }
 
         $causesArray = $user->causes;
-        collect($causesArray)->pull($cause);
 
-        $user->causes = $causesArray;
+        $user->causes = array_diff($causesArray, array($cause));
 
         $user->save();
 

--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -49,10 +49,10 @@ class CauseUpdateController extends Controller
             abort(404, 'That cause does not exist.');
         }
 
-        //using the getter method to pull the array of causes rather than stored obj
+        // Using the getter method to pull the array of causes rather than stored obj
         $causesArray = $user->causes;
 
-        // reassigning it to be an array with the item removed
+        // Reassigning it to be an array with the item removed
         $user->causes = array_diff($causesArray, [$cause]);
 
         $user->save();

--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -49,8 +49,10 @@ class CauseUpdateController extends Controller
             abort(404, 'That cause does not exist.');
         }
 
+        //using the getter method to pull the array of causes rather than stored obj
         $causesArray = $user->causes;
 
+        // reassigning it to be an array with the item removed
         $user->causes = array_diff($causesArray, array($cause));
 
         $user->save();


### PR DESCRIPTION
### What's this PR do?

This pull request changes the approach for how we're removing the causes from a users interests.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This was an issue for users who had chosen causes when they initially signed up, but then attempted to remove them from their phoenix profile because the method we were using was expecting an array rather than an obj. This is part of some ongoing fixes to work around the underlying problem being created by the storage of causes as objects at sign up rather than the expected array. 

### Relevant tickets

References [Pivotal # 172363507](https://www.pivotaltracker.com/story/show/172363507).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
