### PR TITLE
Update referrer_user_id Validation Log

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -240,7 +240,6 @@ class Registrar
             } else {
                 logger()->warning('invalid_referrer_user_id', [
                     'referrer_user_id' => $referrerUserId,
-                    'id' => $user->id,
                 ]);
             }
         }


### PR DESCRIPTION
### What's this PR do?

This pull request removes a useless `id` prop from our validation warning log for invalid `referrer_user_id`s #1039 

### How should this be reviewed?
👀 

### Any background context you want to provide?
The user isn't saved yet so this will always be `null`! Pretty sure we can use the log context to trace down the user is necessary though.

### Relevant tickets
[Slack thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1595520951005600?thread_ts=1595520478.004400&cid=CUQMU4Q6B)

