### PR TITLE
Use NIST password rules.

### DIFF
--- a/app/Auth/PasswordRules.php
+++ b/app/Auth/PasswordRules.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Northstar\Auth;
+
+use LangleyFoxall\LaravelNISTPasswordRules\PasswordRules as NISTPasswordRules;
+use LangleyFoxall\LaravelNISTPasswordRules\Rules\BreachedPasswords;
+use LangleyFoxall\LaravelNISTPasswordRules\Rules\ContextSpecificWords;
+use LangleyFoxall\LaravelNISTPasswordRules\Rules\DerivativesOfContextSpecificWords;
+use LangleyFoxall\LaravelNISTPasswordRules\Rules\DictionaryWords;
+use LangleyFoxall\LaravelNISTPasswordRules\Rules\RepetitiveCharacters;
+use LangleyFoxall\LaravelNISTPasswordRules\Rules\SequentialCharacters;
+
+abstract class PasswordRules extends NISTPasswordRules
+{
+    /**
+     * The base rules for setting a new password. These are used to construct
+     * the "change password" rules. (We omit the "confirm" rule here, since
+     * we don't ask users to confirm their password when registering.)
+     */
+    public static function register($username)
+    {
+        return [
+            'required',
+            'string',
+            'min:8',
+            'max:512', // We enforce this maximum to prevent long passwords from bogging down hashing.
+            new SequentialCharacters(),
+            new RepetitiveCharacters(),
+            new DictionaryWords(),
+            new ContextSpecificWords($username),
+            new DerivativesOfContextSpecificWords($username),
+            new BreachedPasswords(),
+        ];
+    }
+
+    public static function changePassword($username, $oldPassword = null)
+    {
+        return [
+            ...parent::changePassword($username, $oldPassword),
+            'confirmed',
+        ];
+    }
+}

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -60,7 +60,6 @@ class Registrar
             'mobile' => 'mobile|nullable|unique:users,mobile,'.$existingId.',_id|required_without:email',
             'birthdate' => 'nullable|date',
             'country' => 'nullable|country',
-            'password' => 'nullable|min:6|max:512',
             'club_id' => 'nullable|integer',
             'mobilecommons_status' => 'in:active,undeliverable,unknown', // for backwards compatibility.
             'sms_status' => 'nullable|in:active,less,stop,undeliverable,unknown,pending',

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -5,6 +5,7 @@ namespace Northstar\Http\Controllers\Web;
 use Northstar\Models\User;
 use Illuminate\Http\Request;
 use Northstar\Auth\Registrar;
+use Northstar\Auth\PasswordRules;
 use Illuminate\Support\Facades\Auth;
 use Psr\Http\Message\ResponseInterface;
 use Northstar\Auth\Entities\UserEntity;
@@ -114,7 +115,7 @@ class AuthController extends Controller
     {
         $credentials = $this->validate($request, [
             'username' => 'required',
-            'password' => 'required',
+            'password' => PasswordRules::login(),
         ]);
 
         // Check if the user needs to reset their password in order to log in:
@@ -193,7 +194,7 @@ class AuthController extends Controller
             'first_name' => 'required|max:50',
             'last_name' => 'required|max:50',
             'email' => 'required|email|unique:users',
-            'password' => 'required|min:6|max:512',
+            'password' => PasswordRules::register($request->email),
         ]);
 
         // Register and login the user.

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Controller as BaseController;
 use Northstar\Events\PasswordUpdated;
 use Northstar\Auth\Registrar;
 use Northstar\Models\User;
+use Northstar\Auth\PasswordRules;
 use Northstar\Http\Controllers\Controller;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -93,7 +94,7 @@ class UserController extends BaseController
             'first_name' => 'required|max:50',
             'last_name' => 'nullable|max:50',
             'birthdate' => 'nullable|required|date',
-            'password' => 'nullable|min:6|max:512|confirmed', // @TODO: Split into separate form.
+            'password' => PasswordRules::optionallyChangePassword($request->email), // @TODO: Split into separate form.
         ]);
 
         // Remove fields with empty values.

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "guzzlehttp/guzzle": "^6.3.0",
     "jenssegers/mongodb": "3.6.*",
     "laminas/laminas-diactoros": "^2.2",
+    "langleyfoxall/laravel-nist-password-rules": "^4.2",
     "laravel/browser-kit-testing": "5.*",
     "laravel/framework": "^6.2",
     "laravel/socialite": "^4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "319f24e57acf35891c59be3eb2e4ece3",
+    "content-hash": "9fb83b887c3df64e77572aa750cad5e9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -490,6 +490,244 @@
             ],
             "description": "Dead-simple setup for Laravel apps.",
             "time": "2020-04-15T20:26:58+00:00"
+        },
+        {
+            "name": "divineomega/do-file-cache",
+            "version": "v2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DivineOmega/DO-File-Cache.git",
+                "reference": "23696a8a4c3ebe2ab3d68a35b2698fa103f69334"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DivineOmega/DO-File-Cache/zipball/23696a8a4c3ebe2ab3d68a35b2698fa103f69334",
+                "reference": "23696a8a4c3ebe2ab3d68a35b2698fa103f69334",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DivineOmega\\DOFileCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "description": "DO File Cache is a PHP File-based Caching Library. Its syntax is designed to closely resemble the PHP memcache extension.",
+            "keywords": [
+                "cache",
+                "caching",
+                "caching library",
+                "file cache",
+                "library",
+                "php"
+            ],
+            "time": "2018-12-31T09:36:51+00:00"
+        },
+        {
+            "name": "divineomega/do-file-cache-psr-6",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DivineOmega/DO-File-Cache-PSR-6.git",
+                "reference": "18f9807d0491d093e9a12741afb40257d92f017e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DivineOmega/DO-File-Cache-PSR-6/zipball/18f9807d0491d093e9a12741afb40257d92f017e",
+                "reference": "18f9807d0491d093e9a12741afb40257d92f017e",
+                "shasum": ""
+            },
+            "require": {
+                "divineomega/do-file-cache": "^2.0.0",
+                "psr/cache": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DivineOmega\\DOFileCachePSR6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Jordan Hall",
+                    "email": "jordan@hall05.co.uk"
+                }
+            ],
+            "description": "PSR-6 adapter for DO File Cache",
+            "time": "2018-07-13T08:32:36+00:00"
+        },
+        {
+            "name": "divineomega/laravel-password-exposed-validation-rule",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DivineOmega/laravel-password-exposed-validation-rule.git",
+                "reference": "a8964d56caf9b502aea15dcee59703662226c3ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DivineOmega/laravel-password-exposed-validation-rule/zipball/a8964d56caf9b502aea15dcee59703662226c3ca",
+                "reference": "a8964d56caf9b502aea15dcee59703662226c3ca",
+                "shasum": ""
+            },
+            "require": {
+                "divineomega/password_exposed": "^3.0.1",
+                "illuminate/contracts": "^5.1||^6.0||^7.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^7.0||^8.0||^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DivineOmega\\LaravelPasswordExposedValidationRule\\": "./src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Jordan Hall",
+                    "email": "jordan@hall05.co.uk"
+                }
+            ],
+            "description": "Laravel validation rule that checks if a password has been exposed in a data breach",
+            "time": "2020-03-04T21:43:32+00:00"
+        },
+        {
+            "name": "divineomega/password_exposed",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DivineOmega/password_exposed.git",
+                "reference": "4ae85cebda3d9c87c2812609edc24c6c83bf5d21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DivineOmega/password_exposed/zipball/4ae85cebda3d9c87c2812609edc24c6c83bf5d21",
+                "reference": "4ae85cebda3d9c87c2812609edc24c6c83bf5d21",
+                "shasum": ""
+            },
+            "require": {
+                "divineomega/do-file-cache-psr-6": "^2.0",
+                "divineomega/psr-18-guzzle-adapter": "^1.0",
+                "nyholm/psr7": "^1.0",
+                "paragonie/certainty": "^2.4",
+                "php": "^7.1",
+                "php-http/discovery": "^1.6",
+                "psr/cache": "^1.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message": "^1.0",
+                "psr/http-message-implementation": "^1.0"
+            },
+            "require-dev": {
+                "fzaninotto/faker": "^1.7",
+                "kriswallsmith/buzz": "^1.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^6.5",
+                "symfony/cache": "^4.2.12",
+                "vimeo/psalm": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DivineOmega\\PasswordExposed\\": "src/"
+                },
+                "files": [
+                    "src/PasswordExposedFunction.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Jordan Hall",
+                    "email": "jordan@hall05.co.uk"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/DivineOmega/password_exposed/graphs/contributors"
+                }
+            ],
+            "description": "This PHP package provides a `password_exposed` helper function, that uses the haveibeenpwned.com API to check if a password has been exposed in a data breach.",
+            "homepage": "https://github.com/DivineOmega/password_exposed",
+            "time": "2019-12-06T11:38:07+00:00"
+        },
+        {
+            "name": "divineomega/psr-18-guzzle-adapter",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DivineOmega/psr-18-guzzle-adapter.git",
+                "reference": "e7cba8fbb500a38bb07deafa71dcb4f2749992c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DivineOmega/psr-18-guzzle-adapter/zipball/e7cba8fbb500a38bb07deafa71dcb4f2749992c8",
+                "reference": "e7cba8fbb500a38bb07deafa71dcb4f2749992c8",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3",
+                "php": "^7.1",
+                "psr/http-client": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DivineOmega\\Psr18GuzzleAdapter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Jordan Hall",
+                    "email": "jordan@hall05.co.uk"
+                }
+            ],
+            "description": "PSR-18 adapter for the Guzzle HTTP client",
+            "time": "2019-02-19T12:03:12+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1716,6 +1954,56 @@
                 }
             ],
             "time": "2020-05-20T16:45:56+00:00"
+        },
+        {
+            "name": "langleyfoxall/laravel-nist-password-rules",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/langleyfoxall/laravel-nist-password-rules.git",
+                "reference": "c3531e0a2acddeb14cc1faf2ecf4ec1eadaf6602"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/langleyfoxall/laravel-nist-password-rules/zipball/c3531e0a2acddeb14cc1faf2ecf4ec1eadaf6602",
+                "reference": "c3531e0a2acddeb14cc1faf2ecf4ec1eadaf6602",
+                "shasum": ""
+            },
+            "require": {
+                "divineomega/laravel-password-exposed-validation-rule": "^2.2.0",
+                "laravel/framework": "^5.4||^6.0||^7.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "fzaninotto/faker": "^1.6",
+                "orchestra/testbench": "^3.4",
+                "php-coveralls/php-coveralls": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LangleyFoxall\\LaravelNISTPasswordRules\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LangleyFoxall\\LaravelNISTPasswordRules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Jordan Hall",
+                    "email": "jordan@langleyfoxall.co.uk"
+                }
+            ],
+            "description": "🔒 Provides Laravel validation rules that follow the password related recommendations found in NIST Special Publication 800-63B.",
+            "time": "2020-03-11T16:22:04+00:00"
         },
         {
             "name": "laravel/browser-kit-testing",
@@ -3311,6 +3599,79 @@
             "time": "2020-08-04T19:12:46+00:00"
         },
         {
+            "name": "nyholm/psr7",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "c17f4f73985f62054a331cbc4ffdf9868c4ef256"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/c17f4f73985f62054a331cbc4ffdf9868c4ef256",
+                "reference": "c17f4f73985f62054a331cbc4ffdf9868c4ef256",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "php-http/message-factory": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "dev-master",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "http://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-05-23T11:29:07+00:00"
+        },
+        {
             "name": "opis/closure",
             "version": "3.5.6",
             "source": {
@@ -3370,6 +3731,68 @@
                 "serialize"
             ],
             "time": "2020-08-11T08:46:50+00:00"
+        },
+        {
+            "name": "paragonie/certainty",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/certainty.git",
+                "reference": "9f2a6c32dd4227f889b327fc091426af4a7ce36d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/certainty/zipball/9f2a6c32dd4227f889b327fc091426af4a7ce36d",
+                "reference": "9f2a6c32dd4227f889b327fc091426af4a7ce36d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6",
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/sodium_compat": "^1.11",
+                "php": "^5.5|^7|^8"
+            },
+            "require-dev": {
+                "composer/composer": "^1",
+                "phpunit/phpunit": "^4|^5|^6|^7"
+            },
+            "bin": [
+                "bin/certainty-cert-symlink"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\Certainty\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Up-to-date, verifiable repository for Certificate Authorities",
+            "keywords": [
+                "CA-Cert",
+                "Ed25519",
+                "Public-Key Infractructure",
+                "ca",
+                "ca-cert.pem",
+                "cacert",
+                "cacert.pem",
+                "certificate authority",
+                "pki",
+                "ssl",
+                "tls"
+            ],
+            "time": "2020-06-27T00:55:48+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -3479,6 +3902,88 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
+            "name": "paragonie/sodium_compat",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/sodium_compat.git",
+                "reference": "bbade402cbe84c69b718120911506a3aa2bae653"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/bbade402cbe84c69b718120911506a3aa2bae653",
+                "reference": "bbade402cbe84c69b718120911506a3aa2bae653",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": ">=1",
+                "php": "^5.2.4|^5.3|^5.4|^5.5|^5.6|^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^3|^4|^5|^6|^7"
+            },
+            "suggest": {
+                "ext-libsodium": "PHP < 7.0: Better performance, password hashing (Argon2i), secure memory management (memzero), and better security.",
+                "ext-sodium": "PHP >= 7.0: Better performance, password hashing (Argon2i), secure memory management (memzero), and better security."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com"
+                },
+                {
+                    "name": "Frank Denis",
+                    "email": "jedisct1@pureftpd.org"
+                }
+            ],
+            "description": "Pure PHP implementation of libsodium; uses the PHP extension if it exists",
+            "keywords": [
+                "Authentication",
+                "BLAKE2b",
+                "ChaCha20",
+                "ChaCha20-Poly1305",
+                "Chapoly",
+                "Curve25519",
+                "Ed25519",
+                "EdDSA",
+                "Edwards-curve Digital Signature Algorithm",
+                "Elliptic Curve Diffie-Hellman",
+                "Poly1305",
+                "Pure-PHP cryptography",
+                "RFC 7748",
+                "RFC 8032",
+                "Salpoly",
+                "Salsa20",
+                "X25519",
+                "XChaCha20-Poly1305",
+                "XSalsa20-Poly1305",
+                "Xchacha20",
+                "Xsalsa20",
+                "aead",
+                "cryptography",
+                "ecdh",
+                "elliptic curve",
+                "elliptic curve cryptography",
+                "encryption",
+                "libsodium",
+                "php",
+                "public-key cryptography",
+                "secret-key cryptography",
+                "side-channel resistant"
+            ],
+            "time": "2020-03-20T21:48:09+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "1.0.3",
             "source": {
@@ -3579,6 +4084,121 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "64a18cc891957e05d91910b3c717d6bd11fbede9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/64a18cc891957e05d91910b3c717d6bd11fbede9",
+                "reference": "64a18cc891957e05d91910b3c717d6bd11fbede9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0"
+            },
+            "require-dev": {
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1",
+                "puli/composer-plugin": "1.0.0-beta10"
+            },
+            "suggest": {
+                "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2020-07-13T15:44:45+00:00"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-12-19T14:08:53+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4210,6 +4830,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -4399,6 +5020,55 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/resources/lang/vendor/laravel-nist-password-rules/en/validation.php
+++ b/resources/lang/vendor/laravel-nist-password-rules/en/validation.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'can-not-contain-word'              => 'The :attribute can not contain the word \':word\'.',
+    'can-not-be-similar-to-word'        => 'The :attribute can not be similar to the word \':word\'.',
+    'found-in-data-breach'              => 'The :attribute was found in a third party data breach, and can not be used.',
+    'can-not-be-dictionary-word'        => 'The :attribute can not be a dictionary word.',
+    'can-not-be-repetitive-characters'  => 'The :attribute can not be repetitive characters.',
+    'can-not-be-sequential-characters'  => 'The :attribute can not be sequential characters.',
+];

--- a/resources/lang/vendor/laravel-nist-password-rules/en/validation.php
+++ b/resources/lang/vendor/laravel-nist-password-rules/en/validation.php
@@ -3,7 +3,7 @@
 return [
     'can-not-contain-word'              => 'The :attribute can not contain the word \':word\'.',
     'can-not-be-similar-to-word'        => 'The :attribute can not be similar to the word \':word\'.',
-    'found-in-data-breach'              => 'The :attribute was found in a third party data breach, and can not be used.',
+    'found-in-data-breach'              => 'The :attribute is not secure. Choose another password.',
     'can-not-be-dictionary-word'        => 'The :attribute can not be a dictionary word.',
     'can-not-be-repetitive-characters'  => 'The :attribute can not be repetitive characters.',
     'can-not-be-sequential-characters'  => 'The :attribute can not be sequential characters.',

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -141,7 +141,7 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
             'first_name' => $this->faker->firstName,
             'last_name' => $this->faker->lastName,
             'email' => $this->faker->unique->email,
-            'password' => 'secret456',
+            'password' => 'my-top-secret-passphrase',
         ]);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request updates our password validation rules to match the [current best-practices from NIST](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5), using the [laravel-nist-password-rules](https://github.com/langleyfoxall/laravel-nist-password-rules) package. This includes the following checks:

- **Changed:** The password must be at least 8 characters long, rather than our previous 6 character minimum.
- **New:** The password cannot be a dictionary word (e.g. `volunteer`).
- **New:** The password can't include (or be too close to) the user's email or "DoSomething.org".
- **New:** The password can't consist of only repeated or sequential characters (e.g. `aaaaaaaa` or `abcdefgh`).
- **New:** The password can't have been found in a third-party data breach (via the ["Have I Been Pwned" API](https://haveibeenpwned.com/Passwords)).

### How should this be reviewed?

We customize the rules a little bit in our own `PasswordRules` class, and then apply them where needed.

#### Open Question: Preventing Passwords from Data Breaches

> **New:** The password can't have been found in a third-party data breach.

I'm curious how people feel about this rule. The idea is that if a password has been included in a data breach, we'd let someone know it was not safe to use. (This prevents someone from accidentally using a password that's floating around on the "dark web" and leaving their account open to hackers).

From a security standpoint, I think this is a smart check & safely implemented – the ["Have I Been Pwned" API](https://haveibeenpwned.com/Passwords) is maintained by a reputable security professional, is actively used by software like 1Password, and only matches based on _hashes_ of passwords (so it's not like we're sending user's passwords "in the clear" to a third party).

_That said_, I'm not sure from a UX perspective if this might cause confusion. Is "The password was found in a third party data breach, and can not be used" clear enough to help users understand why we're saying they need to use a different password? Is there a better way of communicating that? cc: @ngjo @ddonizeth @hbghidey 

### Any background context you want to provide?

The intent here is to strike a balance between rules that encourage strong passwords, without adding draconian policies (like adding a certain number of digits or symbols) that prevent users from using [passphrases](https://xkcd.com/936/). Hopefully these rules should not ever affect most users since they're really specific "edge cases" for especially poor passwords.

These rules will _only_ take effect for _new_ passwords (either new registrations or the next time a user changes their password).

I'll be following up in another PR to [update the "Change Password" form to require a user's current password](https://www.pivotaltracker.com/story/show/173717920)

### Relevant tickets

References [Pivotal #173718892](https://www.pivotaltracker.com/story/show/173718892).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
