### PR TITLE
Send "call to action" password reset events directly to Customer.io.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,11 +24,6 @@ MAIL_DRIVER=log
 STORAGE_DRIVER=local
 QUEUE_DRIVER=sync
 
-# Blink
-BLINK_URL=http://blink.dev
-BLINK_USERNAME=username
-BLINK_PASSWORD=password
-
 # Mail:
 MAIL_ADDRESS=noreply@dosomething.org
 MAIL_NAME=DoSomething.org

--- a/app/Jobs/SendPasswordResetToCustomerIo.php
+++ b/app/Jobs/SendPasswordResetToCustomerIo.php
@@ -4,6 +4,7 @@ namespace Northstar\Jobs;
 
 use Northstar\Models\User;
 use Illuminate\Bus\Queueable;
+use Northstar\Services\CustomerIo;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
@@ -65,24 +66,16 @@ class SendPasswordResetToCustomerIo implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(CustomerIo $customerIo)
     {
-        // Rate limit Blink/Customer.io API requests to 10/s.
+        // Rate limit Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
-        $throttler->then(function () {
-            $payload = [
+        $throttler->then(function () use ($customerIo) {
+            $customerIo->trackEvent($this->user, 'track_call_to_action_email', [
                 'actionUrl' => $this->getUrl(),
                 'type' => $this->type,
                 'userId' => $this->user->id,
-            ];
-
-            $shouldSendToCustomerIo = config('features.blink');
-            if ($shouldSendToCustomerIo) {
-                gateway('blink')->userCallToActionEmail($payload);
-            }
-
-            $verb = $shouldSendToCustomerIo ? 'sent' : 'would have been sent';
-            info('Call To Action Email for '.$payload['userId'].' '.$verb.' to Customer.io');
+            ]);
         }, function () {
             // Could not obtain lock... release to the queue.
             return $this->release(10);

--- a/app/Jobs/SendPasswordResetToCustomerIo.php
+++ b/app/Jobs/SendPasswordResetToCustomerIo.php
@@ -71,7 +71,7 @@ class SendPasswordResetToCustomerIo implements ShouldQueue
         // Rate limit Customer.io API requests to 10/s.
         $throttler = Redis::throttle('customerio')->allow(10)->every(1);
         $throttler->then(function () use ($customerIo) {
-            $customerIo->trackEvent($this->user, 'track_call_to_action_email', [
+            $customerIo->trackEvent($this->user, 'call_to_action_email', [
                 'actionUrl' => $this->getUrl(),
                 'type' => $this->type,
                 'userId' => $this->user->id,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -514,8 +514,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     }
 
     /**
-     * Transform the user model for Blink.
-     * WARNING: THIS PAYLOAD CAN ONLY INCLUDE 300 ATTRIBUTES!!
+     * Transform the user model for Customer.io's profile schema.
+     *
+     * These values must be simple strings or integers (no objects or arrays).
+     * Dates should be represented as UNIX timestamps (other) in order to use
+     * them in triggers. (Note: this payload is limited to 300 attributes).
      *
      * @return array
      */

--- a/config/services.php
+++ b/config/services.php
@@ -58,12 +58,6 @@ return [
         'password' => env('GAMBIT_PASSWORD'),
     ],
 
-    'blink' => [
-        'url' => env('BLINK_URL'),
-        'user' => env('BLINK_USERNAME'),
-        'password' => env('BLINK_PASSWORD'),
-    ],
-
     'customerio' => [
         'url' => 'https://track.customer.io/api/v1/',
         'username' => env('CUSTOMER_IO_USERNAME'),

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -4,18 +4,10 @@ namespace Tests;
 
 use Carbon\Carbon;
 use FakerPhoneNumber;
-use DoSomething\Gateway\Blink;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
 {
-    /**
-     * The Blink API client mock.
-     *
-     * @var \Mockery\MockInterface
-     */
-    protected $blinkMock;
-
     /**
      * The Customer.io API client mock.
      *
@@ -47,10 +39,6 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
-
-        // Configure a mock for Blink model events.
-        $this->blinkMock = $this->mock(Blink::class);
-        $this->blinkMock->shouldReceive('userCallToActionEmail')->andReturn(true);
 
         // Configure a mock for any Customer.io API calls.
         $this->customerIoMock = $this->mock(\Northstar\Services\CustomerIo::class);

--- a/tests/Http/ResetTest.php
+++ b/tests/Http/ResetTest.php
@@ -40,7 +40,7 @@ class ResetTest extends BrowserKitTestCase
         ]);
         $this->assertResponseStatus(200);
         $this->seeJsonStructure(['success']);
-        $this->blinkMock->shouldHaveReceived('userCallToActionEmail')->once();
+        $this->customerIoMock->shouldHaveReceived('trackEvent')->once();
 
         $this->seeInDatabase('password_resets', ['email' => $user->email]);
     }

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -105,7 +105,7 @@ class SubscriptionsTest extends BrowserKitTestCase
         ]);
 
         $this->assertResponseStatus(201);
-        $this->blinkMock->shouldHaveReceived('userCallToActionEmail')->once();
+        $this->customerIoMock->shouldHaveReceived('trackEvent')->once();
 
         $this->seeInDatabase('password_resets', ['email' => 'topics@dosomething.org']);
     }


### PR DESCRIPTION
### What's this PR do?

This pull request updates Northstar to send the `track_call_to_action_email` password reset/account activation emails directly to Customer.io, rather than proxying them through Blink for a second round of rate-limiting and validation.

### How should this be reviewed?

I've split this work up into atomic commits:

🍃 I cleaned up the `trackEvent` method to: first, check if Customer.io is enabled for the environment we're in (so we don't need that logic in every job that sends events); use their `json` payload format to remove need for a for-loop; and check response status to throw an exception if something is wrong. ba01f78

🎯 Sends the `track_call_to_action_email` event directly to Customer.io. This was previously sent to Blink's `callToAction` queue which routed it to the correct Customer.io event name [here](https://github.com/DoSomething/blink/blob/dfe6d5ef138bd2fb3d66a105d626f4ab6f62d6c5/src/workers/CustomerIoCallToActionEmailWorker.js#L9). 6882e6b

🗑️ Removes unused configuration and mocks for Blink, now that we no longer use this API here. cd68b94

📄 Updates documentation on the `toCustomerIoPayload` method to explain some API limitations. b3ae448

### Any background context you want to provide?

This fully removes this application's reliance on Blink! 🥍 

### Relevant tickets

References [Pivotal #174827019](https://www.pivotaltracker.com/story/show/174827019).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
