### PR TITLE
Add ability to manage redirects to Northstar's admin panel.

### DIFF
--- a/app/Http/Controllers/Web/Admin/RedirectsController.php
+++ b/app/Http/Controllers/Web/Admin/RedirectsController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers\Web\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Fastly;
+use App\Services\Resources\Redirect;
+use Illuminate\Http\Request;
+
+class RedirectsController extends Controller
+{
+    /**
+     * The Fastly API client.
+     * @var Fastly
+     */
+    protected $fastly;
+
+    /**
+     * Create a RedirectsController.
+     *
+     * @param Fastly $fastly
+     */
+    public function __construct(Fastly $fastly)
+    {
+        $this->fastly = $fastly;
+
+        $this->middleware('auth:web');
+        $this->middleware('role:admin');
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $redirects = $this->fastly->getAllRedirects();
+
+        return view('admin.redirects.index', ['redirects' => $redirects]);
+    }
+
+    /**
+     * Show redirect details.
+     *
+     * @param Redirect $redirect
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Redirect $redirect)
+    {
+        return view('admin.redirects.show', ['redirect' => $redirect]);
+    }
+
+    /**
+     * Create a new redirect.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('admin.redirects.create');
+    }
+
+    /**
+     * Store a new redirect.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $this->validate(
+            $request,
+            [
+                'path' => 'required|string|regex:/^[^?]+$/',
+                'target' => 'required|url',
+            ],
+            [
+                'path.regex' => 'Paths cannot contain query strings.',
+            ],
+        );
+
+        $redirect = $this->fastly->createRedirect(
+            $request->path,
+            $request->target,
+        );
+
+        return redirect()->route('admin.redirects.show', $redirect->id);
+    }
+
+    /**
+     * Edit redirect details.
+     *
+     * @param Redirect $redirect
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Redirect $redirect)
+    {
+        return view('admin.redirects.edit', ['redirect' => $redirect]);
+    }
+
+    /**
+     * Update an existing redirect's details.
+     *
+     * @param Redirect $redirect
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Redirect $redirect, Request $request)
+    {
+        $this->validate($request, [
+            'target' => 'required|url',
+        ]);
+
+        $this->fastly->updateRedirect($redirect->path, $request->target);
+
+        return redirect()->route('admin.redirects.show', $redirect->id);
+    }
+
+    /**
+     * Destroy an existing redirect.
+     *
+     * @param Redirect $redirect
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Redirect $redirect)
+    {
+        $successful = $this->fastly->deleteRedirect($redirect->id);
+
+        if (!$successful) {
+            return redirect()
+                ->route('admin.redirects.index')
+                ->with('flash', 'Could not delete redirect.');
+        }
+
+        return redirect()
+            ->route('admin.redirects.index')
+            ->with('flash', 'BAM! Deleted.');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,6 +26,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // ...
+        $this->app->bind(Fastly::class, function ($app) {
+            return new Fastly(config('services.fastly'));
+        });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,8 +26,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(Fastly::class, function ($app) {
-            return new Fastly(config('services.fastly'));
-        });
+        // ...
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Auth\Registrar;
+use App\Services\Fastly;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
 
@@ -40,6 +41,16 @@ class RouteServiceProvider extends ServiceProvider
 
         Route::bind('mobile', function ($value) {
             return app(Registrar::class)->resolveOrFail(['mobile' => $value]);
+        });
+
+        Route::bind('redirect', function ($key) {
+            $redirect = app(Fastly::class)->getRedirect($key);
+
+            if (!$redirect) {
+                throw new NotFoundHttpException();
+            }
+
+            return $redirect;
         });
     }
 

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Services;
+
+use App\Services\Resources\Redirect;
+use App\Services\Resources\RedirectCollection;
+use DoSomething\Gateway\AuthorizesWithApiKey;
+use DoSomething\Gateway\Common\RestApiClient;
+
+class Fastly extends RestApiClient
+{
+    use AuthorizesWithApiKey;
+
+    /**
+     * Create a new API client.
+     *
+     * @param array $config
+     * @param array $overrides
+     */
+    public function __construct($overrides = [])
+    {
+        $this->apiKeyHeader = 'Fastly-Key';
+        $this->apiKey = config('services.fastly.api_key');
+
+        // Resources that we'll be working with in Fastly:
+        $this->frontendServiceId = config('services.fastly.services.frontend');
+        $this->backendServiceId = config('services.fastly.services.backend');
+        $this->redirectsTableId = config('services.fastly.redirects_table');
+
+        parent::__construct(config('services.fastly.url'), $overrides);
+    }
+
+    /**
+     * Get all redirects.
+     *
+     * @return RedirectCollection
+     */
+    public function getAllRedirects()
+    {
+        $redirects = $this->get(
+            "service/$this->frontendServiceId/dictionary/$this->redirectsTableId/items",
+        );
+
+        $redirects = array_map(function ($redirect) {
+            return Redirect::fromItems($redirect);
+        }, $redirects);
+
+        return new RedirectCollection(['data' => $redirects]);
+    }
+
+    /**
+     * Get a redirect by key.
+     *
+     * @return Redirect
+     */
+    public function getRedirect($id)
+    {
+        $key = Redirect::decodeId($id);
+
+        $redirect = $this->get(
+            "service/$this->frontendServiceId/dictionary/$this->redirectsTableId/item/$key",
+        );
+
+        return Redirect::fromItems($redirect);
+    }
+
+    /**
+     * Create a redirect.
+     *
+     * @return Redirect
+     */
+    public function createRedirect($path, $target)
+    {
+        // Ensure path begins with a slash & is lower-case.
+        $path = $path[0] === '/' ? $path : '/' . $path;
+        $path = strtolower($path);
+
+        // Create or update a record in the redirects dictionary.
+        $key = urlencode($path);
+        $redirect = $this->put(
+            "service/$this->frontendServiceId/dictionary/$this->redirectsTableId/item/$key",
+            [
+                'item_value' => $target,
+            ],
+        );
+
+        return Redirect::fromItems($redirect);
+    }
+
+    /**
+     * Update a redirect.
+     *
+     * @return Redirect
+     */
+    public function updateRedirect($path, $target)
+    {
+        // Update the corresponding record in the redirects dictionary.
+        $key = urlencode($path);
+        $redirect = $this->patch(
+            "service/$this->frontendServiceId/dictionary/$this->redirectsTableId/item/$key",
+            [
+                'item_value' => $target,
+            ],
+        );
+
+        return Redirect::fromItems($redirect);
+    }
+
+    /**
+     * Delete a redirect.
+     *
+     * @return bool
+     */
+    public function deleteRedirect($id)
+    {
+        $key = Redirect::decodeId($id);
+
+        // Delete the corresponding record in the redirects dictionary.
+        return $this->delete(
+            "service/$this->frontendServiceId/dictionary/$this->redirectsTableId/item/$key",
+        );
+    }
+
+    /**
+     * Send a POST request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @param array $payload - Body of the POST request
+     * @param bool $withAuthorization - Should this request be authorized?
+     * @return array
+     */
+    public function post($path, $payload = [], $withAuthorization = true)
+    {
+        $options = [
+            'form_params' => $payload,
+        ];
+
+        return $this->send('POST', $path, $options, $withAuthorization);
+    }
+
+    /**
+     * Send a PATCH request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @param array $payload - Body of the PUT request
+     * @param bool $withAuthorization - Should this request be authorized?
+     * @return array
+     */
+    public function patch($path, $payload = [], $withAuthorization = true)
+    {
+        $options = [
+            'form_params' => $payload,
+        ];
+
+        return $this->send('PATCH', $path, $options, $withAuthorization);
+    }
+
+    /**
+     * Determine if the response was successful or not.
+     *
+     * @param mixed $json
+     * @return bool
+     */
+    public function responseSuccessful($json)
+    {
+        return $json['status'] === 'ok';
+    }
+}

--- a/app/Services/Resources/Redirect.php
+++ b/app/Services/Resources/Redirect.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services\Resources;
+
+use Carbon\Carbon;
+use DoSomething\Gateway\Common\ApiResponse;
+use Illuminate\Support\Arr;
+use JsonSerializable;
+
+class Redirect extends ApiResponse implements JsonSerializable
+{
+    /**
+     * Create a new redirect from the given API response.
+     * @param $attributes
+     */
+    public function __construct($attributes)
+    {
+        if ($attributes instanceof self) {
+            $attributes = $attributes->attributes;
+        }
+
+        parent::__construct($attributes);
+    }
+
+    /**
+     * Create a new redirect from the Fastly dictionary item.
+     * @param $redirect
+     */
+    public static function fromItems($redirect)
+    {
+        return new static([
+            'id' => self::encodeId($redirect),
+            'path' => $redirect['item_key'],
+            'target' => $redirect['item_value'],
+            'updated_at' => Arr::get($redirect, 'updated_at', Carbon::now()), // not returned from updates.
+            'created_at' => Arr::get($redirect, 'updated_at', Carbon::now()), // not returned from updates.
+        ]);
+    }
+
+    /**
+     * Encode the redirect key to be URL-safe.
+     *
+     * @param string $redirect
+     * @return string
+     */
+    public static function encodeId($redirect)
+    {
+        // In order to use these in URLs (like /redirects/:id), we need to
+        // make them URL-safe. We first base64-encode the path, and then
+        // replace any slashes with underscores.
+        return str_replace('/', '_', base64_encode($redirect['item_key']));
+    }
+
+    /**
+     * Decode the ID into a Fastly item key.
+     *
+     * @param string $redirect
+     * @return string
+     */
+    public static function decodeId($id)
+    {
+        return urlencode(base64_decode(str_replace('_', '/', $id)));
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->attributes;
+    }
+}

--- a/app/Services/Resources/RedirectCollection.php
+++ b/app/Services/Resources/RedirectCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\Resources;
+
+use DoSomething\Gateway\Common\ApiCollection;
+use JsonSerializable;
+
+class RedirectCollection extends ApiCollection implements JsonSerializable
+{
+    public function __construct($response)
+    {
+        parent::__construct($response, Redirect::class);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/config/features.php
+++ b/config/features.php
@@ -34,4 +34,7 @@ return [
     // If this is enabled, we'll also make requests to Rogue, Gambit, and
     // Customer.io's deletion APIs whenever a user model is deleted.
     'delete-api' => env('DS_ENABLE_DELETE_APIS', false),
+
+    // If this is enabled, we'll expose the new "admin" routes from Aurora:
+    'admin' => env('DS_ENABLE_ADMIN_ROUTES', false),
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -72,7 +72,12 @@ return [
 
     'fastly' => [
         'url' => 'https://api.fastly.com/',
-        'key' => env('FASTLY_API_TOKEN'),
-        'service_id' => env('FASTLY_SERVICE_ID'),
+        'api_key' => env('FASTLY_API_KEY'),
+        'redirects_table' => env('FASTLY_TABLE_REDIRECTS'),
+        'frontend_url' => env('FASTLY_FRONTEND_SERVICE_URL'),
+        'services' => [
+            'frontend' => env('FASTLY_FRONTEND_SERVICE_ID'),
+            'backend' => env('FASTLY_BACKEND_SERVICE_ID'),
+        ],
     ],
 ];

--- a/resources/assets/scss/_components/_table.scss
+++ b/resources/assets/scss/_components/_table.scss
@@ -1,0 +1,35 @@
+/**
+ * Table
+ */
+.table {
+  display: table;
+  width: 100%;
+  border: 1px solid $light-gray;
+  border-radius: $sm-border-radius;
+  border-collapse: separate; // Needed to display border radius on table.
+
+  @include media($small) {
+    display: block;
+  }
+}
+
+.table-header {
+  background: $white;
+  color: $purple;
+  font-weight: $weight-bold;
+  text-align: left;
+}
+
+.table-row {
+  display: table-row;
+  background: $white;
+
+  &:nth-of-type(odd) {
+    background: #efefef;
+  }
+}
+
+.table-cell {
+  padding: ($base-spacing / 4) ($base-spacing / 2);
+  display: table-cell;
+}

--- a/resources/assets/scss/app.scss
+++ b/resources/assets/scss/app.scss
@@ -30,6 +30,7 @@
 @import '_components/_google-login';
 @import '_components/_divider';
 @import '_components/_password-visibility';
+@import '_components/_table';
 @import '_components/_text-field';
 @import '_components/_field-label';
 @import '_components/_button';

--- a/resources/views/admin/redirects/create.blade.php
+++ b/resources/views/admin/redirects/create.blade.php
@@ -13,6 +13,8 @@
                 @include('forms.errors')
 
                 <form action="{{ route('redirects.store') }}" method="POST">
+                    {{ csrf_field() }}
+
                     <div class="form-item -padded">
                         <label for="path" class="field-label">Incoming Path</label>
                         <input class="text-field" placeholder="e.g. /us/campaigns/old-path" name="path" type="text" id="path">

--- a/resources/views/admin/redirects/create.blade.php
+++ b/resources/views/admin/redirects/create.blade.php
@@ -12,7 +12,7 @@
 
                 @include('forms.errors')
 
-                <form action="{{ route('redirects.store') }}" method="POST">
+                <form action="{{ route('admin.redirects.store') }}" method="POST">
                     {{ csrf_field() }}
 
                     <div class="form-item -padded">

--- a/resources/views/admin/redirects/create.blade.php
+++ b/resources/views/admin/redirects/create.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.admin')
+
+@section('title', 'Redirects')
+@section('subtitle', 'Create & manage URL redirects.')
+
+@section('main_content')
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <h1>Create Redirect</h1>
+                <p>Any visitors to the address in "incoming path" will be instantly redirected to the target URL.</p>
+
+                @include('forms.errors')
+
+                <form action="{{ route('redirects.store') }}" method="POST">
+                    <div class="form-item -padded">
+                        <label for="path" class="field-label">Incoming Path</label>
+                        <input class="text-field" placeholder="e.g. /us/campaigns/old-path" name="path" type="text" id="path">
+                    </div>
+
+                    <div class="form-item -padded">
+                        <label for="target" class="field-label">Target URL</label>
+                        <input class="text-field" placeholder="e.g. https://www.dosomething.org/new-path" name="target" type="text" id="target">
+                    </div>
+
+                    <input class="button" type="submit" value="Create Redirect">
+                </form>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/admin/redirects/edit.blade.php
+++ b/resources/views/admin/redirects/edit.blade.php
@@ -12,8 +12,8 @@
                 @include('forms.errors')
 
                 <form action="{{ route('redirects.update', $redirect->id) }}" method="POST">
-                    <input type="hidden" name="_method" value="PUT">
-                    <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                    {{ method_field('PUT') }}
+                    {{ csrf_field() }}
 
                     <div class="form-item -padded">
                         <label for="path" class="field-label">Incoming Path</label>

--- a/resources/views/admin/redirects/edit.blade.php
+++ b/resources/views/admin/redirects/edit.blade.php
@@ -22,7 +22,7 @@
 
                     <div class="form-item -padded">
                         <label for="target" class="field-label">Target URL</label>
-                        <input class="text-field" value="{{ $redirect->path }}" placeholder="e.g. https://www.dosomething.org/new-path" name="target" type="text" id="target">
+                        <input class="text-field" value="{{ $redirect->target }}" placeholder="e.g. https://www.dosomething.org/new-path" name="target" type="text" id="target">
                     </div>
 
                     <input class="button" type="submit" value="Update Redirect">

--- a/resources/views/admin/redirects/edit.blade.php
+++ b/resources/views/admin/redirects/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.admin')
+
+@section('title', 'Redirects')
+@section('subtitle', 'Create & manage URL redirects.')
+
+@section('main_content')
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <h1><code>{{ $redirect->path }}</code></h1>
+
+                @include('forms.errors')
+
+                <form action="{{ route('redirects.update', $redirect->id) }}" method="POST">
+                    <input type="hidden" name="_method" value="PUT">
+                    <input type="hidden" name="_token" value="{{ csrf_token() }}">
+
+                    <div class="form-item -padded">
+                        <label for="path" class="field-label">Incoming Path</label>
+                        <input class="text-field" value="{{ $redirect->path }}" placeholder="e.g. /us/campaigns/old-path" name="path" type="text" id="path" disabled>
+                    </div>
+
+                    <div class="form-item -padded">
+                        <label for="target" class="field-label">Target URL</label>
+                        <input class="text-field" value="{{ $redirect->path }}" placeholder="e.g. https://www.dosomething.org/new-path" name="target" type="text" id="target">
+                    </div>
+
+                    <input class="button" type="submit" value="Update Redirect">
+                </form>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/admin/redirects/edit.blade.php
+++ b/resources/views/admin/redirects/edit.blade.php
@@ -11,7 +11,7 @@
 
                 @include('forms.errors')
 
-                <form action="{{ route('redirects.update', $redirect->id) }}" method="POST">
+                <form action="{{ route('admin.redirects.update', $redirect->id) }}" method="POST">
                     {{ method_field('PUT') }}
                     {{ csrf_field() }}
 

--- a/resources/views/admin/redirects/index.blade.php
+++ b/resources/views/admin/redirects/index.blade.php
@@ -11,7 +11,7 @@
                 <p>These are the URL redirects registered in Fastly.</p>
             </div>
             <div class="container__block -narrow">
-                <a class="button -secondary" href="{{ route('redirects.create') }}">New redirect</a>
+                <a class="button -secondary" href="{{ route('admin.redirects.create') }}">New redirect</a>
             </div>
             <div class="container__block">
                 <table class="table">
@@ -24,7 +24,7 @@
                     <tbody>
                         @foreach($redirects as $redirect)
                             <tr class="table-row">
-                                <td class="table-cell break-all" title="{{ $redirect->path }}"><a href="{{ route('redirects.show', [$redirect->id]) }}">{{ Illuminate\Support\Str::limit($redirect->path, 40) }}</a></td>
+                                <td class="table-cell break-all" title="{{ $redirect->path }}"><a href="{{ route('admin.redirects.show', [$redirect->id]) }}">{{ Illuminate\Support\Str::limit($redirect->path, 40) }}</a></td>
                                 <td class="table-cell break-all" title="{{ $redirect->target }}">{{ Illuminate\Support\Str::limit($redirect->target, 60) }}</td>
                             </tr>
                         @endforeach

--- a/resources/views/admin/redirects/index.blade.php
+++ b/resources/views/admin/redirects/index.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.admin')
+
+@section('title', 'Redirects')
+@section('subtitle', 'Create & manage URL redirects.')
+
+@section('main_content')
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <div class="gallery__heading"><h1>All Redirects</h1></div>
+                <p>These are the URL redirects registered in Fastly.</p>
+            </div>
+            <div class="container__block -narrow">
+                <a class="button -secondary" href="{{ route('redirects.create') }}">New redirect</a>
+            </div>
+            <div class="container__block">
+                <table class="table">
+                    <thead>
+                        <tr class="row table-header">
+                            <th class="table-cell">Path</th>
+                            <th class="table-cell">Target</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($redirects as $redirect)
+                            <tr class="table-row">
+                                <td class="table-cell break-all" title="{{ $redirect->path }}"><a href="{{ route('redirects.show', [$redirect->id]) }}">{{ Illuminate\Support\Str::limit($redirect->path, 40) }}</a></td>
+                                <td class="table-cell break-all" title="{{ $redirect->target }}">{{ Illuminate\Support\Str::limit($redirect->target, 60) }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/admin/redirects/show.blade.php
+++ b/resources/views/admin/redirects/show.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.admin')
+
+@section('title', 'Redirects')
+@section('subtitle', 'Create & manage URL redirects.')
+
+@section('main_content')
+
+    <div class="container -padded">
+        <div class="wrapper">
+            <div class="container__block -narrow">
+                <h1><code>{{ $redirect->path }}</code></h1>
+            </div>
+
+            <div class="container__block -half">
+                <label class="field-label">Path:</label>
+                <code class="break-all"><em>{{ config('services.fastly.service_url') }}</em>{{ $redirect->path }}</code><br><br>
+                <label class="field-label">Target:</label>
+                <code class="break-all">{{ $redirect->target }}</code><br><br>
+                <label class="field-label">Redirect Status:</label>
+                <code>302 (Found)</code><br><br>
+            </div>
+
+            <div class="container__block -half">
+                <div class="danger-zone">
+                    <h4 class="danger-zone__heading">Danger Zone&#8482;</h4>
+                    <div class="danger-zone__block">
+                        <div class="form-item">
+                            <label for="role" class="field-label">Delete Redirect</label>
+                            <p class="footnote">This will
+                                <strong>delete</strong> this redirect path and it
+                                will no longer be available to users or search
+                                engines. The target will not be modified.
+                        </div>
+
+                        <a class="button -secondary -danger"
+                            href="{{ route('redirects.destroy', $redirect->id) }}"
+                            data-method="DELETE" data-confirm="Are you sure you want to delete this redirect?">Delete Redirect</a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="container__block -narrow">
+                <a class="secondary" href="{{ route('redirects.edit', [ $redirect->id ]) }}">Edit this redirect</a>
+                <p class="footnote">
+                    Last updated: {{ $redirect->updated_at->format('F d, Y g:ia') }}<br />
+                    Created: {{ $redirect->created_at->format('F d, Y g:ia') }}
+                </p>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/admin/redirects/show.blade.php
+++ b/resources/views/admin/redirects/show.blade.php
@@ -33,14 +33,14 @@
                         </div>
 
                         <a class="button -secondary -danger"
-                            href="{{ route('redirects.destroy', $redirect->id) }}"
+                            href="{{ route('admin.redirects.destroy', $redirect->id) }}"
                             data-method="DELETE" data-confirm="Are you sure you want to delete this redirect?">Delete Redirect</a>
                     </div>
                 </div>
             </div>
 
             <div class="container__block -narrow">
-                <a class="secondary" href="{{ route('redirects.edit', [ $redirect->id ]) }}">Edit this redirect</a>
+                <a class="secondary" href="{{ route('admin.redirects.edit', [ $redirect->id ]) }}">Edit this redirect</a>
                 <p class="footnote">
                     Last updated: {{ $redirect->updated_at->format('F d, Y g:ia') }}<br />
                     Created: {{ $redirect->created_at->format('F d, Y g:ia') }}

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -47,7 +47,7 @@
                                     </a>
                                 </li> --}}
                                 <li>
-                                    <a href="{{ route('redirects.index') }}">
+                                    <a href="{{ route('admin.redirects.index') }}">
                                         <strong class="navigation__title">Redirects</strong>
                                         <span class="navigation__subtitle">Vanity URLs & SEO</span>
                                     </a>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -12,10 +12,8 @@
 </head>
 
 <body class="modernizr-no-js">
-    @if (Session::has('flash_message'))
-        <div class="{{ Session::get('flash_message')['class'] }}">
-            <em>{{ Session::get('flash_message')['text'] }}</em>
-        </div>
+    @if (session('flash'))
+        <div class="messages">{{ session('flash') }}</div>
     @endif
 
     <div class="chrome">

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,11 +66,13 @@ Route::post('password/reset/{type}', 'ResetPasswordController@reset');
 
 // Administration
 if (config('features.admin')) {
-    Route::prefix('admin')->group(function () {
-        // Homepage
-        Route::view('/', 'admin.home');
+    Route::prefix('admin')
+        ->name('admin.')
+        ->group(function () {
+            // Homepage
+            Route::view('/', 'home');
 
-        // Fastly Redirects
-        Route::resource('redirects', 'Admin\RedirectsController');
-    });
+            // Fastly Redirects
+            Route::resource('redirects', 'Admin\RedirectsController');
+        });
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,4 +68,7 @@ Route::post('password/reset/{type}', 'ResetPasswordController@reset');
 Route::prefix('admin')->group(function () {
     // Homepage
     Route::view('/', 'admin.home');
+
+    // Fastly Redirects
+    Route::resource('redirects', 'Admin\RedirectsController');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,7 +70,7 @@ if (config('features.admin')) {
         ->name('admin.')
         ->group(function () {
             // Homepage
-            Route::view('/', 'home');
+            Route::view('/', 'admin.home');
 
             // Fastly Redirects
             Route::resource('redirects', 'Admin\RedirectsController');

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,10 +65,12 @@ Route::get('password/reset/{type}/{token}', [
 Route::post('password/reset/{type}', 'ResetPasswordController@reset');
 
 // Administration
-Route::prefix('admin')->group(function () {
-    // Homepage
-    Route::view('/', 'admin.home');
+if (config('features.admin')) {
+    Route::prefix('admin')->group(function () {
+        // Homepage
+        Route::view('/', 'admin.home');
 
-    // Fastly Redirects
-    Route::resource('redirects', 'Admin\RedirectsController');
-});
+        // Fastly Redirects
+        Route::resource('redirects', 'Admin\RedirectsController');
+    });
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds Aurora's Fastly redirect management interface to Northstar's admin panel. This allows staffers to configure redirects for paths on `www.` without a developer's assistance. I've placed these routes under a feature flag so we can wait to "flip the switch" on them until after we come back from break.

### How should this be reviewed?

These files are more-or-less copied over from their equivalents on Aurora: [`RedirectsController.php`](https://github.com/DoSomething/aurora/blob/2bf89f3a9360d358dd4494ba150323c527869487/app/Http/Controllers/RedirectsController.php), [`Fastly.php`](https://github.com/DoSomething/aurora/tree/2bf89f3a9360d358dd4494ba150323c527869487/app/Services/Fastly.php), [`Resources/*.php`](https://github.com/DoSomething/aurora/tree/2bf89f3a9360d358dd4494ba150323c527869487/app/Resources), and [`views/redirects/*.php`](https://github.com/DoSomething/aurora/tree/2bf89f3a9360d358dd4494ba150323c527869487/resources/views/redirects).

### Any background context you want to provide?

This was the easiest piece to extract since it doesn't have any local data dependencies!

### Relevant tickets

References [Pivotal #175943296](https://www.pivotaltracker.com/story/show/175943296).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
