### PR TITLE
Cleanup for new password reset rules.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -32,7 +32,6 @@ class Handler extends ExceptionHandler
         HttpException::class,
         OAuthServerException::class,
         ModelNotFoundException::class,
-        ValidationException::class,
         NorthstarValidationException::class,
     ];
 
@@ -46,6 +45,13 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $e)
     {
+        // If we throw a 422 Validation Exception, write something to the log for later review:
+        if ($e instanceof ValidationException || $e instanceof NorthstarValidationException) {
+            info('Validation failed.', ['url' => request()->path(), 'errors' => $e->errors()]);
+
+            return;
+        }
+
         parent::report($e);
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,7 +8,6 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Illuminate\Foundation\Validation\ValidationException as LegacyValidationException;
 use Illuminate\Validation\ValidationException;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Psr\Http\Message\ResponseInterface;
@@ -35,7 +34,6 @@ class Handler extends ExceptionHandler
         ModelNotFoundException::class,
         ValidationException::class,
         NorthstarValidationException::class,
-        LegacyValidationException::class,
     ];
 
     /**

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -5,6 +5,7 @@ namespace Northstar\Http\Controllers\Web;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Northstar\Auth\PasswordRules;
 use Northstar\Events\PasswordUpdated;
 use Northstar\PasswordResetType;
 use Illuminate\Support\Facades\Auth;
@@ -33,6 +34,20 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+    }
+
+    /**
+     * Get the password reset validation rules.
+     *
+     * @return array
+     */
+    protected function rules()
+    {
+        return [
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => PasswordRules::changePassword(request()->email),
+        ];
     }
 
     /**

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -54,7 +54,7 @@
 
         <div class="form-item password-visibility">
             <label for="password" class="field-label">Password*</label>
-            <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="6+ characters... make it tricky!" data-validate="password" data-validate-required />
+            <input name="password" type="password" id="password" class="text-field required js-validate" placeholder="8+ characters... make it tricky!" data-validate="password" data-validate-required />
             <span class="password-visibility__toggle -hide"></span>
         </div>
 

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -45,16 +45,17 @@ class PasswordResetTest extends BrowserKitTestCase
         // The user should visit the link that was sent via email & set a new password.
         $this->visit($resetPasswordUrl);
         $this->postForm('Reset Password', [
-            'password' => 'top_secret',
-            'password_confirmation' => 'top_secret',
+            'password' => 'new-top-secret-passphrase',
+            'password_confirmation' => 'new-top-secret-passphrase',
         ]);
 
         // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
+        $this->seeIsAuthenticated();
         $this->seeIsAuthenticatedAs($user, 'web');
         $this->assertRedirectedTo(config('services.phoenix.url').'/next/login');
 
         // And their account should be updated with their new password.
-        $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));
+        $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'new-top-secret-passphrase']));
     }
 
     /**
@@ -114,15 +115,16 @@ class PasswordResetTest extends BrowserKitTestCase
         $this->see('Create a password to join a movement of young people dedicated to making their communities a better place for everyone.');
 
         $this->postForm('Activate Account', [
-            'password' => 'top_secret',
-            'password_confirmation' => 'top_secret',
+            'password' => 'new-top-secret-passphrase',
+            'password_confirmation' => 'new-top-secret-passphrase',
         ]);
 
         // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
+        $this->seeIsAuthenticated();
         $this->seeIsAuthenticatedAs($user, 'web');
         $this->assertRedirectedTo(config('services.phoenix.url').'/next/login');
 
         // And their account should be updated with their new password.
-        $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'top_secret']));
+        $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'new-top-secret-passphrase']));
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request includes follow-up from #1051:

🍃 Removes an old validation class from our `$dontReport` array that no longer exists in this Laravel release. 47b2d7b

🎋 Write validation errors to the application log. This will help us keep an eye on how often these occur. d8be3c0

*️⃣ Updates the placeholder for the registration form's password field to specify new length requirement. 08a7bad

⛑️ Applies new password validation rules to reset form as well. aa6a19b

### How should this be reviewed?

I'd recommend reviewing commit-by-commit!

### Any background context you want to provide?

I've got the changes to separate out the "change password" form staged, but holding for another PR to keep this small.

### Relevant tickets

References [Pivotal #173718892](https://www.pivotaltracker.com/story/show/173718892).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
