### PR TITLE
Pre Registration Analytics tracking

### DIFF
--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -560,6 +560,19 @@ function init() {
       });
     });
 
+    $('#voter-reg-pre-registration').on('click', () => {
+      // Tracks clicking on the Check Registration Status Link in the Onboarding flow for confirmed users.
+      trackAnalyticsEvent({
+        metadata: {
+          adjective: 'pre_registration',
+          category: 'onboarding',
+          noun: 'link_action',
+          target: 'link',
+          verb: 'clicked',
+        },
+      });
+    });
+
     // Check for and track validation errors returned from the backend after form submission.
     const $validationErrors = $('.validation-error');
     if ($validationErrors && $validationErrors.length) {

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -561,7 +561,7 @@ function init() {
     });
 
     $('#voter-reg-pre-registration').on('click', () => {
-      // Tracks clicking on the Check Registration Status Link in the Onboarding flow for confirmed users.
+      // Tracks clicking on the Learn More Link in the Onboarding flow for users eligible for pre-registration.
       trackAnalyticsEvent({
         metadata: {
           adjective: 'pre_registration',


### PR DESCRIPTION
### What's this PR do?

This pull request adds an analytics event for when users click on the `pre-registration` link in the prompt during the registration flow.

### How should this be reviewed?

👀 

### Any background context you want to provide?

N/A

### Relevant tickets

References [Pivotal # 172094857](https://www.pivotaltracker.com/story/show/172094857).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
