### PR TITLE
Validate User Club ID Attribute

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -61,6 +61,7 @@ class Registrar
             'birthdate' => 'nullable|date',
             'country' => 'nullable|country',
             'password' => 'nullable|min:6|max:512',
+            'club_id' => 'nullable|integer',
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
             'sms_status' => 'nullable|in:active,less,stop,undeliverable,unknown,pending',
             'sms_paused' => 'boolean',

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -655,6 +655,29 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that the `club_id` field is validated.
+     * POST /v2/users
+     *
+     * @return void
+     */
+    public function testV2ValidatesClubId()
+    {
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'club_id' => 'something bad',
+        ]);
+
+        $this->assertResponseStatus(422);
+
+        $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'club_id' => 1,
+        ]);
+
+        $this->assertResponseStatus(201);
+    }
+
+    /**
      * Test that we can only upsert with the ?upsert=true param
      * POST /v2/users/
      *


### PR DESCRIPTION
### What's this PR do?

This pull request adds a test to ensure that we can't assign invalid `club_id`s via the API, and then a corresponding validation rule for the `club_id` attribute to the Registrar.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I neglected to add this validation in #1046 so figured a test would be a prudent step as well!

### Relevant tickets

References [Pivotal #174339687](https://www.pivotaltracker.com/story/show/174339687).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
