### PR TITLE
Rename 'Northstar\' namespace to 'App\'.

### DIFF
--- a/app/Auth/DrupalPasswordHash.php
+++ b/app/Auth/DrupalPasswordHash.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
 define('DRUPAL_MIN_HASH_COUNT', 7);
 define('DRUPAL_MAX_HASH_COUNT', 30);

--- a/app/Auth/Encrypter.php
+++ b/app/Auth/Encrypter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
 use Defuse\Crypto\Key;
 use League\OAuth2\Server\CryptTrait;

--- a/app/Auth/Entities/AccessTokenEntity.php
+++ b/app/Auth/Entities/AccessTokenEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Entities;
+namespace App\Auth\Entities;
 
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Signer\Key;

--- a/app/Auth/Entities/AuthCodeEntity.php
+++ b/app/Auth/Entities/AuthCodeEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Entities;
+namespace App\Auth\Entities;
 
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AuthCodeTrait;

--- a/app/Auth/Entities/ClientEntity.php
+++ b/app/Auth/Entities/ClientEntity.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Auth\Entities;
+namespace App\Auth\Entities;
 
+use App\Models\Client;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Traits\ClientTrait;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
-use Northstar\Models\Client;
 
 class ClientEntity implements ClientEntityInterface
 {

--- a/app/Auth/Entities/RefreshTokenEntity.php
+++ b/app/Auth/Entities/RefreshTokenEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Entities;
+namespace App\Auth\Entities;
 
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;

--- a/app/Auth/Entities/ScopeEntity.php
+++ b/app/Auth/Entities/ScopeEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Entities;
+namespace App\Auth\Entities;
 
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;

--- a/app/Auth/Entities/UserEntity.php
+++ b/app/Auth/Entities/UserEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Entities;
+namespace App\Auth\Entities;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;

--- a/app/Auth/Normalizer.php
+++ b/app/Auth/Normalizer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
 use Carbon\Carbon;
 use libphonenumber\PhoneNumberFormat;

--- a/app/Auth/NorthstarTokenGuard.php
+++ b/app/Auth/NorthstarTokenGuard.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
+use App\Models\User;
 use Illuminate\Auth\TokenGuard;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
 use Mockery\CountValidator\Exception;
-use Northstar\Models\User;
 
 class NorthstarTokenGuard extends TokenGuard implements Guard
 {
@@ -50,7 +50,7 @@ class NorthstarTokenGuard extends TokenGuard implements Guard
      * Retrieve the user from a parsed JWT access token that
      * was provided with the current request.
      *
-     * @return \Northstar\Models\User|null
+     * @return \App\Models\User|null
      */
     public function getUserForToken()
     {

--- a/app/Auth/NorthstarUserProvider.php
+++ b/app/Auth/NorthstarUserProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -18,7 +18,7 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
     /**
      * Create a new database user provider.
      *
-     * @param \Northstar\Auth\Registrar $registrar
+     * @param \App\Auth\Registrar $registrar
      * @param \Illuminate\Contracts\Hashing\Hasher $hasher
      * @param string $model
      */
@@ -36,7 +36,7 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
      * Retrieve a user by the given credentials.
      *
      * @param  array  $credentials
-     * @return \Northstar\Models\User|null
+     * @return \App\Models\User|null
      */
     public function retrieveByCredentials(array $credentials)
     {

--- a/app/Auth/PasswordRules.php
+++ b/app/Auth/PasswordRules.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
 use LangleyFoxall\LaravelNISTPasswordRules\PasswordRules as NISTPasswordRules;
 use LangleyFoxall\LaravelNISTPasswordRules\Rules\BreachedPasswords;

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
+use App\Exceptions\NorthstarValidationException;
+use App\Models\User;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -10,8 +12,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Factory as Validation;
-use Northstar\Exceptions\NorthstarValidationException;
-use Northstar\Models\User;
 
 class Registrar
 {

--- a/app/Auth/Repositories/AccessTokenRepository.php
+++ b/app/Auth/Repositories/AccessTokenRepository.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
+use App\Auth\Entities\AccessTokenEntity;
+use App\Models\User;
 use Carbon\Carbon;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
-use Northstar\Auth\Entities\AccessTokenEntity;
-use Northstar\Models\User;
 
 class AccessTokenRepository implements AccessTokenRepositoryInterface
 {

--- a/app/Auth/Repositories/AuthCodeRepository.php
+++ b/app/Auth/Repositories/AuthCodeRepository.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
+use App\Auth\Entities\AuthCodeEntity;
+use App\Models\AuthCode;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
-use Northstar\Auth\Entities\AuthCodeEntity;
-use Northstar\Models\AuthCode;
 
 class AuthCodeRepository implements AuthCodeRepositoryInterface
 {

--- a/app/Auth/Repositories/ClientRepository.php
+++ b/app/Auth/Repositories/ClientRepository.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
+use App\Auth\Entities\ClientEntity;
+use App\Models\Client;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
-use Northstar\Auth\Entities\ClientEntity;
-use Northstar\Models\Client;
 
 class ClientRepository implements ClientRepositoryInterface
 {
@@ -17,7 +17,7 @@ class ClientRepository implements ClientRepositoryInterface
      */
     public function getClientEntity($clientIdentifier)
     {
-        /** @var \Northstar\Models\Client $model */
+        /** @var \App\Models\Client $model */
         $model = Client::where('client_id', $clientIdentifier)->first();
 
         if (!$model) {

--- a/app/Auth/Repositories/KeyRepository.php
+++ b/app/Auth/Repositories/KeyRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
 use League\OAuth2\Server\CryptKey;
 use Storage;

--- a/app/Auth/Repositories/RefreshTokenRepository.php
+++ b/app/Auth/Repositories/RefreshTokenRepository.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
+use App\Auth\Entities\RefreshTokenEntity;
+use App\Models\RefreshToken;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
-use Northstar\Auth\Entities\RefreshTokenEntity;
-use Northstar\Models\RefreshToken;
 
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {

--- a/app/Auth/Repositories/ScopeRepository.php
+++ b/app/Auth/Repositories/ScopeRepository.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
+use App\Auth\Entities\ScopeEntity;
+use App\Auth\Scope;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
-use Northstar\Auth\Entities\ScopeEntity;
-use Northstar\Auth\Scope;
 
 class ScopeRepository implements ScopeRepositoryInterface
 {

--- a/app/Auth/Repositories/UserRepository.php
+++ b/app/Auth/Repositories/UserRepository.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Auth\Repositories;
+namespace App\Auth\Repositories;
 
+use App\Auth\Entities\UserEntity;
+use App\Auth\Registrar;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
-use Northstar\Auth\Entities\UserEntity;
-use Northstar\Auth\Registrar;
 
 class UserRepository implements UserRepositoryInterface
 {

--- a/app/Auth/Responses/BearerTokenResponse.php
+++ b/app/Auth/Responses/BearerTokenResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth\Responses;
+namespace App\Auth\Responses;
 
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\ResponseTypes\BearerTokenResponse as BaseTokenResponse;

--- a/app/Auth/Role.php
+++ b/app/Auth/Role.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
 use Illuminate\Support\Facades\Log;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -59,7 +59,7 @@ class Role
             return true;
         }
 
-        /** @var \Northstar\Models\User $user */
+        /** @var \App\Models\User $user */
         $user = auth()->user();
 
         // If there isn't a logged-in user, they can't have a role!

--- a/app/Auth/Scope.php
+++ b/app/Auth/Scope.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Auth;
+namespace App\Auth;
 
+use App\Models\Client;
 use Illuminate\Support\Facades\Log;
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Northstar\Models\Client;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class Scope

--- a/app/Console/Commands/BackfillCustomerIo.php
+++ b/app/Console/Commands/BackfillCustomerIo.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Jobs\SendUserToCustomerIo;
+use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Northstar\Jobs\SendUserToCustomerIo;
-use Northstar\Models\User;
 
 class BackfillCustomerIo extends Command
 {

--- a/app/Console/Commands/DeleteUsersCommand.php
+++ b/app/Console/Commands/DeleteUsersCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\User;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Northstar\Models\User;
 
 class DeleteUsersCommand extends Command
 {

--- a/app/Console/Commands/IdentifyUsersCommand.php
+++ b/app/Console/Commands/IdentifyUsersCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Auth\Registrar;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
 use League\Csv\Writer;
-use Northstar\Auth\Registrar;
 
 class IdentifyUsersCommand extends Command
 {

--- a/app/Console/Commands/ImportSubStatusFromCio.php
+++ b/app/Console/Commands/ImportSubStatusFromCio.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Jobs\GetEmailSubStatusFromCustomerIo;
+use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use League\Csv\Reader;
-use Northstar\Jobs\GetEmailSubStatusFromCustomerIo;
-use Northstar\Models\User;
 
 class ImportSubStatusFromCio extends Command
 {

--- a/app/Console/Commands/KeysCommand.php
+++ b/app/Console/Commands/KeysCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Auth\Repositories\KeyRepository;
 use Illuminate\Console\Command;
-use Northstar\Auth\Repositories\KeyRepository;
 use phpseclib\Crypt\RSA;
 
 class KeysCommand extends Command

--- a/app/Console/Commands/ProcessDeletionsCommand.php
+++ b/app/Console/Commands/ProcessDeletionsCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Northstar\Models\User;
 
 class ProcessDeletionsCommand extends Command
 {

--- a/app/Console/Commands/RemoveTotpDevice.php
+++ b/app/Console/Commands/RemoveTotpDevice.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Auth\Registrar;
 use Illuminate\Console\Command;
-use Northstar\Auth\Registrar;
 
 class RemoveTotpDevice extends Command
 {

--- a/app/Console/Commands/SetCommunityTopic.php
+++ b/app/Console/Commands/SetCommunityTopic.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Northstar\Models\User;
 
 class SetCommunityTopic extends Command
 {

--- a/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
+++ b/app/Console/Commands/SetDefaultSmsSubscriptionTopics.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Northstar\Models\User;
 
 class SetDefaultSmsSubscriptionTopics extends Command
 {

--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
 use Defuse\Crypto\Key;
 use DFurnes\Environmentalist\ConfiguresApplication;

--- a/app/Console/Commands/StandardizeBirthdates.php
+++ b/app/Console/Commands/StandardizeBirthdates.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use MongoDB\BSON\UTCDateTime;
-use Northstar\Models\User;
 
 class StandardizeBirthdates extends Command
 {

--- a/app/Console/Commands/UnsetFieldCommand.php
+++ b/app/Console/Commands/UnsetFieldCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
 use DB;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Console\Commands;
+namespace App\Console\Commands;
 
+use App\Models\User;
 use Illuminate\Console\Command;
 use League\Csv\Reader;
-use Northstar\Models\User;
 
 class UpdateUserFieldsCommand extends Command
 {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Console;
+namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;

--- a/app/Events/Event.php
+++ b/app/Events/Event.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Events;
+namespace App\Events;
 
 abstract class Event
 {

--- a/app/Events/PasswordUpdated.php
+++ b/app/Events/PasswordUpdated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Events;
+namespace App\Events;
 
 use Illuminate\Queue\SerializesModels;
 

--- a/app/Events/Throttled.php
+++ b/app/Events/Throttled.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Events;
+namespace App\Events;
 
 class Throttled extends Event
 {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Exceptions;
+namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -126,7 +126,7 @@ class Handler extends ExceptionHandler
      */
     protected function rateLimited($exception)
     {
-        event(new \Northstar\Events\Throttled());
+        event(new \App\Events\Throttled());
 
         $retryAfter = $exception->getHeaders()['Retry-After'];
         $minutes = ceil($retryAfter / 60);

--- a/app/Exceptions/NorthstarValidationException.php
+++ b/app/Exceptions/NorthstarValidationException.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Exceptions;
+namespace App\Exceptions;
 
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\JsonResponse;
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
 
 class NorthstarValidationException extends Exception
 {

--- a/app/Http/Controllers/CauseUpdateController.php
+++ b/app/Http/Controllers/CauseUpdateController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 
 class CauseUpdateController extends Controller
 {

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\ClientTransformer;
+use App\Models\Client;
 use Illuminate\Http\Request;
-use Northstar\Http\Transformers\ClientTransformer;
-use Northstar\Models\Client;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ClientController extends Controller

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Exceptions\NorthstarValidationException;
+use App\Http\Controllers\Traits\FiltersRequests;
+use App\Http\Controllers\Traits\TransformsResponses;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
-use Northstar\Exceptions\NorthstarValidationException;
-use Northstar\Http\Controllers\Traits\FiltersRequests;
-use Northstar\Http\Controllers\Traits\TransformsResponses;
 
 abstract class Controller extends BaseController
 {

--- a/app/Http/Controllers/DeletionRequestController.php
+++ b/app/Http/Controllers/DeletionRequestController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 use Illuminate\Http\Request;
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
 
 class DeletionRequestController extends Controller
 {

--- a/app/Http/Controllers/DiscoveryController.php
+++ b/app/Http/Controllers/DiscoveryController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
 class DiscoveryController extends Controller
 {

--- a/app/Http/Controllers/EmailController.php
+++ b/app/Http/Controllers/EmailController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 
 class EmailController extends Controller
 {

--- a/app/Http/Controllers/KeyController.php
+++ b/app/Http/Controllers/KeyController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Auth\Repositories\KeyRepository;
 use JOSE_JWK;
-use Northstar\Auth\Repositories\KeyRepository;
 use phpseclib\Crypt\RSA;
 
 class KeyController extends Controller

--- a/app/Http/Controllers/Legacy/MergeController.php
+++ b/app/Http/Controllers/Legacy/MergeController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Northstar\Http\Controllers\Legacy;
+namespace App\Http\Controllers\Legacy;
 
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\Legacy\UserTransformer;
+use App\Merge\Merger;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Http\Transformers\Legacy\UserTransformer;
-use Northstar\Merge\Merger;
-use Northstar\Models\User;
 
 class MergeController extends Controller
 {
@@ -51,10 +51,10 @@ class MergeController extends Controller
             'id' => ['required', 'exists:users,_id', 'not_in:' . $id],
         ]);
 
-        /** @var \Northstar\Models\User $target */
+        /** @var \App\Models\User $target */
         $target = User::findOrFail($id);
 
-        /** @var \Northstar\Models\User $duplicate */
+        /** @var \App\Models\User $duplicate */
         $duplicate = User::findOrFail($request->input('id'));
 
         // Get all profile fields from the duplicate (except metadata like ID or source).

--- a/app/Http/Controllers/Legacy/ProfileController.php
+++ b/app/Http/Controllers/Legacy/ProfileController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Northstar\Http\Controllers\Legacy;
+namespace App\Http\Controllers\Legacy;
 
+use App\Auth\Registrar;
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\Legacy\UserTransformer;
+use App\Models\User;
 use Illuminate\Contracts\Auth\Guard as Auth;
 use Illuminate\Http\Request;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Http\Transformers\Legacy\UserTransformer;
-use Northstar\Models\User;
 
 class ProfileController extends Controller
 {
@@ -46,7 +46,7 @@ class ProfileController extends Controller
      */
     public function show()
     {
-        /** @var \Northstar\Models\User $user */
+        /** @var \App\Models\User $user */
         $user = $this->auth->user();
 
         return $this->item($user);
@@ -60,7 +60,7 @@ class ProfileController extends Controller
      */
     public function update(Request $request)
     {
-        /** @var \Northstar\Models\User $user */
+        /** @var \App\Models\User $user */
         $user = $this->auth->user();
 
         // Normalize & validate the given request.

--- a/app/Http/Controllers/Legacy/UserController.php
+++ b/app/Http/Controllers/Legacy/UserController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Http\Controllers\Legacy;
+namespace App\Http\Controllers\Legacy;
 
+use App\Auth\Registrar;
+use App\Auth\Role;
+use App\Exceptions\NorthstarValidationException;
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\Legacy\UserTransformer;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Northstar\Auth\Registrar;
-use Northstar\Auth\Role;
-use Northstar\Exceptions\NorthstarValidationException;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Http\Transformers\Legacy\UserTransformer;
-use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UserController extends Controller

--- a/app/Http/Controllers/MobileController.php
+++ b/app/Http/Controllers/MobileController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 
 class MobileController extends Controller
 {

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Auth\Encrypter;
+use App\Events\Throttled;
+use App\Http\Transformers\UserInfoTransformer;
+use App\Models\RefreshToken;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Http\Request;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Northstar\Auth\Encrypter;
-use Northstar\Events\Throttled;
-use Northstar\Http\Transformers\UserInfoTransformer;
-use Northstar\Models\RefreshToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/app/Http/Controllers/ResetController.php
+++ b/app/Http/Controllers/ResetController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Models\User;
+use App\PasswordResetType;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use Northstar\Models\User;
-use Northstar\PasswordResetType;
 
 class ResetController extends Controller
 {
@@ -32,7 +32,7 @@ class ResetController extends Controller
             'type' => ['required', Rule::in(PasswordResetType::all())],
         ]);
 
-        /** @var \Northstar\Models\User $user */
+        /** @var \App\Models\User $user */
         $user = User::findOrFail($request['id']);
 
         $user->sendPasswordReset($request['type']);

--- a/app/Http/Controllers/ScopeController.php
+++ b/app/Http/Controllers/ScopeController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Northstar\Auth\Scope;
+use App\Auth\Scope;
 
 class ScopeController extends Controller
 {

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Auth\Registrar;
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
+use App\PasswordResetType;
 use Illuminate\Http\Request;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
-use Northstar\PasswordResetType;
 
 class SubscriptionController extends Controller
 {

--- a/app/Http/Controllers/SubscriptionUpdateController.php
+++ b/app/Http/Controllers/SubscriptionUpdateController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 
 class SubscriptionUpdateController extends Controller
 {

--- a/app/Http/Controllers/Traits/FiltersRequests.php
+++ b/app/Http/Controllers/Traits/FiltersRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Controllers\Traits;
+namespace App\Http\Controllers\Traits;
 
 trait FiltersRequests
 {

--- a/app/Http/Controllers/Traits/TransformsResponses.php
+++ b/app/Http/Controllers/Traits/TransformsResponses.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Controllers\Traits;
+namespace App\Http\Controllers\Traits;
 
 use Illuminate\Pagination\Paginator;
 use League\Fractal\Manager;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
+use App\Auth\Registrar;
+use App\Auth\Role;
+use App\Exceptions\NorthstarValidationException;
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
-use Northstar\Auth\Registrar;
-use Northstar\Auth\Role;
-use Northstar\Exceptions\NorthstarValidationException;
-use Northstar\Http\Transformers\UserTransformer;
-use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class UserController extends Controller

--- a/app/Http/Controllers/UserInfoController.php
+++ b/app/Http/Controllers/UserInfoController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Controllers;
+namespace App\Http\Controllers;
 
 class UserInfoController extends Controller
 {

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\Entities\UserEntity;
+use App\Auth\PasswordRules;
+use App\Auth\Registrar;
+use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use League\OAuth2\Server\AuthorizationServer;
-use Northstar\Auth\Entities\UserEntity;
-use Northstar\Auth\PasswordRules;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Models\User;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -211,7 +211,7 @@ class AuthController extends Controller
      *
      * @param Request $request
      * @return \Illuminate\Http\Response
-     * @throws \Northstar\Exceptions\NorthstarValidationException
+     * @throws \App\Exceptions\NorthstarValidationException
      */
     public function postRegister(Request $request)
     {

--- a/app/Http/Controllers/Web/FacebookController.php
+++ b/app/Http/Controllers/Web/FacebookController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\Registrar;
+use App\Http\Controllers\Controller;
+use App\Models\User;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Models\User;
 
 class FacebookController extends Controller
 {

--- a/app/Http/Controllers/Web/ForgotPasswordController.php
+++ b/app/Http/Controllers/Web/ForgotPasswordController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
-use Northstar\Http\Controllers\Controller;
 
 class ForgotPasswordController extends Controller
 {

--- a/app/Http/Controllers/Web/GoogleController.php
+++ b/app/Http/Controllers/Web/GoogleController.php
@@ -1,7 +1,11 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\Registrar;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\Google;
 use Carbon\Carbon;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
@@ -9,10 +13,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Models\User;
-use Northstar\Services\Google;
 
 class GoogleController extends Controller
 {
@@ -74,7 +74,7 @@ class GoogleController extends Controller
             $googleUser = Socialite::driver('google')->user();
             // Use the service container so we can mock Google API requests in tests.
             // @see https://laravel.com/docs/5.5/helpers#method-app
-            $client = app('Northstar\Services\Google');
+            $client = app('App\Services\Google');
 
             $googleProfile = $client->getProfile($googleUser->token);
         } catch (RequestException | ClientException | InvalidStateException $e) {

--- a/app/Http/Controllers/Web/PasswordController.php
+++ b/app/Http/Controllers/Web/PasswordController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\PasswordRules;
+use App\Events\PasswordUpdated;
+use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\Request;
-use Northstar\Auth\PasswordRules;
-use Northstar\Events\PasswordUpdated;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Models\User;
 
 class PasswordController extends Controller
 {
@@ -22,7 +22,7 @@ class PasswordController extends Controller
     /**
      * Update the specified user's password.
      *
-     * @param  \Northstar\Models\User $user
+     * @param  \App\Models\User $user
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */

--- a/app/Http/Controllers/Web/ProfileAboutController.php
+++ b/app/Http/Controllers/Web/ProfileAboutController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\Registrar;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Controllers\Controller;
 
 class ProfileAboutController extends Controller
 {

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\Registrar;
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Northstar\Auth\Registrar;
-use Northstar\Http\Controllers\Controller;
 
 class ProfileSubscriptionsController extends Controller
 {

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\PasswordRules;
+use App\Events\PasswordUpdated;
+use App\Http\Controllers\Controller;
+use App\PasswordResetType;
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
-use Northstar\Auth\PasswordRules;
-use Northstar\Events\PasswordUpdated;
-use Northstar\Http\Controllers\Controller;
-use Northstar\PasswordResetType;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResetPasswordController extends Controller

--- a/app/Http/Controllers/Web/TotpController.php
+++ b/app/Http/Controllers/Web/TotpController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Http\Controllers\Controller;
+use App\Models\User;
 use Endroid\QrCode\QrCode;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Models\User;
 use OTPHP\Factory;
 use OTPHP\TOTP;
 

--- a/app/Http/Controllers/Web/UserController.php
+++ b/app/Http/Controllers/Web/UserController.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Northstar\Http\Controllers\Web;
+namespace App\Http\Controllers\Web;
 
+use App\Auth\PasswordRules;
+use App\Auth\Registrar;
+use App\Events\PasswordUpdated;
+use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
-use Northstar\Auth\PasswordRules;
-use Northstar\Auth\Registrar;
-use Northstar\Events\PasswordUpdated;
-use Northstar\Http\Controllers\Controller;
-use Northstar\Models\User;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class UserController extends BaseController

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http;
+namespace App\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
@@ -15,9 +15,9 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \Northstar\Http\Middleware\LogMemoryUsage::class,
-        \Northstar\Http\Middleware\TrimStrings::class,
-        \Northstar\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\LogMemoryUsage::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \App\Http\Middleware\TrustProxies::class,
     ];
 
     /**
@@ -27,17 +27,17 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \Northstar\Http\Middleware\EncryptCookies::class,
+            \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \Northstar\Http\Middleware\VerifyCsrfToken::class,
-            \Northstar\Http\Middleware\SetLanguageFromHeader::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \App\Http\Middleware\SetLanguageFromHeader::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             'guard:web',
         ],
         'api' => [
-            \Northstar\Http\Middleware\ParseOAuthHeader::class,
+            \App\Http\Middleware\ParseOAuthHeader::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Barryvdh\Cors\HandleCors::class,
             'guard:api',
@@ -51,11 +51,11 @@ class Kernel extends HttpKernel
      */
     protected $routeMiddleware = [
         'guard' => \DoSomething\Gateway\Server\Middleware\SetGuard::class,
-        'auth' => \Northstar\Http\Middleware\Authenticate::class,
+        'auth' => \App\Http\Middleware\Authenticate::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest' => \Northstar\Http\Middleware\RedirectIfAuthenticated::class,
-        'scope' => \Northstar\Http\Middleware\RequireScope::class,
-        'role' => \Northstar\Http\Middleware\RequireRole::class,
-        'throttle' => \Northstar\Http\Middleware\ThrottleRequests::class,
+        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'scope' => \App\Http\Middleware\RequireScope::class,
+        'role' => \App\Http\Middleware\RequireRole::class,
+        'throttle' => \App\Http\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthenticationException;

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Cookie\Middleware\EncryptCookies as BaseEncrypter;
 

--- a/app/Http/Middleware/LogMemoryUsage.php
+++ b/app/Http/Middleware/LogMemoryUsage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Facades\Log;

--- a/app/Http/Middleware/ParseOAuthHeader.php
+++ b/app/Http/Middleware/ParseOAuthHeader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Support\Str;
 use League\OAuth2\Server\ResourceServer;

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\Factory as Auth;

--- a/app/Http/Middleware/RequireRole.php
+++ b/app/Http/Middleware/RequireRole.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
+use App\Auth\Role;
 use Closure;
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Northstar\Auth\Role;
 
 class RequireRole
 {

--- a/app/Http/Middleware/RequireScope.php
+++ b/app/Http/Middleware/RequireScope.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
+use App\Auth\Scope;
 use Closure;
-use Northstar\Auth\Scope;
 
 class RequireScope
 {

--- a/app/Http/Middleware/SetLanguageFromHeader.php
+++ b/app/Http/Middleware/SetLanguageFromHeader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use App;
 use Closure;

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Routing\Middleware\ThrottleRequests as BaseThrottler;

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Http\Middleware\TrimStrings as BaseTrimmer;
 

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Fideloper\Proxy\TrustProxies as Middleware;
 use Illuminate\Http\Request;

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Middleware;
+namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as BaseVerifier;
 

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Http\Requests;
+namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/app/Http/Transformers/BaseTransformer.php
+++ b/app/Http/Transformers/BaseTransformer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\User;
 use Illuminate\Support\Str;
 use League\Fractal\Scope;
 use League\Fractal\TransformerAbstract;
-use Northstar\Models\User;
 
 class BaseTransformer extends TransformerAbstract
 {

--- a/app/Http/Transformers/ClientTransformer.php
+++ b/app/Http/Transformers/ClientTransformer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\Client;
 use Illuminate\Support\Str;
 use League\Fractal\TransformerAbstract;
-use Northstar\Models\Client;
 
 class ClientTransformer extends TransformerAbstract
 {

--- a/app/Http/Transformers/Legacy/UserTransformer.php
+++ b/app/Http/Transformers/Legacy/UserTransformer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Http\Transformers\Legacy;
+namespace App\Http\Transformers\Legacy;
 
+use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 use League\Fractal\TransformerAbstract;
-use Northstar\Models\User;
 
 class UserTransformer extends TransformerAbstract
 {

--- a/app/Http/Transformers/UserInfoTransformer.php
+++ b/app/Http/Transformers/UserInfoTransformer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\User;
 use League\Fractal\TransformerAbstract;
-use Northstar\Models\User;
 
 class UserInfoTransformer extends TransformerAbstract
 {

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Http\Transformers;
+namespace App\Http\Transformers;
 
+use App\Models\User;
 use Illuminate\Support\Facades\Gate;
-use Northstar\Models\User;
 
 class UserTransformer extends BaseTransformer
 {

--- a/app/Jobs/CreateCustomerIoEvent.php
+++ b/app/Jobs/CreateCustomerIoEvent.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
+use App\Models\User;
+use App\Services\CustomerIo;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
-use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
 
 class CreateCustomerIoEvent implements ShouldQueue
 {

--- a/app/Jobs/DeleteUserFromOtherServices.php
+++ b/app/Jobs/DeleteUserFromOtherServices.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
+use App\Services\CustomerIo;
+use App\Services\Gambit;
+use App\Services\Rogue;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
-use Northstar\Services\CustomerIo;
-use Northstar\Services\Gambit;
-use Northstar\Services\Rogue;
 
 class DeleteUserFromOtherServices implements ShouldQueue
 {

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Northstar\Models\User;
 use Redis;
 
 class GetEmailSubStatusFromCustomerIo implements ShouldQueue

--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
 abstract class Job
 {

--- a/app/Jobs/SendPasswordResetToCustomerIo.php
+++ b/app/Jobs/SendPasswordResetToCustomerIo.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
+use App\Models\User;
+use App\Services\CustomerIo;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
-use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
 
 class SendPasswordResetToCustomerIo implements ShouldQueue
 {

--- a/app/Jobs/SendPasswordUpdatedToCustomerIo.php
+++ b/app/Jobs/SendPasswordUpdatedToCustomerIo.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
+use App\Models\User;
+use App\Services\CustomerIo;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
-use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
 
 class SendPasswordUpdatedToCustomerIo implements ShouldQueue
 {

--- a/app/Jobs/SendUserToCustomerIo.php
+++ b/app/Jobs/SendUserToCustomerIo.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Northstar\Jobs;
+namespace App\Jobs;
 
+use App\Models\User;
+use App\Services\CustomerIo;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
-use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
 
 class SendUserToCustomerIo implements ShouldQueue
 {

--- a/app/Listeners/ReportFailedAuthenticationAttempt.php
+++ b/app/Listeners/ReportFailedAuthenticationAttempt.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Listeners;
+namespace App\Listeners;
 
 use Illuminate\Support\Facades\Log;
 

--- a/app/Listeners/ReportPasswordUpdated.php
+++ b/app/Listeners/ReportPasswordUpdated.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Listeners;
+namespace App\Listeners;
 
-use Northstar\Events\PasswordUpdated;
-use Northstar\Jobs\SendPasswordUpdatedToCustomerIo;
+use App\Events\PasswordUpdated;
+use App\Jobs\SendPasswordUpdatedToCustomerIo;
 
 class ReportPasswordUpdated
 {

--- a/app/Listeners/ReportSuccessfulAuthentication.php
+++ b/app/Listeners/ReportSuccessfulAuthentication.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Northstar\Listeners;
+namespace App\Listeners;
 
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Log;
-use Northstar\Models\User;
 
 class ReportSuccessfulAuthentication
 {

--- a/app/Listeners/ReportThrottledRequest.php
+++ b/app/Listeners/ReportThrottledRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Listeners;
+namespace App\Listeners;
 
 use Illuminate\Support\Facades\Log;
 

--- a/app/Logging/ContextFormatter.php
+++ b/app/Logging/ContextFormatter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Logging;
+namespace App\Logging;
 
 use Illuminate\Log\Logger;
 

--- a/app/Merge/Merger.php
+++ b/app/Merge/Merger.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Northstar\Merge;
+namespace App\Merge;
 
+use App\Exceptions\NorthstarValidationException;
 use Illuminate\Support\Str;
-use Northstar\Exceptions\NorthstarValidationException;
 
 class Merger
 {

--- a/app/Models/AuthCode.php
+++ b/app/Models/AuthCode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Models;
+namespace App\Models;
 
 use Carbon\Carbon;
 

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Models;
+namespace App\Models;
 
 use Illuminate\Support\Str;
 

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Models;
+namespace App\Models;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;

--- a/app/Models/RefreshToken.php
+++ b/app/Models/RefreshToken.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Models;
+namespace App\Models;
 
 /**
  * The OAuth refresh token model.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,7 +1,11 @@
 <?php
 
-namespace Northstar\Models;
+namespace App\Models;
 
+use App\Auth\Role;
+use App\Jobs\SendPasswordResetToCustomerIo;
+use App\PasswordResetType;
+use App\Services\GraphQL;
 use Carbon\Carbon;
 use Email\Parse as EmailParser;
 use Illuminate\Auth\Authenticatable;
@@ -16,10 +20,6 @@ use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Auth\DatabaseTokenRepository;
 use Jenssegers\Mongodb\Eloquent\SoftDeletes;
 use libphonenumber\PhoneNumberFormat;
-use Northstar\Auth\Role;
-use Northstar\Jobs\SendPasswordResetToCustomerIo;
-use Northstar\PasswordResetType;
-use Northstar\Services\GraphQL;
 
 /**
  * The User model. (Fight for the user!).

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Northstar\Observers;
+namespace App\Observers;
 
+use App\Jobs\CreateCustomerIoEvent;
+use App\Jobs\DeleteUserFromOtherServices;
+use App\Jobs\SendUserToCustomerIo;
+use App\Models\RefreshToken;
+use App\Models\User;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
-use Northstar\Jobs\CreateCustomerIoEvent;
-use Northstar\Jobs\DeleteUserFromOtherServices;
-use Northstar\Jobs\SendUserToCustomerIo;
-use Northstar\Models\RefreshToken;
-use Northstar\Models\User;
 
 class UserObserver
 {
     /**
      * Handle the User "creating" event.
      *
-     * @param  \Northstar\Models\User  $user
+     * @param  \App\Models\User  $user
      * @return void
      */
     public function creating(User $user)
@@ -40,7 +40,7 @@ class UserObserver
     /**
      * Handle the User "created" event.
      *
-     * @param  \Northstar\Models\User  $user
+     * @param  \App\Models\User  $user
      * @return void
      */
     public function created(User $user)
@@ -57,7 +57,7 @@ class UserObserver
     /**
      * Handle the User "updating" event.
      *
-     * @param  \Northstar\Models\User  $user
+     * @param  \App\Models\User  $user
      * @return void
      */
     public function updating(User $user)
@@ -131,7 +131,7 @@ class UserObserver
     /**
      * Handle the User "updated" event.
      *
-     * @param  \Northstar\Models\User  $user
+     * @param  \App\Models\User  $user
      * @return void
      */
     public function updated(User $user)
@@ -145,7 +145,7 @@ class UserObserver
     /**
      * Handle the User "deleting" event.
      *
-     * @param  \Northstar\Models\User  $user
+     * @param  \App\Models\User  $user
      * @return void
      */
     public function deleting(User $user)

--- a/app/PasswordResetType.php
+++ b/app/PasswordResetType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar;
+namespace App;
 
 class PasswordResetType
 {

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Policies;
+namespace App\Policies;
 
+use App\Auth\Scope;
+use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Northstar\Auth\Scope;
-use Northstar\Models\User;
 
 class UserPolicy
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
-use Northstar\Models\User;
-use Northstar\Observers\UserObserver;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
+use App\Models\User;
+use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Northstar\Models\User;
-use Northstar\Policies\UserPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\ServiceProvider;

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
+use App\Events\PasswordUpdated;
+use App\Events\Throttled;
+use App\Listeners\ReportFailedAuthenticationAttempt;
+use App\Listeners\ReportPasswordUpdated;
+use App\Listeners\ReportSuccessfulAuthentication;
+use App\Listeners\ReportThrottledRequest;
 use Event;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Northstar\Events\PasswordUpdated;
-use Northstar\Events\Throttled;
-use Northstar\Listeners\ReportFailedAuthenticationAttempt;
-use Northstar\Listeners\ReportPasswordUpdated;
-use Northstar\Listeners\ReportSuccessfulAuthentication;
-use Northstar\Listeners\ReportThrottledRequest;
 
 class EventServiceProvider extends ServiceProvider
 {

--- a/app/Providers/OAuthServiceProvider.php
+++ b/app/Providers/OAuthServiceProvider.php
@@ -1,7 +1,18 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
+use App\Auth\NorthstarTokenGuard;
+use App\Auth\NorthstarUserProvider;
+use App\Auth\Registrar;
+use App\Auth\Repositories\AccessTokenRepository;
+use App\Auth\Repositories\AuthCodeRepository;
+use App\Auth\Repositories\ClientRepository;
+use App\Auth\Repositories\KeyRepository;
+use App\Auth\Repositories\RefreshTokenRepository;
+use App\Auth\Repositories\ScopeRepository;
+use App\Auth\Repositories\UserRepository;
+use App\Auth\Responses\BearerTokenResponse;
 use DateInterval;
 use Defuse\Crypto\Key;
 use Illuminate\Cache\RateLimiter;
@@ -19,17 +30,6 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
-use Northstar\Auth\NorthstarTokenGuard;
-use Northstar\Auth\NorthstarUserProvider;
-use Northstar\Auth\Registrar;
-use Northstar\Auth\Repositories\AccessTokenRepository;
-use Northstar\Auth\Repositories\AuthCodeRepository;
-use Northstar\Auth\Repositories\ClientRepository;
-use Northstar\Auth\Repositories\KeyRepository;
-use Northstar\Auth\Repositories\RefreshTokenRepository;
-use Northstar\Auth\Repositories\ScopeRepository;
-use Northstar\Auth\Repositories\UserRepository;
-use Northstar\Auth\Responses\BearerTokenResponse;
 
 class OAuthServiceProvider extends ServiceProvider
 {

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
+use App\Auth\Registrar;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
-use Northstar\Auth\Registrar;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -15,7 +15,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    protected $namespace = 'Northstar\Http\Controllers';
+    protected $namespace = 'App\Http\Controllers';
 
     /**
      * The registrar handles creating, updating, and

--- a/app/Providers/SixpackServiceProvider.php
+++ b/app/Providers/SixpackServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use SeatGeek\Sixpack\Session\Base as Sixpack;

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Northstar\Providers;
+namespace App\Providers;
 
+use App\Auth\Scope;
 use Illuminate\Support\ServiceProvider;
 use libphonenumber\PhoneNumberUtil;
-use Northstar\Auth\Scope;
 
 class ValidationServiceProvider extends ServiceProvider
 {

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Northstar\Services;
+namespace App\Services;
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class CustomerIo
 {

--- a/app/Services/Gambit.php
+++ b/app/Services/Gambit.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Northstar\Services;
+namespace App\Services;
 
-use Northstar\Models\User;
+use App\Models\User;
 use RuntimeException;
 
 class Gambit

--- a/app/Services/Google.php
+++ b/app/Services/Google.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Services;
+namespace App\Services;
 
 class Google
 {

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Northstar\Services;
+namespace App\Services;
 
 use Softonic\GraphQL\ClientBuilder;
 

--- a/app/Services/Rogue.php
+++ b/app/Services/Rogue.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Northstar\Services;
+namespace App\Services;
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class Rogue
 {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,17 +1,17 @@
 <?php
 
+use App\Auth\Entities\ClientEntity;
+use App\Auth\Normalizer;
+use App\Auth\Repositories\AccessTokenRepository;
+use App\Auth\Repositories\KeyRepository;
+use App\Auth\Repositories\ScopeRepository;
+use App\Models\Client;
 use Carbon\Carbon;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
-use Northstar\Auth\Entities\ClientEntity;
-use Northstar\Auth\Normalizer;
-use Northstar\Auth\Repositories\AccessTokenRepository;
-use Northstar\Auth\Repositories\KeyRepository;
-use Northstar\Auth\Repositories\ScopeRepository;
-use Northstar\Models\Client;
 use SeatGeek\Sixpack\Session\Base as Sixpack;
 
 /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -28,17 +28,17 @@ $app = new Illuminate\Foundation\Application(
 
 $app->singleton(
     'Illuminate\Contracts\Http\Kernel',
-    'Northstar\Http\Kernel'
+    'App\Http\Kernel'
 );
 
 $app->singleton(
     'Illuminate\Contracts\Console\Kernel',
-    'Northstar\Console\Kernel'
+    'App\Console\Kernel'
 );
 
 $app->singleton(
     'Illuminate\Contracts\Debug\ExceptionHandler',
-    'Northstar\Exceptions\Handler'
+    'App\Exceptions\Handler'
 );
 
 /*

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
       "app/helpers.php"
     ],
     "psr-4": {
-      "Northstar\\": "app/"
+      "App\\": "app/"
     }
   },
   "extra": {

--- a/config/app.php
+++ b/config/app.php
@@ -156,14 +156,14 @@ return [
         /*
          * Application Service Providers...
          */
-        Northstar\Providers\AppServiceProvider::class,
-        Northstar\Providers\AuthServiceProvider::class,
-        Northstar\Providers\BroadcastServiceProvider::class,
-        Northstar\Providers\EventServiceProvider::class,
-        Northstar\Providers\OAuthServiceProvider::class,
-        Northstar\Providers\RouteServiceProvider::class,
-        Northstar\Providers\ValidationServiceProvider::class,
-        Northstar\Providers\SixpackServiceProvider::class,
+        App\Providers\AppServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
+        App\Providers\BroadcastServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
+        App\Providers\OAuthServiceProvider::class,
+        App\Providers\RouteServiceProvider::class,
+        App\Providers\ValidationServiceProvider::class,
+        App\Providers\SixpackServiceProvider::class,
     ],
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -77,8 +77,8 @@ return [
 
     'providers' => [
         'users' => [
-            'driver' => 'northstar', // @see: \Northstar\Auth\NorthstarUserProvider
-            'model' => Northstar\Models\User::class,
+            'driver' => 'northstar', // @see: \App\Auth\NorthstarUserProvider
+            'model' => App\Models\User::class,
         ],
     ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -38,21 +38,21 @@ return [
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
-            'tap' => [Northstar\Logging\ContextFormatter::class],
+            'tap' => [App\Logging\ContextFormatter::class],
             'level' => 'debug',
         ],
 
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
-            'tap' => [Northstar\Logging\ContextFormatter::class],
+            'tap' => [App\Logging\ContextFormatter::class],
             'level' => 'debug',
             'days' => 7,
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
-            'tap' => [Northstar\Logging\ContextFormatter::class],
+            'tap' => [App\Logging\ContextFormatter::class],
             'level' => 'debug',
         ],
     ],

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -7,7 +7,7 @@
  *
  * @var \Illuminate\Database\Eloquent\Factory $factory
  */
-$factory->define(Northstar\Models\User::class, function (
+$factory->define(App\Models\User::class, function (
     Faker\Generator $faker
 ) {
     $faker->addProvider(new FakerPhoneNumber($faker));
@@ -57,7 +57,7 @@ $factory->define(Northstar\Models\User::class, function (
     ];
 });
 
-$factory->state(Northstar\Models\User::class, 'email-subscribed', function (
+$factory->state(App\Models\User::class, 'email-subscribed', function (
     Faker\Generator $faker
 ) {
     return [
@@ -69,7 +69,7 @@ $factory->state(Northstar\Models\User::class, 'email-subscribed', function (
     ];
 });
 
-$factory->state(Northstar\Models\User::class, 'email-unsubscribed', function (
+$factory->state(App\Models\User::class, 'email-unsubscribed', function (
     Faker\Generator $faker
 ) {
     return [
@@ -77,7 +77,7 @@ $factory->state(Northstar\Models\User::class, 'email-unsubscribed', function (
     ];
 });
 
-$factory->state(Northstar\Models\User::class, 'sms-subscribed', function (
+$factory->state(App\Models\User::class, 'sms-subscribed', function (
     Faker\Generator $faker
 ) {
     return [
@@ -87,7 +87,7 @@ $factory->state(Northstar\Models\User::class, 'sms-subscribed', function (
     ];
 });
 
-$factory->state(Northstar\Models\User::class, 'sms-unsubscribed', function (
+$factory->state(App\Models\User::class, 'sms-unsubscribed', function (
     Faker\Generator $faker
 ) {
     return [
@@ -96,7 +96,7 @@ $factory->state(Northstar\Models\User::class, 'sms-unsubscribed', function (
     ];
 });
 
-$factory->defineAs(Northstar\Models\User::class, 'staff', function (
+$factory->defineAs(App\Models\User::class, 'staff', function (
     Faker\Generator $faker
 ) {
     $faker->addProvider(new FakerPhoneNumber($faker));
@@ -117,7 +117,7 @@ $factory->defineAs(Northstar\Models\User::class, 'staff', function (
     ];
 });
 
-$factory->defineAs(Northstar\Models\User::class, 'admin', function (
+$factory->defineAs(App\Models\User::class, 'admin', function (
     Faker\Generator $faker
 ) {
     $faker->addProvider(new FakerPhoneNumber($faker));
@@ -139,7 +139,7 @@ $factory->defineAs(Northstar\Models\User::class, 'admin', function (
 });
 
 $factory->defineAs(
-    \Northstar\Models\Client::class,
+    \App\Models\Client::class,
     'authorization_code',
     function (Faker\Generator $faker) {
         return [
@@ -159,7 +159,7 @@ $factory->defineAs(
     },
 );
 
-$factory->defineAs(\Northstar\Models\Client::class, 'password', function (
+$factory->defineAs(\App\Models\Client::class, 'password', function (
     Faker\Generator $faker
 ) {
     return [
@@ -172,7 +172,7 @@ $factory->defineAs(\Northstar\Models\Client::class, 'password', function (
 });
 
 $factory->defineAs(
-    \Northstar\Models\Client::class,
+    \App\Models\Client::class,
     'client_credentials',
     function (Faker\Generator $faker) {
         return [

--- a/database/seeds/ClientTableSeeder.php
+++ b/database/seeds/ClientTableSeeder.php
@@ -1,8 +1,8 @@
 <?php
 
+use App\Auth\Scope;
+use App\Models\Client;
 use Illuminate\Database\Seeder;
-use Northstar\Auth\Scope;
-use Northstar\Models\Client;
 
 class ClientTableSeeder extends Seeder
 {

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Database\Seeder;
-use Northstar\Models\User;
 
 class UserTableSeeder extends Seeder
 {

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,7 +6,7 @@
  * contains the "api" middleware group. Now create something great!
  *
  * @var \Illuminate\Routing\Router $router
- * @see \Northstar\Providers\RouteServiceProvider
+ * @see \App\Providers\RouteServiceProvider
  */
 
 // https://profile.dosomething.org/v2/

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@
  * contains the "web" middleware group. Now create something great!
  *
  * @var \Illuminate\Routing\Router $router
- * @see \Northstar\Providers\RouteServiceProvider
+ * @see \App\Providers\RouteServiceProvider
  */
 
 // Homepage

--- a/tests/Auth/DrupalPasswordHashTest.php
+++ b/tests/Auth/DrupalPasswordHashTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Northstar\Auth\DrupalPasswordHash;
-use Northstar\Auth\Registrar;
-use Northstar\Models\User;
+use App\Auth\DrupalPasswordHash;
+use App\Auth\Registrar;
+use App\Models\User;
 
 class DrupalPasswordHashTest extends BrowserKitTestCase
 {

--- a/tests/Auth/RegistrarTest.php
+++ b/tests/Auth/RegistrarTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Auth\Registrar;
+use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
-use Northstar\Auth\Registrar;
-use Northstar\Models\User;
 
 class RegistrarTest extends BrowserKitTestCase
 {

--- a/tests/Console/AddAddressesCommand.php
+++ b/tests/Console/AddAddressesCommand.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class AddAddressesCommand extends TestCase
 {

--- a/tests/Console/BackfillCustomerIoTest.php
+++ b/tests/Console/BackfillCustomerIoTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class BackfillCustomerIoTest extends BrowserKitTestCase
 {

--- a/tests/Console/CommunityTopicBackfillTest.php
+++ b/tests/Console/CommunityTopicBackfillTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class CommunityTopicBackfillTest extends BrowserKitTestCase
 {

--- a/tests/Console/DeleteUsersCommandTest.php
+++ b/tests/Console/DeleteUsersCommandTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Models\User;
+use App\Services\Gambit;
+use App\Services\Rogue;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
-use Northstar\Services\Gambit;
-use Northstar\Services\Rogue;
 
 class DeleteUsersCommandTest extends TestCase
 {

--- a/tests/Console/IdentifyUsersCommandTest.php
+++ b/tests/Console/IdentifyUsersCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class IdentifyUsersCommandTest extends TestCase
 {

--- a/tests/Console/ProcessDeletionsCommandTest.php
+++ b/tests/Console/ProcessDeletionsCommandTest.php
@@ -1,10 +1,10 @@
 <?php
 
+use App\Models\User;
+use App\Services\Gambit;
+use App\Services\Rogue;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
-use Northstar\Services\Gambit;
-use Northstar\Services\Rogue;
 
 class ProcessDeletionsCommandTest extends TestCase
 {

--- a/tests/Console/StandardizeBirthdatesTest.php
+++ b/tests/Console/StandardizeBirthdatesTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class StandardizeBirthdatesTest extends TestCase
 {

--- a/tests/Console/UnsetFieldsTest.php
+++ b/tests/Console/UnsetFieldsTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class UnsetFieldsTest extends TestCase
 {

--- a/tests/Console/UpdateUserFieldsCommandTest.php
+++ b/tests/Console/UpdateUserFieldsCommandTest.php
@@ -1,8 +1,8 @@
 <?php
 
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Artisan;
-use Northstar\Models\User;
 
 class UpdateUserFieldsCommandTest extends BrowserKitTestCase
 {

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -42,13 +42,13 @@ trait CreatesApplication
 
         // Configure a mock for any Customer.io API calls.
         $this->customerIoMock = $this->mock(
-            \Northstar\Services\CustomerIo::class,
+            \App\Services\CustomerIo::class,
         );
         $this->customerIoMock->shouldReceive('updateCustomer')->andReturn(null);
         $this->customerIoMock->shouldReceive('trackEvent');
 
         // Configure a mock for GraphQL calls.
-        $this->graphqlMock = $this->mock(\Northstar\Services\GraphQL::class);
+        $this->graphqlMock = $this->mock(\App\Services\GraphQL::class);
         $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([
             'name' => 'San Dimas High School',
             'location' => 'US-CA',

--- a/tests/Events/Authentication.php
+++ b/tests/Events/Authentication.php
@@ -1,14 +1,14 @@
 <?php
 
+use App\Models\User;
 use Carbon\Carbon;
-use Northstar\Models\User;
 
 class AuthenticationEventsTest extends BrowserKitTestCase
 {
     /** @test */
     public function testSuccessfulLoginEvent()
     {
-        /** @var \Northstar\Models\User $user */
+        /** @var \App\Models\User $user */
         $user = factory(User::class)->create([
             'last_authenticated_at' => Carbon::yesterday(),
         ]);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\Client;
 use Carbon\Carbon;
-use Northstar\Models\Client;
 
 class HelpersTest extends BrowserKitTestCase
 {

--- a/tests/Http/CauseUpdateTest.php
+++ b/tests/Http/CauseUpdateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class CauseUpdateTest extends BrowserKitTestCase
 {

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Northstar\Models\Client;
-use Northstar\Models\User;
+use App\Models\Client;
+use App\Models\User;
 
 class ClientTest extends BrowserKitTestCase
 {

--- a/tests/Http/DeletionRequestTest.php
+++ b/tests/Http/DeletionRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Carbon\Carbon;
-use Northstar\Models\User;
 
 class DeletionRequestTest extends BrowserKitTestCase
 {

--- a/tests/Http/MergeTest.php
+++ b/tests/Http/MergeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class MergeTest extends BrowserKitTestCase
 {

--- a/tests/Http/OAuthTest.php
+++ b/tests/Http/OAuthTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Northstar\Models\Client;
-use Northstar\Models\User;
+use App\Models\Client;
+use App\Models\User;
 
 class OAuthTest extends BrowserKitTestCase
 {
@@ -244,7 +244,7 @@ class OAuthTest extends BrowserKitTestCase
         }
 
         // This next request should trigger a StatHat counter.
-        $this->expectsEvents(\Northstar\Events\Throttled::class);
+        $this->expectsEvents(\App\Events\Throttled::class);
 
         $this->post('v2/auth/token', $invalidCredentials);
         $this->assertResponseStatus(429);

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class ProfileSubscriptionsTest extends BrowserKitTestCase
 {

--- a/tests/Http/ResetTest.php
+++ b/tests/Http/ResetTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Northstar\Models\User;
-use Northstar\PasswordResetType;
+use App\Models\User;
+use App\PasswordResetType;
 
 class ResetTest extends BrowserKitTestCase
 {

--- a/tests/Http/SubscriptionUpdateTest.php
+++ b/tests/Http/SubscriptionUpdateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class SubscriptionUpdateTest extends BrowserKitTestCase
 {

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class SubscriptionsTest extends BrowserKitTestCase
 {
@@ -113,7 +113,7 @@ class SubscriptionsTest extends BrowserKitTestCase
     }
 
     /**
-     * Test rate limiting (10 posts per hour)
+     * Test rate limiting (10 posts per hour).
      *
      * @return void
      */

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Northstar\Models\User;
-use Northstar\Services\Gambit;
-use Northstar\Services\Rogue;
+use App\Models\User;
+use App\Services\Gambit;
+use App\Services\Rogue;
 
 class UserTest extends BrowserKitTestCase
 {
@@ -748,7 +748,7 @@ class UserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test that we can only upsert with the ?upsert=true param
+     * Test that we can only upsert with the ?upsert=true param.
      *
      * @return void
      */
@@ -792,7 +792,7 @@ class UserTest extends BrowserKitTestCase
 
     /**
      * Test that we can filter records with both ?search[email]=test@dosomething.org
-     * and ?search=test@dosomething.org patterns
+     * and ?search=test@dosomething.org patterns.
      *
      * @return void
      */

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Models\User;
 use Laravel\Socialite\AbstractUser;
-use Northstar\Models\User;
 
 class FacebookTest extends BrowserKitTestCase
 {

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -1,8 +1,8 @@
 <?php
 
+use App\Models\User;
+use App\Services\Google;
 use Laravel\Socialite\AbstractUser;
-use Northstar\Models\User;
-use Northstar\Services\Google;
 
 class GoogleTest extends BrowserKitTestCase
 {

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Auth\Registrar;
+use App\Jobs\SendPasswordResetToCustomerIo;
+use App\Models\User;
 use Illuminate\Support\Facades\Bus;
-use Northstar\Auth\Registrar;
-use Northstar\Jobs\SendPasswordResetToCustomerIo;
-use Northstar\Models\User;
 
 class PasswordResetTest extends BrowserKitTestCase
 {
@@ -83,7 +83,7 @@ class PasswordResetTest extends BrowserKitTestCase
             $this->see('We can\'t find a user with that e-mail address.');
         }
 
-        $this->expectsEvents(\Northstar\Events\Throttled::class);
+        $this->expectsEvents(\App\Events\Throttled::class);
 
         $this->visit('password/reset');
         $this->submitForm('Request New Password', [

--- a/tests/Http/Web/TotpTest.php
+++ b/tests/Http/Web/TotpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class TotpTest extends BrowserKitTestCase
 {

--- a/tests/Http/Web/WebAuthenticationTest.php
+++ b/tests/Http/Web/WebAuthenticationTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Northstar\Models\Client;
-use Northstar\Models\User;
+use App\Models\Client;
+use App\Models\User;
 
 class WebAuthenticationTest extends BrowserKitTestCase
 {
@@ -96,7 +96,7 @@ class WebAuthenticationTest extends BrowserKitTestCase
         }
 
         // This next request should trigger a StatHat counter.
-        $this->expectsEvents(\Northstar\Events\Throttled::class);
+        $this->expectsEvents(\App\Events\Throttled::class);
 
         $this->visit('login');
         $this->submitForm('Log In', [

--- a/tests/Http/Web/WebUserTest.php
+++ b/tests/Http/Web/WebUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class WebUserTest extends BrowserKitTestCase
 {

--- a/tests/LegacyHttp/ProfileTest.php
+++ b/tests/LegacyHttp/ProfileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class ProfileTest extends BrowserKitTestCase
 {

--- a/tests/LegacyHttp/UserTest.php
+++ b/tests/LegacyHttp/UserTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Northstar\Models\User;
-use Northstar\Services\CustomerIo;
-use Northstar\Services\Gambit;
-use Northstar\Services\Rogue;
+use App\Models\User;
+use App\Services\CustomerIo;
+use App\Services\Gambit;
+use App\Services\Rogue;
 
 class LegacyUserTest extends BrowserKitTestCase
 {
@@ -235,7 +235,7 @@ class LegacyUserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test for retrieving a nonexistent User
+     * Test for retrieving a nonexistent User.
      *
      * @return void
      */
@@ -246,7 +246,7 @@ class LegacyUserTest extends BrowserKitTestCase
     }
 
     /**
-     * Tests retrieving multiple users by their id
+     * Tests retrieving multiple users by their id.
      */
     public function testFilterUsersById()
     {
@@ -774,7 +774,7 @@ class LegacyUserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test for updating an existing user
+     * Test for updating an existing user.
      *
      * @return void
      */
@@ -881,7 +881,7 @@ class LegacyUserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test for deleting an existing user
+     * Test for deleting an existing user.
      *
      * @return void
      */
@@ -912,7 +912,7 @@ class LegacyUserTest extends BrowserKitTestCase
     }
 
     /**
-     * Test the write scope is required to delete an existing user
+     * Test the write scope is required to delete an existing user.
      *
      * @return void
      */
@@ -1425,7 +1425,7 @@ class LegacyUserTest extends BrowserKitTestCase
 
     /**
      * Test that we can filter records with both ?search[email]=test@dosomething.org
-     * and ?search=test@dosomething.org patterns
+     * and ?search=test@dosomething.org patterns.
      *
      * @return void
      */

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 
 class ModelTest extends BrowserKitTestCase
 {

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Northstar\Models\User;
-use Northstar\Services\GraphQL;
+use App\Models\User;
+use App\Services\GraphQL;
 
 class UserModelTest extends BrowserKitTestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-use Northstar\Models\User;
+use App\Models\User;
 use Tests\CreatesApplication;
 use Tests\WithAuthentication;
 use Tests\WithMocks;

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -2,21 +2,21 @@
 
 namespace Tests;
 
+use App\Auth\Entities\AccessTokenEntity;
+use App\Auth\Entities\ClientEntity;
+use App\Auth\Entities\ScopeEntity;
+use App\Auth\Scope;
+use App\Models\Client;
+use App\Models\User;
 use DateInterval;
 use League\OAuth2\Server\CryptKey;
-use Northstar\Auth\Entities\AccessTokenEntity;
-use Northstar\Auth\Entities\ClientEntity;
-use Northstar\Auth\Entities\ScopeEntity;
-use Northstar\Auth\Scope;
-use Northstar\Models\Client;
-use Northstar\Models\User;
 
 trait WithAuthentication
 {
     /**
      * Make a new authenticated web user.
      *
-     * @return \Northstar\Models\User
+     * @return \App\Models\User
      */
     protected function makeAuthWebUser()
     {


### PR DESCRIPTION
### What's this PR do?

This pull request renames the `Northstar\` custom namespace to `App\`. 

### How should this be reviewed?

This is really just a simple find-replace! The PSR-4 namespace was changed in `composer.json`'s `"psr-4"` key, and then I just updated the `namespace` for each file & any references that used the old `Northstar\` prefix to reference those classes.

### Any background context you want to provide?

You can see the original rationale behind this change in the [Remove Custom App Namespace RFC](https://github.com/DoSomething/rfcs/blob/master/012-remove-custom-app-namespace.md).

Another nice benefit of this change (alongside formatting changes from #1069) – you can now easily find any of the classes we've written ourselves grouped at the top of the imports list, since `App` is (almost) always going to be alphabetically first!

### Relevant tickets

References [Pivotal #175983239](https://www.pivotaltracker.com/story/show/175983239).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
