### PR TITLE
Refactor UserUpdateFieldsCommand to use standard input

### DIFF
--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -111,8 +111,7 @@ class UpdateUserFieldsCommand extends Command
 
             if ($this->option('verbose')) {
                 $this->line('northstar:update: Updated user - ' . $user->id);
-                $mb = memory_get_peak_usage() / 1000000;
-                $this->line('northstar:update: ' . $mb . ' Mb used');
+                $this->line('northstar:update: ' . $this->getMbUsed() . ' Mb used');
             }
 
             $this->logPercent();
@@ -120,6 +119,16 @@ class UpdateUserFieldsCommand extends Command
         }
 
         $this->line('northstar:update: Done updating users!');
+    }
+
+    /**
+     * Returns number of megabytes used.
+     *
+     * @return float
+     */
+    public function getMbUsed()
+    {
+        return memory_get_peak_usage() / 1000000;
     }
 
     /**
@@ -135,18 +144,15 @@ class UpdateUserFieldsCommand extends Command
             return;
         }
 
-        $percent = ($this->currentCount / $this->totalCount) * 100;
-        $mb = memory_get_peak_usage() / 1000000;
-
         $this->line(
             'northstar:update: ' .
                 $this->currentCount .
                 '/' .
                 $this->totalCount .
                 ' - ' .
-                $percent .
+                ($this->currentCount / $this->totalCount) * 100 .
                 '% done - ' .
-                $mb .
+                $this->getMbUsed() .
                 ' Mb used',
         );
     }

--- a/app/Console/Commands/UpdateUserFieldsCommand.php
+++ b/app/Console/Commands/UpdateUserFieldsCommand.php
@@ -15,14 +15,14 @@ class UpdateUserFieldsCommand extends Command
      */
     protected $signature = 'northstar:update
                             {input=php://stdin}
-                            {--field=* : Which fields we should look for in the csv and update on the user}';
+                            {--field=* : Each field that should be updated}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'For each user in the csv, overwrites each given field with the new value given in the csv.';
+    protected $description = 'For each user in the csv, overwrites each field with its new value.';
 
     /**
      * The total number of records to process.

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -1,0 +1,21 @@
+# Commands
+
+This page starts on documentation for custom [Artisan commands](https://laravel.com/docs/6.x/artisan#writing-commands) that have been added to Northstar.
+
+## Update User Fields
+
+Updates a set of users with given field values from a CSV.
+
+The CSV requires a `northstar_id` column, as well as columns for each field to update.
+
+Example:
+
+```
+cat ../northstar-updates.csv | php artisan northstar:update --field=email_subscription_status --field=sms_status --verbose
+```
+
+In this example, we run the console command with a `northstar-updates.csv` file, which we'd expect to contain the following fields:
+
+* `northstar_id` (required)
+* `email_subscription_status`
+* `sms_status`

--- a/tests/Console/UpdateUserFieldsCommandTest.php
+++ b/tests/Console/UpdateUserFieldsCommandTest.php
@@ -17,8 +17,8 @@ class UpdateUserFieldsCommandTest extends BrowserKitTestCase
 
         // Run the user update command.
         Artisan::call('northstar:update', [
-            'path' => 'tests/Console/files/example-user-updates.csv',
-            'fields' => ['source', 'created_at'],
+            'input' => 'tests/Console/files/example-user-updates.csv',
+            '--field' => ['source', 'created_at'],
         ]);
 
         // Make sure the updates were made
@@ -70,8 +70,8 @@ class UpdateUserFieldsCommandTest extends BrowserKitTestCase
 
         // Run the user update command.
         Artisan::call('northstar:update', [
-            'path' => 'tests/Console/files/example-topic-updates.csv',
-            'fields' => ['email_subscription_topics'],
+            'input' => 'tests/Console/files/example-topic-updates.csv',
+            '--field' => ['email_subscription_topics'],
         ]);
 
         // Updating user with no email topics
@@ -125,8 +125,8 @@ class UpdateUserFieldsCommandTest extends BrowserKitTestCase
 
         // Run the user update command.
         Artisan::call('northstar:update', [
-            'path' => 'tests/Console/files/example-email-subscription-status-updates.csv',
-            'fields' => ['email_subscription_status'],
+            'input' => 'tests/Console/files/example-email-subscription-status-updates.csv',
+            '--field' => ['email_subscription_status'],
         ]);
 
         // Verify users who have been unsubscribed


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `northstar:update` command to expect a file over standard input, to avoid needing to upload source files to S3.  

Additional changes:

* DRY calculating megabytes used

* Starts on documentation for our console commands, to make it easier to remember which commands are available (and their required file formats, when applicable)

### How should this be reviewed?

👀 

### Any background context you want to provide?

Refs https://github.com/DoSomething/northstar/pull/1075#issuecomment-740684225 and https://github.com/DoSomething/rogue/pull/1095#discussion_r469333530



### Relevant tickets

References [Pivotal #175184578](https://www.pivotaltracker.com/story/show/175184578).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
