### PR TITLE
Fixes another edge case on domain helper.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -244,6 +244,12 @@ function is_dosomething_domain(string $url): bool
         return false;
     }
 
+    // Reject a host that includes an escaped '.', which could be used to
+    // bypass our domain check below (e.g. 'cobalt.io\.dosomething.org'):
+    if (str_contains($host, '\.')) {
+        return false;
+    }
+
     return (bool) preg_match('/(^|\.)dosomething\.org$/', $host);
 }
 

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -74,5 +74,6 @@ class HelpersTest extends BrowserKitTestCase
         $this->assertFalse(is_dosomething_domain('https://dosomething.org.evil.com'), 'It should reject a non-DoSomething hostname with valid "prefix".');
         $this->assertFalse(is_dosomething_domain('https://www.dontdosomething.org'), 'It should reject a non-DoSomething hostname with valid "suffix".');
         $this->assertFalse(is_dosomething_domain('https://cobalt.io\@admin.dosomething.org'), 'It should reject a URL with username hack.');
+        $this->assertFalse(is_dosomething_domain('https://cobalt.io\.admin.dosomething.org'), 'It should reject hostname with escaped dot.');
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request fixes another edge case on `is_dosomething_domain` flagged by our Cobalt researcher.

### How should this be reviewed?

👀

### Any background context you want to provide?

🔒

### Relevant tickets

References [Pivotal #173719172](https://www.pivotaltracker.com/story/show/173719172).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
