### PR TITLE
Store referrer_user_id on the User instead of source_details

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -233,6 +233,11 @@ class Registrar
         }
 
         $user->setSource(null, $sourceDetail ? stringify_object($sourceDetail) : null);
+
+        if (session('referrer_user_id')) {
+            $user->referrer_user_id = session('referrer_user_id');
+        }
+
         // Set the user's country code by Fastly geo-location header.
         $user->country = country_code();
         // Set the user's zip code by Fastly geo-location header.

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -67,14 +67,15 @@ class AuthController extends Controller
                 'title' => request()->query('title', trans('auth.get_started.create_account')),
                 'callToAction' => request()->query('callToAction', trans('auth.get_started.call_to_action')),
                 'coverImage' => request()->query('coverImage', asset('members.jpg')),
-                // Store any provided UTMs, Referrer User ID, or Contentful ID for user's source_detail:
+                // Store any provided UTMs or Contentful ID for user's source_detail:
                 'source_detail' => array_filter([
                     'contentful_id' => request()->query('contentful_id'),
-                    'referrer_user_id' => request()->query('referrer_user_id'),
                     'utm_source' => request()->query('utm_source'),
                     'utm_medium' => request()->query('utm_medium'),
                     'utm_campaign' => request()->query('utm_campaign'),
                 ]),
+                // Store the provided Referrer User ID for user's referrer_user_id field:
+                'referrer_user_id' => request()->query('referrer_user_id'),
             ]);
 
             // Optionally, we can override the default authorization page using `?mode=login`.

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -198,6 +198,21 @@ class WebAuthenticationTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that a referrar_user_id in session is attached to the registering user.
+     */
+    public function testRegisterBetaWithReferrerUserId()
+    {
+        // Mock a session for the user with ?referrer_user_id=x param, indicating a referred user.
+        $this->withSession(['referrer_user_id' => '123'])->registerUpdated();
+
+        $this->seeIsAuthenticated('web');
+
+        $user = auth()->user();
+
+        $this->assertEquals('123', $user->referrer_user_id);
+    }
+
+    /**
      * Test that users get feature_flags values when tests are on.
      */
     public function testRegisterBetaWithFeatureFlagsTest()

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -198,7 +198,7 @@ class WebAuthenticationTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that a referrar_user_id in session is attached to the registering user.
+     * Test that a referrer_user_id in session is attached to the registering user.
      */
     public function testRegisterBetaWithReferrerUserId()
     {


### PR DESCRIPTION
### What's this PR do?

This pull request stores incoming auth requests with `?referrer_user_id` query params in the session directly (not nested in the `source_detail`), then sets the registring user's `referrer_user_id` field to this value.

### How should this be reviewed?
👀 

### Any background context you want to provide?
- If we add more fields to the top level, it could be nice to nest them under one session key and assign them to the user more elegantly instead of individually, but figured for this one field this works fine. (`source_detail` contains it's own mechanics so they definitely can't be grouped together).
- I asked a question [in Slack](https://dosomething.slack.com/archives/CUQMU4Q6B/p1593023731003100) about testing the session storage part of this flow since it doesn't look like we have anything set up yet. For now, I've at least added the applicable test to the `WebAuthenticationTest` for the Registrar's hand in this.

### Relevant tickets

References [Pivotal #172981900](https://www.pivotaltracker.com/story/show/172981900).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.

![Screen Shot 2020-06-24 at 2 49 08 PM](https://user-images.githubusercontent.com/12417657/85615301-07904b00-b62a-11ea-8d57-6e3d1dde49b4.png)
