### PR TITLE
Directly send profile updates to Customer.io.

### DIFF
--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -4,6 +4,7 @@ namespace Northstar\Jobs;
 
 use Northstar\Models\User;
 use Illuminate\Bus\Queueable;
+use Northstar\Services\CustomerIo;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
@@ -36,21 +37,12 @@ class SendUserToCustomerIo implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(CustomerIo $customerIo)
     {
-        // Rate limit Blink/Customer.io API requests to 10/s.
+        // Rate limit Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
-        $throttler->then(function () {
-            // Send to Customer.io
-            $shouldSendToCustomerIo = config('features.blink');
-            if ($shouldSendToCustomerIo) {
-                $blinkPayload = $this->user->toCustomerIoPayload();
-                gateway('blink')->userCreate($blinkPayload);
-            }
-
-            // Log
-            $verb = $shouldSendToCustomerIo ? 'sent' : 'would have been sent';
-            info('User '.$this->user->id.' '.$verb.' to Customer.io');
+        $throttler->then(function () use ($customerIo) {
+            $customerIo->updateCustomer($this->user);
         }, function () {
             // Could not obtain lock... release to the queue.
             return $this->release(10);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -520,7 +520,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         $payload = [
             'id' => $this->id,
             'email' => $this->email,
-            'mobile' => $this->mobile, // TODO: Update Blink to just accept 'phone' field.
+            'phone' => $this->mobile,
             'sms_status' => $this->sms_status,
             'sms_status_source' => (isset($this->audit['sms_status']['source'])) ? $this->audit['sms_status']['source'] : null,
             'sms_paused' => (bool) $this->sms_paused,
@@ -543,9 +543,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'referrer_user_id' => $this->referrer_user_id,
             'deletion_requested_at' => optional($this->deletion_requested_at)->timestamp,
             'last_messaged_at' => optional($this->last_messaged_at)->timestamp,
-            'last_authenticated_at' => iso8601($this->last_authenticated_at), // TODO: Update Blink to just accept timestamp.
-            'updated_at' => iso8601($this->updated_at), // TODO: Update Blink to just accept timestamp.
-            'created_at' => iso8601($this->created_at), // TODO: Update Blink to just accept timestamp.
+            'last_authenticated_at' => optional($this->last_authenticated_at)->timestamp,
+            'updated_at' => optional($this->updated_at)->timestamp,
+            'created_at' => optional($this->created_at)->timestamp,
             // Email subscription topics:
             'news_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('news', $this->email_subscription_topics) : false,
             'lifestyle_email_subscription_status' => isset($this->email_subscription_topics) ? in_array('lifestyle', $this->email_subscription_topics) : false,

--- a/config/services.php
+++ b/config/services.php
@@ -65,7 +65,7 @@ return [
     ],
 
     'customerio' => [
-        'url' => env('CUSTOMER_IO_URL'),
+        'url' => 'https://track.customer.io/api/v1/',
         'username' => env('CUSTOMER_IO_USERNAME'),
         'password' => env('CUSTOMER_IO_PASSWORD'),
     ],

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -14,6 +14,6 @@ class BackfillCustomerIoTest extends BrowserKitTestCase
         Artisan::call('northstar:cio');
 
         // Make sure we send to Customer.io the expected number of times (5 times when created, 5 times when we call the command)
-        $this->blinkMock->shouldHaveReceived('userCreate')->times(10);
+        $this->customerIoMock->shouldHaveReceived('updateCustomer')->times(10);
     }
 }

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -3,7 +3,6 @@
 use Northstar\Models\User;
 use Northstar\Services\Rogue;
 use Northstar\Services\Gambit;
-use Northstar\Services\CustomerIo;
 use Illuminate\Support\Facades\Artisan;
 
 class DeleteUsersCommandTest extends TestCase

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -21,7 +21,7 @@ class DeleteUsersCommandTest extends TestCase
         // Mock the external service APIs & assert that we make two "delete" requests:
         $this->mock(Rogue::class)->shouldReceive('deleteUser')->twice();
         $this->mock(Gambit::class)->shouldReceive('deleteUser')->twice();
-        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->twice();
+        $this->customerIoMock->shouldReceive('deleteUser')->twice();
 
         // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
         Artisan::call('northstar:delete', ['input' => $input]);

--- a/tests/Console/ProcessDeletionsCommandTest.php
+++ b/tests/Console/ProcessDeletionsCommandTest.php
@@ -4,7 +4,6 @@ use Carbon\Carbon;
 use Northstar\Models\User;
 use Northstar\Services\Rogue;
 use Northstar\Services\Gambit;
-use Northstar\Services\CustomerIo;
 use Illuminate\Support\Facades\Artisan;
 
 class ProcessDeletionsCommandTest extends TestCase

--- a/tests/Console/ProcessDeletionsCommandTest.php
+++ b/tests/Console/ProcessDeletionsCommandTest.php
@@ -21,7 +21,7 @@ class ProcessDeletionsCommandTest extends TestCase
         // Mock the external service APIs & assert that we make two "delete" requests:
         $this->mock(Rogue::class)->shouldReceive('deleteUser')->twice();
         $this->mock(Gambit::class)->shouldReceive('deleteUser')->twice();
-        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->twice();
+        $this->customerIoMock->shouldReceive('deleteUser')->twice();
 
         // Run the 'northstar:delete' command on the 'example-identify-output.csv' file:
         Artisan::call('northstar:process-deletions');

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -50,11 +50,11 @@ trait CreatesApplication
 
         // Configure a mock for Blink model events.
         $this->blinkMock = $this->mock(Blink::class);
-        $this->blinkMock->shouldReceive('userCreate')->andReturn(true);
         $this->blinkMock->shouldReceive('userCallToActionEmail')->andReturn(true);
 
         // Configure a mock for any Customer.io API calls.
         $this->customerIoMock = $this->mock(\Northstar\Services\CustomerIo::class);
+        $this->customerIoMock->shouldReceive('updateCustomer');
         $this->customerIoMock->shouldReceive('trackEvent');
 
         // Configure a mock for GraphQL calls.

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -54,7 +54,7 @@ trait CreatesApplication
 
         // Configure a mock for any Customer.io API calls.
         $this->customerIoMock = $this->mock(\Northstar\Services\CustomerIo::class);
-        $this->customerIoMock->shouldReceive('updateCustomer');
+        $this->customerIoMock->shouldReceive('updateCustomer')->andReturn(null);
         $this->customerIoMock->shouldReceive('trackEvent');
 
         // Configure a mock for GraphQL calls.

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -3,7 +3,6 @@
 use Northstar\Models\User;
 use Northstar\Services\Rogue;
 use Northstar\Services\Gambit;
-use Northstar\Services\CustomerIo;
 
 class UserTest extends BrowserKitTestCase
 {

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -894,7 +894,7 @@ class UserTest extends BrowserKitTestCase
 
         $this->mock(Rogue::class)->shouldReceive('deleteUser')->once();
         $this->mock(Gambit::class)->shouldReceive('deleteUser')->once();
-        $this->mock(CustomerIo::class)->shouldReceive('deleteUser')->once();
+        $this->customerIoMock->shouldReceive('deleteUser')->once();
 
         $response = $this->asAdminUser()->json('DELETE', 'v2/users/'.$userToDelete->id, [
             'first_name' => 'Hercules',

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -7,7 +7,7 @@ use Northstar\Services\CustomerIo;
 class UserModelTest extends BrowserKitTestCase
 {
     /** @test */
-    public function it_should_send_new_users_to_blink()
+    public function it_should_send_new_users_to_customer_io()
     {
         config(['features.blink' => true]);
 
@@ -18,7 +18,7 @@ class UserModelTest extends BrowserKitTestCase
         ]);
 
         // We should have made one "create" request to Blink.
-        $this->blinkMock->shouldHaveReceived('userCreate')->once()->with([
+        $this->customerIoMock->shouldHaveReceived('updateCustomer')->once()->with([
             'id' => $user->id,
             'first_name' => $user->first_name,
             'display_name' => $user->display_name,
@@ -76,7 +76,7 @@ class UserModelTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function it_should_send_updated_users_to_blink()
+    public function it_should_send_updated_users_to_customer_io()
     {
         config(['features.blink' => true]);
 
@@ -86,7 +86,7 @@ class UserModelTest extends BrowserKitTestCase
 
         // We should have made one "create" request to Blink,
         // and a second "update" request afterwards.
-        $this->blinkMock->shouldHaveReceived('userCreate')->twice();
+        $this->customerIoMock->shouldHaveReceived('updateCustomer')->twice();
     }
 
     /** @test */

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -2,7 +2,6 @@
 
 use Northstar\Models\User;
 use Northstar\Services\GraphQL;
-use Northstar\Services\CustomerIo;
 
 class UserModelTest extends BrowserKitTestCase
 {

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -17,15 +17,18 @@ class UserModelTest extends BrowserKitTestCase
             'causes' => ['animal_welfare', 'education', 'lgbtq_rights_equality', 'sexual_harassment_assault'],
         ]);
 
-        // We should have made one "create" request to Blink.
-        $this->customerIoMock->shouldHaveReceived('updateCustomer')->once()->with([
+        // We should have made one "update" request to Customer.io when creating this user.
+        $this->customerIoMock->shouldHaveReceived('updateCustomer')->once();
+
+        // The Customer.io payload should be serialized correctly:
+        $this->assertEquals($user->toCustomerIoPayload(), [
             'id' => $user->id,
             'first_name' => $user->first_name,
             'display_name' => $user->display_name,
             'last_name' => null,
             'birthdate' => '631238400',
             'email' => $user->email,
-            'mobile' => $user->mobile,
+            'phone' => $user->mobile,
             'sms_status' => $user->sms_status,
             'sms_paused' => (bool) $user->sms_paused,
             'sms_status_source' => 'northstar',
@@ -47,8 +50,8 @@ class UserModelTest extends BrowserKitTestCase
             'deletion_requested_at' => null,
             'last_authenticated_at' => null,
             'last_messaged_at' => null,
-            'updated_at' => $user->updated_at->toIso8601String(),
-            'created_at' => $user->created_at->toIso8601String(),
+            'updated_at' => $user->updated_at->timestamp,
+            'created_at' => $user->created_at->timestamp,
             'news_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('news', $user->email_subscription_topics) : false,
             'lifestyle_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('lifestyle', $user->email_subscription_topics) : false,
             'community_email_subscription_status' => isset($user->email_subscription_topics) ? in_array('community', $user->email_subscription_topics) : false,
@@ -84,8 +87,8 @@ class UserModelTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
         $user->update(['birthdate' => '1/15/1990']);
 
-        // We should have made one "create" request to Blink,
-        // and a second "update" request afterwards.
+        // We should have made one request to Customer.io when we created this
+        // user, and a second "update" request when we called 'update()'.
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->twice();
     }
 
@@ -269,9 +272,9 @@ class UserModelTest extends BrowserKitTestCase
         $this->assertEquals($eventPayload['club_leader_display_name'], $clubLeader->display_name);
         $this->assertEquals($eventPayload['club_leader_email'], $clubLeader->email);
 
-        $this->mock(CustomerIo::class)->shouldReceive('trackEvent')->once()->withSomeOfArgs('club_id_updated', $eventPayload);
-
         $user->update(['club_id' => $newClubId]);
+
+        $this->customerIoMock->shouldHaveReceived('trackEvent')->once();
     }
 
     /**
@@ -287,7 +290,7 @@ class UserModelTest extends BrowserKitTestCase
         $this->mock(GraphQL::class)->shouldReceive('getClubById', 'getSchoolById')->andReturn(null);
 
         // The Customer.io event shoud not be dispatched.
-        $this->mock(CustomerIo::class)->shouldNotReceive('trackEvent');
+        $this->customerIoMock->shouldNotReceive('trackEvent');
 
         $user->update(['club_id' => 123]);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request updates Northstar to send profile updates directly to [Customer.io](https://customer.io), rather than routing them through Blink for an extra round of validation, queueing, and rate-limiting. (We're already doing that here!) 

### How should this be reviewed?

I've split this up into individual commits to make it easier to review:

💬 I added a method to talk directly to Customer.io's ["update customer" endpoint](https://customer.io/docs/api/#apitrackcustomerscustomers_update) in  564826c.

🏭 I've updated our transformer to format fields for Customer.io (e.g. turning all dates into timestamps and renaming `mobile` to `phone`) in b75a292. This handles transformations previously applied in Blink's [`CustomerIoUpdateCustomerMessage.js`](https://github.com/DoSomething/blink/blob/8e7fa6592976354305fe1d2eb7da83863b97979a/src/messages/CustomerIoUpdateCustomerMessage.js).

🏒 Makes Customer.io API calls in our queued event, rather than Blink's event API. 841af7e

📥 _Cleanup:_ I inlined the `CUSTOMER_IO_URL` environment variable in c7a2228f1333f7781d9b6cb4c1d94dbc53441e77. This isn't something we ever need to customize (like we do with our own services, which have multiple environments), so it makes more sense to hard-code to reduce the chance of configuration error.

🚥 _Tests:_ Finally, I've updated test assertions to expect the `CustomerIo` class to be called instead of `Blink` in 7d478be.

### Any background context you want to provide?

For more context, see the [Northstar/Rogue Queue Simplification](https://docs.google.com/document/d/1Mu48WFJqBosA4nzPKCd21ZejV_tQA0GrxWav4cZaIOA/edit#heading=h.kz5h7hwnv2z2) spec.

### Relevant tickets

References Pivotal [#174827016](https://www.pivotaltracker.com/story/show/174827016).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
