### PR TITLE
Adding a pre registration prompt for users who may be eligible

### DIFF
--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -17,7 +17,6 @@ function togglePreregistrationPrompt() {
     if(birthdate.length === 10 && new Date(birthdate)) {
         const newBirthdate = new Date(birthdate);
         const age = calculateAge(newBirthdate);
-        console.log('this is the age', age)
         if(16 <= age && age < 18) {
             preRegisteredContent.classList.remove('hidden');
         }

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -5,8 +5,8 @@ const $ = require('jquery');
  * based on birthdate on '/profile/about' form
  */
 
-function togglePreregistrationPrompt() {
-    const birthdate = document.getElementById('birthdate').value;
+function togglePreregistrationPrompt(event) {
+    const birthdate = event.target.value;
     const preRegisteredContent = document.getElementById('voter-reg-cta-pre-registration');
 
     const calculateAge = (date) => {
@@ -17,6 +17,7 @@ function togglePreregistrationPrompt() {
     if(birthdate.length === 10 && new Date(birthdate)) {
         const newBirthdate = new Date(birthdate);
         const age = calculateAge(newBirthdate);
+
         if(16 <= age && age < 18) {
             preRegisteredContent.classList.remove('hidden');
         }
@@ -66,7 +67,10 @@ const init = () => {
         })
 
         const birthdateInput = document.getElementById('birthdate');
-        birthdateInput.addEventListener('input', togglePreregistrationPrompt);
+
+        if(birthdateInput) {
+            birthdateInput.addEventListener('input', togglePreregistrationPrompt);
+        }
       });
 }
 

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -39,7 +39,7 @@ function clickHandlerToggleContent(event) {
     const preRegisteredContent = document.getElementById('voter-reg-cta-pre-registration');
     const value = event.target.value
 
-    if(value === 'unregistered' && window.getComputedStyle(preRegisteredContent).display === 'none') {
+    if(value === 'unregistered' && preRegisteredContent.classList.contains('hidden')) {
         unregisteredContent.classList.remove('hidden')
         uncertainContent.classList.add('hidden')
         confirmedContent.classList.add('hidden')

--- a/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
+++ b/resources/assets/js/utilities/VoterRegistrationCtaToggle.js
@@ -1,17 +1,45 @@
 const $ = require('jquery');
 
 /**
+ * Utility script to enable toggling visibility of pre registration for voting 
+ * based on birthdate on '/profile/about' form
+ */
+
+function togglePreregistrationPrompt() {
+    const birthdate = document.getElementById('birthdate').value;
+    const preRegisteredContent = document.getElementById('voter-reg-cta-pre-registration');
+
+    const calculateAge = (date) => {
+        const now = new Date();
+        return now.getFullYear() - date.getFullYear();
+    }
+
+    if(birthdate.length === 10 && new Date(birthdate)) {
+        const newBirthdate = new Date(birthdate);
+        const age = calculateAge(newBirthdate);
+        console.log('this is the age', age)
+        if(16 <= age && age < 18) {
+            preRegisteredContent.classList.remove('hidden');
+        }
+    }
+    else {
+        preRegisteredContent.classList.add('hidden');
+    }
+}
+
+/**
  * Utility script to enable toggling visibility of voter registration 
- * call to action on '/profile/about' form
+ * call to actions on '/profile/about' form
  */
 
 function clickHandlerToggleContent(event) {
     const confirmedContent = document.getElementById('voter-reg-cta-confirmed');
     const uncertainContent = document.getElementById('voter-reg-cta-uncertain');
     const unregisteredContent = document.getElementById('voter-reg-cta-unregistered');
+    const preRegisteredContent = document.getElementById('voter-reg-cta-pre-registration');
     const value = event.target.value
 
-    if(value === 'unregistered') {
+    if(value === 'unregistered' && window.getComputedStyle(preRegisteredContent).display === 'none') {
         unregisteredContent.classList.remove('hidden')
         uncertainContent.classList.add('hidden')
         confirmedContent.classList.add('hidden')
@@ -37,6 +65,9 @@ const init = () => {
         voterRegStatusInputs.forEach(inputField => {
             inputField.addEventListener('click', clickHandlerToggleContent)
         })
+
+        const birthdateInput = document.getElementById('birthdate');
+        birthdateInput.addEventListener('input', togglePreregistrationPrompt);
       });
 }
 

--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -28,6 +28,13 @@
                 <label for="birthdate" class="field-label">Birthday (MM/DD/YYYY)</label>
                 <input name="birthdate" type="text" id="birthdate" class="text-field js-validate" placeholder="MM/DD/YYYY" value="{{ old('birthdate') ?: format_date($user->birthdate, "m/d/Y") }}" data-validate="birthday" autofocus />
             </div>
+            <div id="voter-reg-cta-pre-registration" class="w-full pt-3 hidden"> 
+                <p>
+                    Did you know you can pre-register to vote in some states before you're 18? 
+                    <a id="voter-reg-pre-registration" target="_blank" rel="noopener noreferrer" href="https://vote.dosomething.org/preregister?r=user:{{$user->id}},source:web,source_details:MembershipFlow_PreReg" >
+                    Learn more and pre-register</a>
+                </p>
+            </div>
         </div>
 
         <div class="form-item flex flex-wrap justify-between md:justify-start">


### PR DESCRIPTION
### What's this PR do? 

This pull request adds a second JS function to toggle the pre registration prompt for voters when they enter the correct pre reg age. It also suppresses the unregistered prompt since they are in a specific group. 

### How should this be reviewed?

Let me know if this seems to make sense and covers the age check accurately. It seems to work as expected, but there should perhaps be a test that enters in the expected dates. I'm also seeing this JS error when I'm on the initial log in or register step. I don't see it for the other event listener so i feel like i might have defined it slightly off. 

<img width="401" alt="Screen Shot 2020-07-17 at 1 16 14 PM" src="https://user-images.githubusercontent.com/15236023/87813385-d291a580-c82f-11ea-8226-f8631a1d5ee3.png">

Behavior in App:
![Kapture 2020-07-17 at 13 19 11](https://user-images.githubusercontent.com/15236023/87813593-33b97900-c830-11ea-9224-7c9264fe80f4.gif)


### Any background context you want to provide?

Last level of VR prompt in the registration flow to see if there are any more users we can catch at this stage of sign up.

### Relevant tickets

References [Pivotal # 172094857](https://www.pivotaltracker.com/story/show/172094857).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
