### PR TITLE
Club ID Update Customer.io Event

### DIFF
--- a/app/Jobs/CreateCustomerIoEvent.php
+++ b/app/Jobs/CreateCustomerIoEvent.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Northstar\Jobs;
+
+use Northstar\Models\User;
+use Illuminate\Bus\Queueable;
+use Northstar\Services\CustomerIo;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class CreateCustomerIoEvent implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The serialized user model.
+     *
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * The name of the event to create.
+     *
+     * @var string
+     */
+    protected $eventName;
+
+    /**
+     * The payload of the event to create.
+     *
+     * @var array
+     */
+    protected $eventData;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user, $eventName, $eventData)
+    {
+        $this->user = $user;
+        $this->eventName = $eventName;
+        $this->eventData = $eventData;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(CustomerIo $customerIo)
+    {
+        // Rate limit Customer.io API requests to 10/s.
+        $throttler = Redis::throttle('customerio')
+            ->allow(10)
+            ->every(1);
+
+        $throttler->then(
+            function () use ($customerIo) {
+                $response = $customerIo->trackEvent(
+                    $this->user,
+                    $this->eventName,
+                    $this->eventData,
+                );
+
+                info(
+                    "Sent {$this->eventName} event for {$this->user->id} to Customer.io",
+                    ['response' => $response],
+                );
+            },
+            function () {
+                return $this->release(10);
+            },
+        );
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -615,7 +615,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function getClubIdUpdatedEventPayload($clubId)
     {
         $club = app(GraphQL::class)->getClubById($clubId);
-        $clubLeader = app(User::class)->find(array_get($club, 'leaderId'));
+        $clubLeader = app(User::class)->find(Arr::get($club, 'leaderId'));
 
         if (! $club || ! $clubLeader) {
             return;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -607,6 +607,30 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
+     * Get payload for a club_id_updated event.
+     *
+     * @param  number $clubId
+     * @return array
+     */
+    public function getClubIdUpdatedEventPayload($clubId)
+    {
+        $club = app(GraphQL::class)->getClubById($clubId);
+        $clubLeader = app(User::class)->find(array_get($club, 'leaderId'));
+
+        if (!$club || !$clubLeader) {
+            return;
+        }
+
+        return [
+            'club_name' => $club['name'],
+            'club_leader_id' => $club['leaderId'],
+            'club_leader_first_name' => $clubLeader->first_name,
+            'club_leader_display_name' => $clubLeader->display_name,
+            'club_leader_email' => $clubLeader->email,
+        ];
+    }
+
+    /**
      * Scope a query to get all of the users in a group.
      *
      * @return \Illuminate\Database\Eloquent\Builder

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -617,7 +617,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         $club = app(GraphQL::class)->getClubById($clubId);
         $clubLeader = app(User::class)->find(array_get($club, 'leaderId'));
 
-        if (!$club || !$clubLeader) {
+        if (! $club || ! $clubLeader) {
             return;
         }
 

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -19,7 +19,7 @@ class GraphQL
     public function __construct()
     {
         $this->client = ClientBuilder::build(config('services.graphql.url'), [
-            'headers' => ['apollographql-client-name' => 'northstar']
+            'headers' => ['apollographql-client-name' => 'northstar'],
         ]);
     }
 

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -44,7 +44,7 @@ class GraphQL
     public function getClubById($clubId)
     {
         $query = '
-        query GetClubById($clubId: Int!) {
+        query GetClubQuery($clubId: Int!) {
           club(id: $clubId) {
             name
             leaderId

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -18,7 +18,9 @@ class GraphQL
      */
     public function __construct()
     {
-        $this->client = ClientBuilder::build(config('services.graphql.url'));
+        $this->client = ClientBuilder::build(config('services.graphql.url'), [
+            'headers' => [ 'apollographql-client-name' => 'northstar' ]
+        ]);
     }
 
     /**

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -19,7 +19,7 @@ class GraphQL
     public function __construct()
     {
         $this->client = ClientBuilder::build(config('services.graphql.url'), [
-            'headers' => [ 'apollographql-client-name' => 'northstar' ]
+            'headers' => ['apollographql-client-name' => 'northstar']
         ]);
     }
 

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -36,6 +36,29 @@ class GraphQL
     }
 
     /**
+     * Query for a Club by ID.
+     *
+     * @param  $clubId Int
+     * @return array
+     */
+    public function getClubById($clubId)
+    {
+        $query = '
+        query GetClubById($clubId: Int!) {
+          club(id: $clubId) {
+            name
+            leaderId
+          }
+        }';
+
+        $variables = [
+            'clubId' => $clubId,
+        ];
+
+        return $this->query($query, $variables)['club'];
+    }
+
+    /**
      * Query for a School by ID.
      *
      * @param  $schoolId String

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use Carbon\Carbon;
 use FakerPhoneNumber;
-use Northstar\Models\User;
 use DoSomething\Gateway\Blink;
 use Illuminate\Contracts\Console\Kernel;
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Carbon\Carbon;
 use FakerPhoneNumber;
+use Northstar\Models\User;
 use DoSomething\Gateway\Blink;
 use Illuminate\Contracts\Console\Kernel;
 
@@ -62,6 +63,10 @@ trait CreatesApplication
         $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([
             'name' => 'San Dimas High School',
             'location' => 'US-CA',
+        ]);
+        $this->graphqlMock->shouldReceive('getClubById')->andReturn([
+            'name' => 'DoSomething Staffers Club',
+            'leaderId' => factory(User::class)->create()->id,
         ]);
 
         return $app;

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -66,7 +66,7 @@ trait CreatesApplication
         ]);
         $this->graphqlMock->shouldReceive('getClubById')->andReturn([
             'name' => 'DoSomething Staffers Club',
-            'leaderId' => factory(User::class)->create()->id,
+            'leaderId' => new \MongoDB\BSON\ObjectId(),
         ]);
 
         return $app;


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Customer.io event dispatched when a user's `club_id` attribute is updated.

### How should this be reviewed?
Does it make sense not to dispatch the event in case of an invalid club? Is this executed properly?
How are the tests for this? 
Is the event name sound? 

### Any background context you want to provide?
We're interested in two emails being triggered through this event (two ['Campaigns'](https://customer.io/docs/campaigns-in-customerio) in customer.io). One, using the provided ID will be to the user or `customer` welcoming them to the club. (No specific attributes needed for that beyond the club name). Two, to the club's leader informing them that the user joined their club (hence those leader attributes).

I first took a page out of @aaronschachter's work in Rogue (https://github.com/DoSomething/rogue/pull/1018) to add a general `CreateCustomerIoEvent` job so we can easily track individual events. I also imitated the flow from those referral events in that work.

A pain point here was some of the test mocking. For one, I had trouble balancing the general mock in `CreatesApplication` for all the other tests involving `club_id` updates to work, while specifically testing against the arguments/return values in our individual tests. We seem to need to re-mock the GraphQL class / Customer.io class in order for this to work.

### Relevant tickets

References [Pivotal #174106264](https://www.pivotaltracker.com/story/show/174106264).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. - _do we document these events anywhere_?
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
