### PR TITLE
Adding a voter reg prompt for members who say "yes"

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -534,8 +534,8 @@ function init() {
       });
     });
     
-    $('#voter-reg-status-link').on('click', () => {
-      // Tracks clicking on the Check Registration Status Link in the Onboarding flow.
+    $('#voter-reg-status-link-uncertain').on('click', () => {
+      // Tracks clicking on the Check Registration Status Link in the Onboarding flow for uncertain users.
       trackAnalyticsEvent({
         metadata: {
           adjective: 'register_not_sure',

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -6,19 +6,27 @@ const $ = require('jquery');
  */
 
 function clickHandlerToggleContent(event) {
-    const unregisteredContent = document.getElementById('voter-reg-cta-unregistered');
+    const confirmedContent = document.getElementById('voter-reg-cta-confirmed');
     const uncertainContent = document.getElementById('voter-reg-cta-uncertain');
+    const unregisteredContent = document.getElementById('voter-reg-cta-unregistered');
     const value = event.target.value
 
     if(value === 'unregistered') {
         unregisteredContent.classList.remove('hidden')
         uncertainContent.classList.add('hidden')
+        confirmedContent.classList.add('hidden')
     } else if(value === 'uncertain') {
         uncertainContent.classList.remove('hidden')
         unregisteredContent.classList.add('hidden')
+        confirmedContent.classList.add('hidden')
+    } else if(value === 'confirmed') {
+        confirmedContent.classList.remove('hidden')
+        unregisteredContent.classList.add('hidden')
+        uncertainContent.classList.add('hidden')
     } else {
         unregisteredContent.classList.add('hidden');
         uncertainContent.classList.add('hidden');
+        confirmedContent.classList.add('hidden')
     }
 
 }

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -62,8 +62,15 @@
             <div id="voter-reg-cta-uncertain" class="w-full hidden"> 
                 <p>
                     Not sure? We can help! Take 2 minutes and 
-                    <a id="voter-reg-status-link" target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
+                    <a id="voter-reg-status-link-uncertain" target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
                     check your voter registration status with Rock The Vote!</a>
+                </p>
+            </div>
+             <div id="voter-reg-cta-confirmed" class="w-full hidden"> 
+                <p>
+                    Moved recently? Haven't voted before or in the past few years? 
+                    <a id="voter-reg-status-link-confirmed" target="_blank" rel="noopener noreferrer" href="https://am-i-registered-to-vote.org/dosomething/" >
+                    Check to make sure you’re still on the voting rolls!</a>
                 </p>
             </div>
         </div>        


### PR DESCRIPTION
# What's this PR do?

This pull request adds a prompt for users who choose the "confirmed" option in response to whether they are registered to vote while they fill out member profile information.

### How should this be reviewed? 

Is there a way to simplify the JS? I went to for the easiest way forward, which feels a little repetitive but simple.

### Any background context you want to provide?

We've seen positive numbers from the other two prompts that have been added to the membership flow!

Large Screen
![Screen Shot 2020-07-06 at 1 31 00 PM](https://user-images.githubusercontent.com/15236023/86623726-06e3a700-bf90-11ea-83e0-32d8b5d7df41.png)

Medium Screen
![Screen Shot 2020-07-06 at 1 31 19 PM](https://user-images.githubusercontent.com/15236023/86623733-0b0fc480-bf90-11ea-9a85-1bb2403f8bff.png)


![Kapture 2020-07-06 at 13 33 12](https://user-images.githubusercontent.com/15236023/86623748-0fd47880-bf90-11ea-9580-baa84c21e23d.gif)


### Relevant tickets

References [Pivotal # 173282289](https://www.pivotaltracker.com/story/show/173282289).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
