### PR TITLE
Add Clubs Email Subscription Topic

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -68,7 +68,7 @@ class Registrar
             'sms_subscription_topics.*' => 'in:general,voting',
             'last_messaged_at' => 'date',
             'email_subscription_status' => 'boolean',
-            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community',
+            'email_subscription_topics.*' => 'in:news,scholarships,lifestyle,community,clubs',
             /**
              * Includes current values sent from Rock The Vote import, as well as older values for
              * backwards compatability.

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -15,7 +15,7 @@ class SubscriptionUpdateController extends Controller
     /**
      * @var array
      */
-    protected $emailSubscriptionTopics = ['news', 'scholarships', 'community', 'lifestyle'];
+    protected $emailSubscriptionTopics = ['news', 'scholarships', 'community', 'lifestyle', 'clubs'];
 
     /**
      * Make a new SubpscriptionUpdateController, inject dependencies,

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -13,6 +13,11 @@ class SubscriptionUpdateController extends Controller
     protected $transformer;
 
     /**
+     * @var array
+     */
+    protected $emailSubscriptionTopics = ['news', 'scholarships', 'community', 'lifestyle'];
+
+    /**
      * Make a new SubpscriptionUpdateController, inject dependencies,
      * and set middleware for this controller's methods.
      *
@@ -30,7 +35,7 @@ class SubscriptionUpdateController extends Controller
     {
         $this->authorize('edit-profile', $user);
 
-        if (! in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
+        if (! in_array($topic, $this->emailSubscriptionTopics)) {
             abort(404, 'That subscription does not exist.');
         }
 
@@ -45,7 +50,7 @@ class SubscriptionUpdateController extends Controller
     {
         $this->authorize('edit-profile', $user);
 
-        if (! in_array($topic, ['news', 'scholarships', 'community', 'lifestyle'])) {
+        if (! in_array($topic, $this->emailSubscriptionTopics)) {
             abort(404, 'That subscription does not exist.');
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -551,6 +551,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('community', $this->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('scholarships', $this->email_subscription_topics) : false,
+            'clubs_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('clubs', $this->email_subscription_topics) : false,
             // SMS subscription topics:
             'general_sms_subscription_status' => isset($this->sms_subscription_topics) ? in_array('general', $this->sms_subscription_topics) : false,
             'voting_sms_subscription_status' => isset($this->sms_subscription_topics) ? in_array('voting', $this->sms_subscription_topics) : false,

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -319,7 +319,7 @@ PUT /v1/users/drupal_id/<drupal_id>
   sms_paused: Boolean; // Whether a user is in a support conversation.
   sms_subscription_topics: Array; // Valid values: 'general', 'voting'
   email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
-  email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community'
+  email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community', 'clubs'
 
 
   // Hidden fields (optional):

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -158,7 +158,7 @@ Either a mobile number or email is required.
   sms_paused: Boolean; // Whether a user is in a support conversation.
   sms_subscription_topics: Array; // Valid values: 'general', voting'
   email_subscription_status: Boolean; // Whether a user is subscribed to receive emails.
-  email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community'
+  email_subscription_topics: Array; // Valid values: 'news', 'scholarships', 'lifestyle', 'community', 'clubs'
   source: String; // Immutable. Will only be set on new records.
   source_detail: String; // Only accepted alongside a valid 'source'.
   created_at: Number; // timestamp

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -41,6 +41,23 @@ class SubscriptionUpdateTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that a user cannot add an invalid email subscription.
+     * POST /v2/users/:id/subscriptions/:topic
+     *
+     * @return void
+     */
+    public function testCantAddInvalidSubscription()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asUser($user, ['user', 'write'])->post('v2/users/'.$user->id.'/subscriptions/invalid');
+
+        // This route won't exist since the topic is invalid.
+        $this->assertResponseStatus(404);
+        $this->assertEquals([], $user->fresh()->email_subscription_topics);
+    }
+
+    /**
      * Test that a user can mark remove email subscriptions.
      * DELETE /v2/users/:id/subscriptions/:topic
      *

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -51,6 +51,7 @@ class UserModelTest extends BrowserKitTestCase
             'lifestyle_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('lifestyle', $user->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('community', $user->email_subscription_topics) : false,
             'scholarship_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('scholarships', $user->email_subscription_topics) : false,
+            'clubs_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('clubs', $user->email_subscription_topics) : false,
             'general_sms_subscription_status' => isset($user->sms_subscription_topics) ? in_array('general', $user->sms_subscription_topics) : false,
             'voting_sms_subscription_status' => isset($user->sms_subscription_topics) ? in_array('voting', $user->sms_subscription_topics) : false,
             'animal_welfare' => true,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `clubs` email subscription topic. (by adding `'clubs'` to the list of valid topics).

### How should this be reviewed?
Am I missing anything?

I was able to successfully sign a user up for the clubs topic via the API:
![image](https://user-images.githubusercontent.com/12417657/90782845-54f90380-e2cd-11ea-9d42-0107ef57f595.png)


### Any background context you want to provide?
We'll be signing up any member who uses the [Club Finder](https://www.pivotaltracker.com/story/show/174340202) to join a club, for this new `'clubs'` newsletter.

We'll be using the [Subscriptions Update endpoint](https://github.com/DoSomething/northstar/blob/dbcf7e98ba0d6476a2a3259909936ced3794734f/routes/api.php#L33) for this via GraphQL. But I also added this topic to the general list in the `Registrar#validate` method.

### Relevant tickets

References [Pivotal #174339806](https://www.pivotaltracker.com/story/show/174339806).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, there is a corresponding PR to surface these in Aurora. ([#174106253](https://www.pivotaltracker.com/story/show/174106253))
- [x] If new attributes were added to users, then the data team already knows about these changes.
