### PR TITLE
if statement to redirect users activating accounts

### DIFF
--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -137,9 +137,8 @@ class ResetPasswordController extends Controller
     public function redirectPath()
     {
         if (Str::contains(request()->type, 'activate-account')) {
-            return 'profile/about';
+        return 'profile/about';
         }
-        
         return config('services.phoenix.url').'/next/login';
     }
 }

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -136,7 +136,8 @@ class ResetPasswordController extends Controller
      */
     public function redirectPath()
     {
-        if (Str::contains(request()->type, 'activate-account')) {
+        if (Str::contains(request()->type, 'activate-account')) 
+        {
         return 'profile/about';
         }
         return config('services.phoenix.url').'/next/login';

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -137,7 +137,7 @@ class ResetPasswordController extends Controller
     public function redirectPath()
     {
         if (Str::contains(request()->type, 'activate-account')) {
-            return redirect('profile/about');
+            return 'profile/about';
         }
         return config('services.phoenix.url').'/next/login';
     }

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -136,6 +136,9 @@ class ResetPasswordController extends Controller
      */
     public function redirectPath()
     {
+        if (Str::contains(request()->type, 'activate-account')) {
+            return redirect('profile/about');
+        }
         return config('services.phoenix.url').'/next/login';
     }
 }

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -139,6 +139,7 @@ class ResetPasswordController extends Controller
         if (Str::contains(request()->type, 'activate-account')) {
             return 'profile/about';
         }
+        
         return config('services.phoenix.url').'/next/login';
     }
 }

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -136,10 +136,10 @@ class ResetPasswordController extends Controller
      */
     public function redirectPath()
     {
-        if (Str::contains(request()->type, 'activate-account')) 
-        {
-        return 'profile/about';
+        if (Str::contains(request()->type, 'activate-account')) {
+            return 'profile/about';
         }
+
         return config('services.phoenix.url').'/next/login';
     }
 }

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -122,7 +122,7 @@ class PasswordResetTest extends BrowserKitTestCase
         // The user should be logged-in to Northstar, and redirected to Phoenix's OAuth flow.
         $this->seeIsAuthenticated();
         $this->seeIsAuthenticatedAs($user, 'web');
-        $this->assertRedirectedTo(config('services.phoenix.url').'/next/login');
+        $this->assertRedirectedTo('profile/about');
 
         // And their account should be updated with their new password.
         $this->assertTrue(app(Registrar::class)->validateCredentials($user->fresh(), ['password' => 'new-top-secret-passphrase']));


### PR DESCRIPTION
### What's this PR do?

This pull request send users to Northstar reg `page /about`, after they activate their account

### How should this be reviewed?
👁️ 
...

### Any background context you want to provide? 
We want to redirect a user to `profile/about` IF they've just activated their account.
...

### Relevant tickets

References [Pivotal #174675565](https://www.pivotaltracker.com/n/projects/2401401/stories/174675565).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
