### PR TITLE
Adds an additional prompt to the reg flow for uncertain voters

### DIFF
--- a/app/Http/Controllers/Web/ProfileAboutController.php
+++ b/app/Http/Controllers/Web/ProfileAboutController.php
@@ -38,7 +38,6 @@ class ProfileAboutController extends Controller
      */
     public function edit()
     {
-
         return view('profiles.about.edit', [
             'user' => auth()->guard('web')->user(),
             'causes1' => array_slice($this->causes, 0, count($this->causes) / 2),

--- a/app/Http/Controllers/Web/ProfileAboutController.php
+++ b/app/Http/Controllers/Web/ProfileAboutController.php
@@ -38,6 +38,7 @@ class ProfileAboutController extends Controller
      */
     public function edit()
     {
+
         return view('profiles.about.edit', [
             'user' => auth()->guard('web')->user(),
             'causes1' => array_slice($this->causes, 0, count($this->causes) / 2),

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -533,6 +533,19 @@ function init() {
         },
       });
     });
+    
+    $('#voter-reg-status-link').on('click', () => {
+      // Tracks clicking on the Check Registration Status Link in the Onboarding flow.
+      trackAnalyticsEvent({
+        metadata: {
+          adjective: 'register_not_sure',
+          category: 'onboarding',
+          noun: 'link_action',
+          target: 'link',
+          verb: 'clicked',
+        },
+      });
+    });
 
     // Check for and track validation errors returned from the backend after form submission.
     const $validationErrors = $('.validation-error');

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -12,14 +12,11 @@ function clickHandlerToggleContent(event) {
 
     if(value === 'unregistered') {
         unregisteredContent.classList.remove('hidden')
-        if(!uncertainContent.classList.contains('hidden')) {
-            uncertainContent.classList.add('hidden')
-        }
+        uncertainContent.classList.add('hidden')
+    
     } else if(value === 'uncertain') {
         uncertainContent.classList.remove('hidden')
-        if(!unregisteredContent.classList.contains('hidden')) {
-            unregisteredContent.classList.add('hidden')
-        }
+        unregisteredContent.classList.add('hidden')
     } else {
         unregisteredContent.classList.add('hidden');
         uncertainContent.classList.add('hidden');

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -6,23 +6,23 @@ const $ = require('jquery');
  */
 
 function clickHandlerToggleContent(event) {
-    const unRegisteredContent = document.getElementById('voter-reg-cta-unregistered');
-    const unCertainContent = document.getElementById('voter-reg-cta-uncertain');
+    const unregisteredContent = document.getElementById('voter-reg-cta-unregistered');
+    const uncertainContent = document.getElementById('voter-reg-cta-uncertain');
     const value = event.target.value
 
     if(value === 'unregistered') {
-        unRegisteredContent.classList.remove('hidden')
-        if(!unCertainContent.classList.contains('hidden')) {
-            unCertainContent.classList.add('hidden')
+        unregisteredContent.classList.remove('hidden')
+        if(!uncertainContent.classList.contains('hidden')) {
+            uncertainContent.classList.add('hidden')
         }
     } else if(value === 'uncertain') {
-        unCertainContent.classList.remove('hidden')
-        if(!unRegisteredContent.classList.contains('hidden')) {
-            unRegisteredContent.classList.add('hidden')
+        uncertainContent.classList.remove('hidden')
+        if(!unregisteredContent.classList.contains('hidden')) {
+            unregisteredContent.classList.add('hidden')
         }
     } else {
-        unRegisteredContent.classList.add('hidden');
-        unCertainContent.classList.add('hidden');
+        unregisteredContent.classList.add('hidden');
+        uncertainContent.classList.add('hidden');
     }
 
 }

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -13,7 +13,6 @@ function clickHandlerToggleContent(event) {
     if(value === 'unregistered') {
         unregisteredContent.classList.remove('hidden')
         uncertainContent.classList.add('hidden')
-    
     } else if(value === 'uncertain') {
         uncertainContent.classList.remove('hidden')
         unregisteredContent.classList.add('hidden')

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -6,12 +6,23 @@ const $ = require('jquery');
  */
 
 function clickHandlerToggleContent(event) {
-    const content = document.getElementById('voter-reg-cta');
+    const unRegisteredContent = document.getElementById('voter-reg-cta-unregistered');
+    const unCertainContent = document.getElementById('voter-reg-cta-uncertain');
+    const value = event.target.value
 
-    if(event.target.value === 'unregistered') {
-        content.classList.remove('hidden')
+    if(value === 'unregistered') {
+        unRegisteredContent.classList.remove('hidden')
+        if(!unCertainContent.classList.contains('hidden')) {
+            unCertainContent.classList.add('hidden')
+        }
+    } else if(value === 'uncertain') {
+        unCertainContent.classList.remove('hidden')
+        if(!unRegisteredContent.classList.contains('hidden')) {
+            unRegisteredContent.classList.add('hidden')
+        }
     } else {
-        content.classList.add('hidden')
+        unRegisteredContent.classList.add('hidden');
+        unCertainContent.classList.add('hidden');
     }
 
 }

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -62,7 +62,7 @@
             <div id="voter-reg-cta-uncertain" class="w-full hidden"> 
                 <p>
                     Not sure? We can help! Take 2 minutes and 
-                    <a target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
+                    <a id="voter-reg-status-link" target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
                     check your voter registration status with Rock The Vote!</a>
                 </p>
             </div>

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -53,10 +53,17 @@
                     <span>I'm not sure</span>
                 </label>
             </div>
-            <div id="voter-reg-cta" class="w-full hidden">
+            <div id="voter-reg-cta-unregistered" class="w-full hidden">
                 <p>Make your voice heard on the issues that matter to you. Take 2 minutes and 
                     <a id="voter-reg-link" target="_blank" rel="noopener noreferrer" href="https://register.rockthevote.com/registrants/new?partner=37187&email_address={{$user->email}}&home_zip_code={{$user->addr_zip}}&source=user:{{$user->id}},source:web,source_details:NewAccountCreationFlow">
                     register to vote at your current address!</a>
+                </p>
+            </div>
+            <div id="voter-reg-cta-uncertain" class="w-full hidden"> 
+                <p>
+                    Not sure? We can help! Take 2 minutes and 
+                    <a target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
+                    check your voter registration status with Rock The Vote</a>!
                 </p>
             </div>
         </div>        

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -63,7 +63,7 @@
                 <p>
                     Not sure? We can help! Take 2 minutes and 
                     <a target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
-                    check your voter registration status with Rock The Vote</a>!
+                    check your voter registration status with Rock The Vote!</a>
                 </p>
             </div>
         </div>        

--- a/tests/Http/ProfileAboutTest.php
+++ b/tests/Http/ProfileAboutTest.php
@@ -30,7 +30,7 @@ class ProfileAboutTest extends BrowserKitTestCase
             ->press('Next')
             ->seePageIs('/profile/subscriptions');
     }
-    
+
     /**
      * Test that users will not see any prompts if they select "Yes" on Voter Registration
      */

--- a/tests/Http/ProfileAboutTest.php
+++ b/tests/Http/ProfileAboutTest.php
@@ -66,7 +66,6 @@ class ProfileAboutTest extends BrowserKitTestCase
             ->select('confirmed', 'voter_registration_status')
             ->dontSee('Not sure? We can help! Take 2 minutes and check your voter registration status with Rock The Vote!')
             ->dontSee('Make your voice heard on the issues that matter to you. Take 2 minutes and register to vote at your current address!');
-
     }
 
     /**

--- a/tests/Http/ProfileAboutTest.php
+++ b/tests/Http/ProfileAboutTest.php
@@ -32,6 +32,44 @@ class ProfileAboutTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that users will see the Rock the Vote prompt if they select "No" on Voter Registration
+     */
+    public function testVoterRegistrationPrompt()
+    {
+        $user = $this->makeAuthWebUser();
+
+        $this->visit('/profile/about')
+            ->select('unregistered', 'voter_registration_status')
+            ->see('Make your voice heard on the issues that matter to you. Take 2 minutes and register to vote at your current address!');
+    }
+
+    /**
+     * Test that users will see the Check Registration Status prompt if they select "Not Sure" on Voter Registration
+     */
+    public function testVoterRegistrationStatusPrompt()
+    {
+        $user = $this->makeAuthWebUser();
+
+        $this->visit('/profile/about')
+            ->select('uncertain', 'voter_registration_status')
+            ->see('Not sure? We can help! Take 2 minutes and check your voter registration status with Rock The Vote!');
+    }
+
+    /**
+     * Test that users will not see any prompts if they select "Yes" on Voter Registration
+     */
+    public function testVoterRegistrationStatusPromptHidden()
+    {
+        $user = $this->makeAuthWebUser();
+
+        $this->visit('/profile/about')
+            ->select('confirmed', 'voter_registration_status')
+            ->dontSee('Not sure? We can help! Take 2 minutes and check your voter registration status with Rock The Vote!')
+            ->dontSee('Make your voice heard on the issues that matter to you. Take 2 minutes and register to vote at your current address!');
+
+    }
+
+    /**
      * Test that users can't update their birthday to an invalid date (backend validation)
      */
     public function testBirthdateError()

--- a/tests/Http/ProfileAboutTest.php
+++ b/tests/Http/ProfileAboutTest.php
@@ -30,31 +30,7 @@ class ProfileAboutTest extends BrowserKitTestCase
             ->press('Next')
             ->seePageIs('/profile/subscriptions');
     }
-
-    /**
-     * Test that users will see the Rock the Vote prompt if they select "No" on Voter Registration
-     */
-    public function testVoterRegistrationPrompt()
-    {
-        $user = $this->makeAuthWebUser();
-
-        $this->visit('/profile/about')
-            ->select('unregistered', 'voter_registration_status')
-            ->see('Make your voice heard on the issues that matter to you. Take 2 minutes and register to vote at your current address!');
-    }
-
-    /**
-     * Test that users will see the Check Registration Status prompt if they select "Not Sure" on Voter Registration
-     */
-    public function testVoterRegistrationStatusPrompt()
-    {
-        $user = $this->makeAuthWebUser();
-
-        $this->visit('/profile/about')
-            ->select('uncertain', 'voter_registration_status')
-            ->see('Not sure? We can help! Take 2 minutes and check your voter registration status with Rock The Vote!');
-    }
-
+    
     /**
      * Test that users will not see any prompts if they select "Yes" on Voter Registration
      */


### PR DESCRIPTION
### What's this PR do?

This pull request adds a different prompt for uncertain voters to the question during registration regarding their voter reg status. It also starts adding some test coverage for these prompts and adds analytics tracking to the new link.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We want to reach this portion of our new members!

I initially added test coverage for all 3 scenarios of voter registration options being selected, but ran into an issue with not being able to account for run time functionality with Laravel. ([see slack thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1590508302008300) and commit removing the tests a7dd996)

We decided to reduce scope creep for this work, but added a [collective icebox ticket](https://www.pivotaltracker.com/story/show/173020906) for adding support in Northstar for this kind of testing in the future. 

![uncertainvoterregprompt](https://user-images.githubusercontent.com/15236023/82936172-2f718d80-9f5c-11ea-8e1f-ec5146fbc988.gif)

### Relevant tickets

References [Pivotal # 172848257](https://www.pivotaltracker.com/story/show/172848257).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
