### PR TITLE
Add Club ID to User Profile

### DIFF
--- a/app/Http/Transformers/Legacy/UserTransformer.php
+++ b/app/Http/Transformers/Legacy/UserTransformer.php
@@ -36,6 +36,8 @@ class UserTransformer extends TransformerAbstract
             $response['interests'] = [];
             $response['birthdate'] = format_date($user->birthdate, 'Y-m-d');
 
+            $response['club_id'] = $user->club_id;
+
             $response['addr_street1'] = $user->addr_street1;
             $response['addr_street2'] = $user->addr_street2;
             $response['addr_city'] = $user->addr_city;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -56,7 +56,6 @@ class UserTransformer extends BaseTransformer
             'id' => $user->_id,
             'display_name' => $user->display_name,
             'first_name' => $user->first_name,
-            'display_name' => $user->display_name,
             'last_initial' => $user->last_initial,
             'photo' => null,
         ];

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -90,7 +90,7 @@ class UserTransformer extends BaseTransformer
             // Email subscription status
             $response['email_subscription_status'] = (bool) $user->email_subscription_status;
 
-            //Cause Areas
+            // Cause Areas
             $response['causes'] = $user->causes;
 
             // Voter registration status

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -74,6 +74,7 @@ class UserTransformer extends BaseTransformer
             $response['interests'] = [];
             $response['age'] = $user->age;
             $response['school_id_preview'] = $user->school_id_preview;
+            $response['club_id'] = $user->club_id;
 
             $response['addr_city'] = $user->addr_city;
             $response['addr_state'] = $user->addr_state;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,6 +39,7 @@ use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
  * @property string $referrer_user_id
  * @property string $voter_registration_status
  * @property string $school_id
+ * @property string $club_id - The Rogue Club ID that the user is a part of
  * @property string $role - The user's role, e.g. 'user', 'staff', or 'admin'
  *
  * @property string $addr_street1
@@ -104,7 +105,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'email', 'mobile', 'password', 'role',
 
         // Profile:
-        'first_name', 'last_name', 'birthdate', 'voter_registration_status', 'causes', 'school_id',
+        'first_name', 'last_name', 'birthdate', 'voter_registration_status', 'causes', 'school_id', 'club_id',
 
         // Address:
         'addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -163,7 +163,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     public static $indexes = [
-        '_id', 'drupal_id', 'email', 'mobile', 'source', 'role', 'facebook_id', 'google_id',
+        '_id', 'drupal_id', 'email', 'mobile', 'source', 'role', 'facebook_id', 'google_id', 'club_id',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -536,6 +536,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'language' => $this->language,
             'country' => $this->country,
             'school_id' => $this->school_id,
+            'club_id' => $this->club_id,
             'voter_registration_status' => $this->voter_registration_status,
             'source' => $this->source,
             'source_detail' => $this->source_detail,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -29,6 +29,7 @@ $factory->define(Northstar\Models\User::class, function (Faker\Generator $faker)
         'language' => $faker->languageCode,
         'source' => 'factory',
         'school_id' => '12500012',
+        'club_id' => 1,
         'causes' => $faker->randomElements(['animal_welfare', 'bullying', 'education', 'environment', 'gender_rights_equality', 'homelessness_poverty', 'immigration_refugees', 'lgbtq_rights_equality', 'mental_health', 'physical_health', 'racial_justice_equity', 'sexual_harassment_assault'], $faker->numberBetween(0, 6)),
         /**
          * Set email subscription status to null by default, as it won't be set for all users.

--- a/database/migrations/2020_08_17_145811_add_index_to_club_id_field.php
+++ b/database/migrations/2020_08_17_145811_add_index_to_club_id_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexToClubIdField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->index('club_id', null, null, ['sparse' => true]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $collection) {
+            $collection->dropIndex('club_id');
+        });
+    }
+}

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -151,6 +151,7 @@ Either a mobile number or email is required.
   country: String; // two character country code
   language: String;
   school_id: String;
+  club_id: Number;
   agg_id: Number;
   cgg_id: Number;
   drupal_id: String;

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -149,6 +149,7 @@ Either a mobile number or email is required.
   addr_zip: String;
   country: String; // two character country code
   language: String;
+  club_id: Number;
   agg_id: Number;
   cgg_id: Number;
   slack_id: String;
@@ -394,6 +395,7 @@ PUT /v2/users/:user_id
   addr_zip: String;
   country: String; // two character country code
   language: String;
+  club_id: Number;
   agg_id: Number;
   cgg_id: Number;
   slack_id: String;

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -101,6 +101,7 @@ class UserTest extends BrowserKitTestCase
         $this->assertArrayNotHasKey('mobile', $data);
         $this->assertArrayNotHasKey('facebook_id', $data);
         $this->assertArrayNotHasKey('school_id', $data);
+        $this->assertArrayNotHasKey('club_id', $data);
     }
 
     /**
@@ -130,6 +131,7 @@ class UserTest extends BrowserKitTestCase
         $this->dontSeeJsonField('data.mobile');
         $this->dontSeeJsonField('data.facebook_id');
         $this->dontSeeJsonField('data.school_id');
+        $this->dontSeeJsonField('data.club_id');
     }
 
     /**
@@ -164,6 +166,7 @@ class UserTest extends BrowserKitTestCase
         $this->seeJsonField('data.mobile_preview', '(860) 203-XXXX');
         $this->seeJsonField('data.school_id', '12500012');
         $this->seeJsonField('data.school_id_preview', '125XXXXX');
+        $this->seeJsonField('data.club_id', 1);
         $this->seeJsonField('data.referrer_user_id', '559442cca59dbfca578b4bed');
     }
 
@@ -184,7 +187,7 @@ class UserTest extends BrowserKitTestCase
         // Check that public & private profile fields are visible
         $this->seeJsonStructure([
             'data' => [
-                'id', 'email', 'first_name', 'last_name', 'facebook_id', 'school_id',
+                'id', 'email', 'first_name', 'last_name', 'facebook_id', 'school_id', 'club_id',
             ],
         ]);
     }
@@ -247,6 +250,7 @@ class UserTest extends BrowserKitTestCase
         $this->asUser($staff, ['user', 'role:staff', 'write'])->json('PUT', 'v2/users/'.$user->id, [
             'first_name' => 'Alexander',
             'last_name' => 'Hamilton',
+            'club_id' => 2,
         ]);
 
         $this->assertResponseStatus(200);
@@ -255,6 +259,7 @@ class UserTest extends BrowserKitTestCase
         $this->seeInDatabase('users', [
             'first_name' => 'Alexander',
             'last_name' => 'Hamilton',
+            'club_id' => 2,
             '_id' => $user->id,
         ]);
     }
@@ -273,6 +278,7 @@ class UserTest extends BrowserKitTestCase
             'first_name' => 'Pepper',
             'last_name' => 'Puppy',
             'school_id' => '7110001',
+            'club_id' => 2,
         ]);
 
         $this->assertResponseStatus(200);
@@ -283,6 +289,7 @@ class UserTest extends BrowserKitTestCase
             'last_name' => 'Puppy',
             '_id' => $user->id,
             'school_id' => '7110001',
+            'club_id' => 2,
         ]);
     }
 
@@ -351,6 +358,7 @@ class UserTest extends BrowserKitTestCase
             'first_name' => 'Wilhelmina',
             'last_name' => 'Grubbly-Plank',
             'school_id' => '11122019',
+            'club_id' => 2,
             'referrer_user_id' => '5e7aa023fdce2754fc584dea',
         ]);
 
@@ -362,6 +370,7 @@ class UserTest extends BrowserKitTestCase
             'last_name' => 'Grubbly-Plank',
             '_id' => $user->id,
             'school_id' => '11122019',
+            'club_id' => 2,
             'referrer_user_id' => '5e7aa023fdce2754fc584dea',
         ]);
     }

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -34,6 +34,7 @@ class UserModelTest extends BrowserKitTestCase
             'addr_zip' => $user->addr_zip,
             'country' => $user->country,
             'school_id' => $user->school_id,
+            'club_id' => $user->club_id,
             'school_name' => 'San Dimas High School',
             'school_state' => 'CA',
             'voter_registration_status' => $user->voter_registration_status,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new club_id attribute to the User model, along with an index migration since we'll be querying & filtering on this field, as well as the accompanying payload attributes & test updates.

### How should this be reviewed?
I'd recommend a commit-by-commit for a nice piecemeal review!

(50f03b1f0730efa9dc95db5a3297e8c9d3672491 contains some information on the `sparse` index.)

### Any background context you want to provide?
This is per the new Clubs table in Rogue! https://github.com/DoSomething/rogue/pull/1102

Adding a new attribute was deceptively tricky -- I wasn't quite sure of _every_ place to update, and kinda poked around some old PR's and searched on attribute names to try and comprehensively add this attribute in. (I'm not quite sure how to make this clearer but just noting!)

One question that occurred to me was whether this attribute needs to be marked as 'sensitive'. The `school_id` is, and a Rogue club will optionally contain a `school_id`, so perhaps this is a sensitive trail of Personally Identifiable Information? (Though this field _is_ only returned for authorized users, so I felt like that should be enough?)

Our documentation for the returned payload for /users in the API seems to not include the sensitive field inclusion rules. I can open a freezer cube for us to update!

### Relevant tickets

References [Pivotal #174339687](https://www.pivotaltracker.com/story/show/174339687).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, there is a corresponding PR to surface these in Aurora. _([#174106253](https://www.pivotaltracker.com/story/show/174106253))_
- [x] If new attributes were added to users, then the data team already knows about these changes.
