### PR TITLE
Fix issues with 'is_dosomething_domain' helper.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -229,15 +229,22 @@ function format_legacy_mobile($mobile)
  * @param  string  $url
  * @return bool
  */
-function is_dosomething_domain($url)
+function is_dosomething_domain(string $url): bool
 {
-    $parsed = parse_url($url);
+    $host = parse_url($url, PHP_URL_HOST);
 
-    if (! array_key_exists('host', $parsed)) {
+    if (! $host) {
         return false;
     }
 
-    return Str::endsWith($parsed['host'], 'dosomething.org') !== false;
+    // Reject any URLs that include HTTP basic authentication, as this
+    // can be used for a "redirect hijack" attack, since some browsers
+    // will improperly read a URL-like username as the URL:
+    if (parse_url($url, PHP_URL_USER)) {
+        return false;
+    }
+
+    return (bool) preg_match('/(^|\.)dosomething\.org$/', $host);
 }
 
 /**

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -62,4 +62,15 @@ class HelpersTest extends BrowserKitTestCase
         $this->asNormalUser()->getJson('/status');
         $this->assertEquals(client_id(), 'phpunit');
     }
+
+    /** @test */
+    public function testIsDoSomethingDomain()
+    {
+        $this->assertTrue(is_dosomething_domain('https://dosomething.org'), 'It should recognize our base domain.');
+        $this->assertTrue(is_dosomething_domain('https://identity.dosomething.org'), 'It should recognize one of our subdomains.');
+        $this->assertTrue(is_dosomething_domain('https://www.dosomething.org/campaigns/teens-for-jeans'), 'It should recognize a nested path.');
+
+        $this->assertFalse(is_dosomething_domain('https://www.google.com'), 'It should reject a non-DoSomething hostname.');
+        $this->assertFalse(is_dosomething_domain('https://dosomething.org.evil.com'), 'It should reject a non-DoSomething hostname with valid "prefix".');
+    }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -72,5 +72,7 @@ class HelpersTest extends BrowserKitTestCase
 
         $this->assertFalse(is_dosomething_domain('https://www.google.com'), 'It should reject a non-DoSomething hostname.');
         $this->assertFalse(is_dosomething_domain('https://dosomething.org.evil.com'), 'It should reject a non-DoSomething hostname with valid "prefix".');
+        $this->assertFalse(is_dosomething_domain('https://www.dontdosomething.org'), 'It should reject a non-DoSomething hostname with valid "suffix".');
+        $this->assertFalse(is_dosomething_domain('https://cobalt.io\@admin.dosomething.org'), 'It should reject a URL with username hack.');
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request fixes some issues with the `is_dosomething_domain` helper, and adds tests to verify the correct behavior.

### How should this be reviewed?

I've added passing tests for what _was_ working in 6b610ca ✅ and some failing tests in a8fef74 ❌ for the reported issue and another bug that I noticed while doing my own testing. I then fixed both of those issues in d01588f. ✅ 

### Any background context you want to provide?

These were interesting bugs! I'll add some more context to the problems & solution in the diff.

### Relevant tickets

References [Pivotal #173719172](https://www.pivotaltracker.com/story/show/173719172).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
