### PR TITLE
Adds analytics event for confirmed users

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -547,6 +547,20 @@ function init() {
       });
     });
 
+    $('#voter-reg-status-link-confirmed').on('click', () => {
+      // Tracks clicking on the Check Registration Status Link in the Onboarding flow for confirmed users.
+      trackAnalyticsEvent({
+        metadata: {
+          adjective: 'double_check_voter_registration',
+          category: 'onboarding',
+          noun: 'link_action',
+          target: 'link',
+          verb: 'clicked',
+          label: 'voter_registration',
+        },
+      });
+    });
+
     // Check for and track validation errors returned from the backend after form submission.
     const $validationErrors = $('.validation-error');
     if ($validationErrors && $validationErrors.length) {

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -556,7 +556,6 @@ function init() {
           noun: 'link_action',
           target: 'link',
           verb: 'clicked',
-          label: 'voter_registration',
         },
       });
     });


### PR DESCRIPTION
### What's this PR do?

This pull request is a follow up to #1030 and adds analytics tracking for a user who chooses "yes" as their voter registration status.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This prompt is serving as a reminder for users to double check their status, hence the naming choice.

### Relevant tickets

References [Pivotal # 173282289](https://www.pivotaltracker.com/story/show/173282289).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
