### PR TITLE
Extract "change password" fields into their own form.

### DIFF
--- a/app/Http/Controllers/Web/PasswordController.php
+++ b/app/Http/Controllers/Web/PasswordController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Northstar\Http\Controllers\Web;
+
+use Illuminate\Http\Request;
+use Northstar\Auth\PasswordRules;
+use Northstar\Events\PasswordUpdated;
+use Northstar\Http\Controllers\Controller;
+use Northstar\Models\User;
+
+class PasswordController extends Controller
+{
+    /**
+     * Make a new PasswordController, inject dependencies and
+     * set middleware for this controller's methods.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth:web');
+    }
+
+    /**
+     * Update the specified user's password.
+     *
+     * @param  \Northstar\Models\User $user
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function update(User $user, Request $request)
+    {
+        $this->authorize('editProfile', $user);
+
+        $this->validate($request, [
+            'current_password' => 'password:web',
+            'password' => PasswordRules::changePassword($user->email),
+        ]);
+
+        $user->password = $request->password;
+        $user->save();
+
+        event(new PasswordUpdated($user, 'profile'));
+
+        return redirect('/');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -102,7 +102,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     protected $fillable = [
         // Unique identifiers & role:
-        'email', 'mobile', 'password', 'role',
+        'email', 'mobile', 'role',
 
         // Profile:
         'first_name', 'last_name', 'birthdate', 'voter_registration_status', 'causes', 'school_id', 'club_id',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -56,6 +56,7 @@ return [
     ],
     'not_in' => 'The selected :attribute is invalid.',
     'numeric' => 'The :attribute must be a number.',
+    'password' => 'The provided current password is incorrect.',
     'regex' => 'The :attribute format is invalid.',
     'required' => 'The :attribute field is required.',
     'required_if' => 'The :attribute field is required when :other is :value.',

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -91,11 +91,27 @@
         </div>
 
         <div class="container__block">
+            <div class="form-actions -padded">
+                <input type="submit" class="button" value="Save">
+            </div>
+        </div>
+    </form>
+
+    <form id="profile-edit-form" method="POST" action="{{ route('passwords.update', $user->id) }}">
+        {{ method_field('PATCH') }}
+        {{ csrf_field() }}
+
+        <div class="container__block">
             <h3 class="heading">Change Password</h3>
 
             <div class="form-item">
+                <label for="password" class="field-label">Current Password</label>
+                <input type="password" id="current_password" class="text-field" name="current_password" placeholder="• • • • • • • •">
+            </div>
+
+            <div class="form-item">
                 <label for="password" class="field-label">New Password</label>
-                <input type="password" id="password" class="text-field" name="password" placeholder="6+ characters... make it tricky!">
+                <input type="password" id="password" class="text-field" name="password" placeholder="8+ characters... make it tricky!">
             </div>
 
             <div class="form-item">
@@ -106,7 +122,7 @@
 
         <div class="container__block">
             <div class="form-actions">
-                <input type="submit" class="button" value="Save">
+                <input type="submit" class="button" value="Change Password">
             </div>
             <ul class="form-actions">
                 <li><a href="{{ url('users/'.$user->id) }}">Cancel</a></li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,9 @@ Route::patch('profile/about', 'ProfileAboutController@update');
 Route::get('profile/subscriptions', 'ProfileSubscriptionsController@edit');
 Route::patch('profile/subscriptions', 'ProfileSubscriptionsController@update');
 
+// Change Password
+Route::patch('users/{id}/password', 'PasswordController@update')->name('passwords.update');
+
 // Password Reset
 Route::get('password/reset', 'ForgotPasswordController@showLinkRequestForm');
 Route::post('password/email', 'ForgotPasswordController@sendResetLinkEmail');

--- a/tests/Auth/DrupalPasswordHashTest.php
+++ b/tests/Auth/DrupalPasswordHashTest.php
@@ -48,9 +48,8 @@ class DrupalPasswordHashTest extends BrowserKitTestCase
             'drupal_password' => '$S$DOQoztwlGzTeaobeBZKNzlDttbZscuCkkZPv8yeoEvrn26H/GN5b',
         ]);
 
-        $user->update([
-            'password' => 'secret',
-        ]);
+        $user->password = 'secret';
+        $user->save();
 
         // Assert user has been updated in the database with a newly hashed password.
         $attributes = $user->fresh()->getAttributes();

--- a/tests/Http/OAuthTest.php
+++ b/tests/Http/OAuthTest.php
@@ -483,8 +483,8 @@ class OAuthTest extends BrowserKitTestCase
      */
     public function testCantRevokeAnotherUsersRefreshToken()
     {
-        $user1 = User::create(['email' => 'login-test@dosomething.org', 'password' => 'secret']);
-        $user2 = User::create(['email' => 'evil-user@dosomething.org', 'password' => 'secret']);
+        $user1 = factory(User::class)->create(['password' => 'rather-secret-phrase']);
+        $user2 = factory(User::class)->create(['password' => 'another-secret-code']);
         $client = factory(Client::class, 'password')->create();
 
         // Make token for user #1.
@@ -493,7 +493,7 @@ class OAuthTest extends BrowserKitTestCase
             'client_id' => $client->client_id,
             'client_secret' => $client->client_secret,
             'username' => $user1->email,
-            'password' => 'secret',
+            'password' => 'rather-secret-phrase',
             'scope' => 'user',
         ])->decodeResponseJson();
 
@@ -506,7 +506,7 @@ class OAuthTest extends BrowserKitTestCase
             'client_id' => $client->client_id,
             'client_secret' => $client->client_secret,
             'username' => $user2->email,
-            'password' => 'secret',
+            'password' => 'another-secret-code',
             'scope' => 'user',
         ])->decodeResponseJson();
 


### PR DESCRIPTION
### What's this PR do?

This pull request extracts the "change password" fields into their own form, and adds a field to confirm the user's existing password before allowing a new password to be set. This makes it harder for an attacker to hijack a user's account.

![Screen Shot 2020-09-03 at 11 57 52 AM](https://user-images.githubusercontent.com/583202/92138704-b6949400-eddc-11ea-82c9-5ac21d930c35.png)

### How should this be reviewed?

Do these changes look good? Any edge cases I may have forgotten?

### Any background context you want to provide?

🔏

### Relevant tickets

References [Pivotal #173717920](https://www.pivotaltracker.com/story/show/173717920).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
