### PR TITLE
Use `addTopic` Helper in Northstar When Adding One Email Subscription Topic

### DIFF
--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -36,6 +36,8 @@ class SubscriptionUpdateController extends Controller
 
         $user->addEmailSubscriptionTopic($topic);
 
+        $user->save();
+
         return $this->item($user);
     }
 

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -34,7 +34,7 @@ class SubscriptionUpdateController extends Controller
             abort(404, 'That subscription does not exist.');
         }
 
-        $user->push('email_subscription_topics', $topic, true);
+        $user->addEmailSubscriptionTopic($topic);
 
         return $this->item($user);
     }

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -54,6 +54,7 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(200);
         $this->seeJsonField('data.email_subscription_topics', []);
+        $this->assertEquals(['news'], $user->fresh()->email_subscription_topics);
     }
 
     /**

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -18,6 +18,7 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(200);
         $this->seeJsonField('data.email_subscription_topics', ['news']);
+        $this->assertEquals(['news'], $user->fresh()->email_subscription_topics);
     }
 
     /**
@@ -36,6 +37,7 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(200);
         $this->seeJsonField('data.email_subscription_topics', ['news']);
+        $this->assertEquals(['news'], $user->fresh()->email_subscription_topics);
     }
 
     /**
@@ -54,7 +56,7 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(200);
         $this->seeJsonField('data.email_subscription_topics', []);
-        $this->assertEquals(['news'], $user->fresh()->email_subscription_topics);
+        $this->assertEquals([], $user->fresh()->email_subscription_topics);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `addEmailSubscriptionTopic` helper so that email_subscription_topic will properly update after a user unsubscribes instead of returning null when a user re-subscribes.

Here's the [thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1594069313011300) where it was addressed for more context.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is a bug fix to [#2201](https://github.com/DoSomething/phoenix-next/pull/2201)

### Relevant tickets

References [Pivotal #173691415](https://www.pivotaltracker.com/story/show/173691415).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
