### PR TITLE
Configure PHP CS Fixer to run on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
           key: node-v2-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+      - run:
+          name: check php code style
+          command: vendor/bin/php-cs-fixer fix --dry-run --no-interaction --verbose
       - run: npm run build
       - run: php artisan northstar:setup
       - run:

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -2,6 +2,8 @@
 
 namespace App\Auth;
 
+use App\Exceptions\NorthstarValidationException;
+use App\Models\User;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -10,8 +12,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Factory as Validation;
-use App\Exceptions\NorthstarValidationException;
-use App\Models\User;
 
 class Registrar
 {

--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -2,8 +2,6 @@
 
 namespace App\Auth;
 
-use App\Exceptions\NorthstarValidationException;
-use App\Models\User;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -12,6 +10,8 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Factory as Validation;
+use App\Exceptions\NorthstarValidationException;
+use App\Models\User;
 
 class Registrar
 {


### PR DESCRIPTION
### What's this PR do?

Whoops! This pull request configures [PHP CS Fixer](https://cs.symfony.com) to automatically check pull requests for style issues. If something isn't formatted correctly, it'll fail the build & can be fixed by simply running `composer format` on your Homestead box!

### How should this be reviewed?

I configured this to run on CircleCI (see Rogue's [`.circleci/config.yml`](https://github.com/DoSomething/rogue/blob/9c83e89167f6e1853711e3a91440abc36500f754/.circleci/config.yml#L51-L53) for reference) in 68ba197. To verify that it works correctly, I purposefully messed up the alphabetical imports in `Registrar.php` in order to get the build to fail. 

I then ran `composer format` on my Homestead box, committed the change, and pushed 52c2471 to get back to ✅!

### Any background context you want to provide?

🧶

### Relevant tickets

References [Pivotal #174652836](https://www.pivotaltracker.com/story/show/174652836).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
