### PR TITLE
Adds voting_method property to Users

### DIFF
--- a/app/Http/Transformers/Legacy/UserTransformer.php
+++ b/app/Http/Transformers/Legacy/UserTransformer.php
@@ -75,6 +75,7 @@ class UserTransformer extends TransformerAbstract
         }
 
         // Make a Voting Plan fields to be rendered in messaging
+        $response['voting_method'] = $user->voting_method;
         $response['voting_plan_method_of_transport'] = $user->voting_plan_method_of_transport;
         $response['voting_plan_time_of_day'] = $user->voting_plan_time_of_day;
         $response['voting_plan_attending_with'] = $user->voting_plan_attending_with;

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -104,6 +104,7 @@ class UserTransformer extends BaseTransformer
         }
 
         // Make a Voting Plan fields to be rendered in messaging
+        $response['voting_method'] = $user->voting_method;
         $response['voting_plan_method_of_transport'] = $user->voting_plan_method_of_transport;
         $response['voting_plan_time_of_day'] = $user->voting_plan_time_of_day;
         $response['voting_plan_attending_with'] = $user->voting_plan_attending_with;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -573,6 +573,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'racial_justice_equity' => in_array('racial_justice_equity', $this->causes) ? true : false,
             'sexual_harassment_assault' => in_array('sexual_harassment_assault', $this->causes) ? true : false,
             // Voting plan:
+            'voting_method' => $this->voting_method,
             'voting_plan_status' => $this->voting_plan_status,
             'voting_plan_method_of_transport' => $this->voting_plan_method_of_transport,
             'voting_plan_time_of_day' => $this->voting_plan_time_of_day,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -123,7 +123,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         // Email Subscription:
         'email_subscription_status', 'email_subscription_topics',
 
-        // Voting Method/Plan field:
+        // Voting Method/Plan fields:
         'voting_method',
         'voting_plan_attending_with',
         'voting_plan_status',
@@ -572,7 +572,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             'physical_health' => in_array('physical_health', $this->causes) ? true : false,
             'racial_justice_equity' => in_array('racial_justice_equity', $this->causes) ? true : false,
             'sexual_harassment_assault' => in_array('sexual_harassment_assault', $this->causes) ? true : false,
-            // Voting plan:
+            // Voting method/plan:
             'voting_method' => $this->voting_method,
             'voting_plan_status' => $this->voting_plan_status,
             'voting_plan_method_of_transport' => $this->voting_plan_method_of_transport,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -123,8 +123,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         // Email Subscription:
         'email_subscription_status', 'email_subscription_topics',
 
-        // Voting Plan:
-        'voting_plan_status', 'voting_plan_method_of_transport', 'voting_plan_time_of_day', 'voting_plan_attending_with',
+        // Voting Method/Plan field:
+        'voting_method',
+        'voting_plan_attending_with',
+        'voting_plan_status',
+        'voting_plan_method_of_transport',
+        'voting_plan_time_of_day',
 
         // Feature flags:
         'feature_flags',

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -70,6 +70,7 @@ class UserModelTest extends BrowserKitTestCase
             'physical_health' => false,
             'racial_justice_equity' => false,
             'sexual_harassment_assault' => true,
+            'voting_method' => null,
             'voting_plan_status' => null,
             'voting_plan_method_of_transport' => null,
             'voting_plan_time_of_day' => null,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new string `voting_method` field to our User model, which will save values like `in-person`, `early`, or `mail`.

### How should this be reviewed?

Example request:
```
curl --location --request PUT 'http://northstar.test/v2/users/5f3dc977ea73310d6443dfe3' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer[token]
--data-raw '{
    "voting_method": "early"
}'
```

Example response:
```
{
    "data": {
        "id": "5f3dc977ea73310d6443dfe3",
        ...
        "email_subscription_status": false,
        "causes": [],
        "voting_method": "early",
        ...
   }
}
```

### Any background context you want to provide?

Per the other `voting_plan_*` fields which are only editable via the voting plan flows on SMS, we're not worried about validating specific values for now. 

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
