### PR TITLE
Reject Invalid referrer_user_ids in Registration Flow

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -234,8 +234,15 @@ class Registrar
 
         $user->setSource(null, $sourceDetail ? stringify_object($sourceDetail) : null);
 
-        if (session('referrer_user_id')) {
-            $user->referrer_user_id = session('referrer_user_id');
+        if ($referrerUserId = session('referrer_user_id')) {
+            if (is_valid_objectid($referrerUserId)) {
+                $user->referrer_user_id = $referrerUserId;
+            } else {
+                logger()->warning('invalid_referrer_user_id', [
+                    'referrer_user_id' => $referrerUserId,
+                    'id' => $user->id,
+                ]);
+            }
         }
 
         // Set the user's country code by Fastly geo-location header.

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -381,3 +381,14 @@ function machine_token(...$scopes)
 
     return 'Bearer '.(string) $accessToken;
 }
+
+/**
+ * Check if the given string is a valid Mongo ObjectID.
+ *
+ * @param  string
+ * @return bool
+ */
+function is_valid_objectid(string $string): bool
+{
+    return (bool) preg_match('/^[a-f\d]{24}$/i', $string);
+}

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -202,14 +202,16 @@ class WebAuthenticationTest extends BrowserKitTestCase
      */
     public function testRegisterBetaWithReferrerUserId()
     {
+        $referrerUserId = factory(User::class)->create()->id;
+
         // Mock a session for the user with ?referrer_user_id=x param, indicating a referred user.
-        $this->withSession(['referrer_user_id' => '123'])->registerUpdated();
+        $this->withSession(['referrer_user_id' => $referrerUserId])->registerUpdated();
 
         $this->seeIsAuthenticated('web');
 
         $user = auth()->user();
 
-        $this->assertEquals('123', $user->referrer_user_id);
+        $this->assertEquals($referrerUserId, $user->referrer_user_id);
     }
 
     /**

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -215,6 +215,21 @@ class WebAuthenticationTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that an invalid referrer_user_id in session is not attached to the registering user.
+     */
+    public function testRegisterBetaWithInvalidReferrerUserId()
+    {
+        // Mock a session for the user with ?referrer_user_id=x param, indicating a referred user.
+        $this->withSession(['referrer_user_id' => '123'])->registerUpdated();
+
+        $this->seeIsAuthenticated('web');
+
+        $user = auth()->user();
+
+        $this->assertEquals(null, $user->referrer_user_id);
+    }
+
+    /**
      * Test that users get feature_flags values when tests are on.
      */
     public function testRegisterBetaWithFeatureFlagsTest()


### PR DESCRIPTION
### What's this PR do?

This pull request rejects and logs invalid `referrer_user_id`s (from the web session) during the web registration flow.

### How should this be reviewed?
Does this validation logic make sense? How're the log message & variables?

### Any background context you want to provide?
See [the ticket](https://www.pivotaltracker.com/story/show/173514593) for some more background, but essentially, we want to start validating this field now that's a formal one on the User & RAF has a wider incentive backed hard launch impending. 

See this [Slack thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1595281712007600) for context on the approach. We're trying to keep this consistent with our `objectid` validation [in Rogue](https://github.com/DoSomething/rogue/blob/e450089e80833c6ab9f29a353cc530730ed4f990/app/Http/Requests/PostRequest.php#L36). ([Which is where](https://github.com/DoSomething/rogue/blob/e450089e80833c6ab9f29a353cc530730ed4f990/app/Providers/AppServiceProvider.php#L51-L54) we're pulling the logic from for our validation helper!)

### Relevant tickets

References [Pivotal #173514593](https://www.pivotaltracker.com/story/show/173514593).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
