### PR TITLE
Store and Track utm_content

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -90,6 +90,7 @@ class AuthController extends Controller
                     'utm_source' => request()->query('utm_source'),
                     'utm_medium' => request()->query('utm_medium'),
                     'utm_campaign' => request()->query('utm_campaign'),
+                    'utm_content' => request()->query('utm_content'),
                 ]),
                 // Store the provided Referrer User ID for user's referrer_user_id field:
                 'referrer_user_id' => request()->query('referrer_user_id'),

--- a/resources/assets/js/utilities/Analytics.js
+++ b/resources/assets/js/utilities/Analytics.js
@@ -74,6 +74,7 @@ export function getAdditionalContext() {
     utmSource: query('utm_source'),
     utmMedium: query('utm_medium'),
     utmCampaign: query('utm_campaign'),
+    utmContent: query('utm_content'),
   };
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on https://github.com/DoSomething/phoenix-next/pull/2472 to store the `utm_content` passed through via authentication redirects to the user's `source_details` field along with the other UTMs. It also tracks it via web analytics events.

### How should this be reviewed?
👁️ 

### Any background context you want to provide?
See https://github.com/DoSomething/phoenix-next/pull/2472

### Relevant tickets

References [Pivotal #176096711](https://www.pivotaltracker.com/story/show/176096711).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.

![image](https://user-images.githubusercontent.com/12417657/102255029-76fb3f00-3ed7-11eb-9bdd-cbd8952b0b4f.png)
