### PR TITLE
Touchups to redirect admin.

### DIFF
--- a/resources/views/admin/redirects/show.blade.php
+++ b/resources/views/admin/redirects/show.blade.php
@@ -13,7 +13,7 @@
 
             <div class="container__block -half">
                 <label class="field-label">Path:</label>
-                <code class="break-all"><em>{{ config('services.fastly.service_url') }}</em>{{ $redirect->path }}</code><br><br>
+                <code class="break-all"><em>{{ config('services.fastly.frontend_url') }}</em>{{ $redirect->path }}</code><br><br>
                 <label class="field-label">Target:</label>
                 <code class="break-all">{{ $redirect->target }}</code><br><br>
                 <label class="field-label">Redirect Status:</label>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -19,7 +19,7 @@
     <div class="chrome">
         <div class="wrapper">
             <nav class="navigation -white -floating">
-                <a class="navigation__logo" href="/"><span>DoSomething.org</span></a>
+                <a class="navigation__logo" href="/admin"><span>DoSomething.org</span></a>
                 <div class="navigation__menu">
                     @auth
                         <ul class="navigation__primary">


### PR DESCRIPTION
### What's this PR do?

This pull request adds two tiny touchups to Northstar's redirect admin (imported from Aurora):

🦑 The logo in the navigation should take you to the "admin home" so you're not stranded on the user-facing profile.

🧵 Properly references the environment variable that displays the "frontend" URL on `redirects.show` page.

### How should this be reviewed?

👀

### Any background context you want to provide?

Two quick follow-ups to #1077.

### Relevant tickets

References [Pivotal #175943296](https://www.pivotaltracker.com/story/show/175943296).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
