### PR TITLE
Get GraphQL school location instead of state

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -599,7 +599,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
             if (isset($school)) {
                 $payload['school_name'] = $school['name'];
-                $payload['school_state'] = $school['state'];
+                $payload['school_state'] = $school['location'] ? substr($school['location'], 3) : null;
             }
         }
 

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -47,7 +47,7 @@ class GraphQL
         query GetSchoolById($schoolId: String!) {
           school(id: $schoolId) {
             name
-            state
+            location
           }
         }';
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -61,7 +61,7 @@ trait CreatesApplication
         $this->graphqlMock = $this->mock(\Northstar\Services\GraphQL::class);
         $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([
             'name' => 'San Dimas High School',
-            'state' => 'CA',
+            'location' => 'US-CA',
         ]);
 
         return $app;


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug -- https://github.com/DoSomething/graphql/pull/270 removed the school's `state` field. This PR should've come first before we removed it.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🔥 

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
