### PR TITLE
Adds Mutator to Ensure that Null is not Returned When User Re-Subscribes

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -725,7 +725,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function getEmailSubscriptionTopicsAttribute($value)
     {
-        //Set empty value equal to array of email_subscription_topics
+        //Ensure we always return an array value for the email_subscription_topics attribute.
         return empty($value) ? [] : $value;
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -719,6 +719,17 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Mutator to ensure null is not returned when user re-subscribes.
+     * 
+     * @param array $value
+     */
+    public function getEmailSubscriptionTopicsAttribute($value)
+    {   
+        //Set empty value equal to array of email_subscription_topics
+        return empty($value) ? [] : $value;
+    }
+
+    /**
      * Mutator to ensure no duplicates in the SMS topics array.
      *
      * @param array $value

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -720,11 +720,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     /**
      * Mutator to ensure null is not returned when user re-subscribes.
-     * 
+     *
      * @param array $value
      */
     public function getEmailSubscriptionTopicsAttribute($value)
-    {   
+    {
         //Set empty value equal to array of email_subscription_topics
         return empty($value) ? [] : $value;
     }


### PR DESCRIPTION
### What's this PR do?

This pull request is a bug fix to a problem we are having when global unsubscribe link is clicked. This commit fixes the "null" error returned when a user attempts to re-subscribe.

### How should this be reviewed?

Is this function formatted correctly? Are the comments fitting?

### Any background context you want to provide?

See [thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1593187616006000) 

### Relevant tickets

References [Pivotal #172444740](https://www.pivotaltracker.com/story/show/172444740).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
