### PR TITLE
Adds no-referrer policy to Reset Password pages

### DIFF
--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -125,6 +125,11 @@ class ResetPasswordController extends Controller
         $data['token'] = $token;
         $data['type'] = $type;
         $data['email'] = $request->email;
+        /**
+         * We specify a no-referrer policy to prevent leaking password reset tokens to
+         * third-party services.
+         * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Integration_with_HTML
+         */
         $data['referrer'] = 'no-referrer';
 
         return view('auth.passwords.reset')->with($data);

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -125,6 +125,7 @@ class ResetPasswordController extends Controller
         $data['token'] = $token;
         $data['type'] = $type;
         $data['email'] = $request->email;
+        $data['referrer'] = 'no-referrer';
 
         return view('auth.passwords.reset')->with($data);
     }

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -125,7 +125,7 @@ class ResetPasswordController extends Controller
         $data['token'] = $token;
         $data['type'] = $type;
         $data['email'] = $request->email;
-        /**
+        /*
          * We specify a no-referrer policy to prevent leaking password reset tokens to
          * third-party services.
          * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Integration_with_HTML

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -22,7 +22,7 @@
     
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    @if ($referrer)
+    @if (isset($referrer))
         <meta name="referrer" content="{{ $referrer }}">
     @endif
 </head>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,10 @@
     @show
     
     <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    @if ($referrer)
+        <meta name="referrer" content="{{ $referrer }}">
+    @endif
 </head>
 
 <body class="chromeless modernizr-no-js">

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -127,6 +127,7 @@ class PasswordResetTest extends BrowserKitTestCase
         $this->see(
             'Create a password to join a movement of young people dedicated to making their communities a better place for everyone.',
         );
+        $this->assertSourceHas('<meta name="referrer" content="no-referrer">');
 
         $this->postForm('Activate Account', [
             'password' => 'new-top-secret-passphrase',

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -127,7 +127,7 @@ class PasswordResetTest extends BrowserKitTestCase
         $this->see(
             'Create a password to join a movement of young people dedicated to making their communities a better place for everyone.',
         );
-        $this->assertSourceHas('<meta name="referrer" content="no-referrer">');
+        $this->see('<meta name="referrer" content="no-referrer">');
 
         $this->postForm('Activate Account', [
             'password' => 'new-top-secret-passphrase',


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `referrer` meta tag with `no-referrer` to prevent leaking password reset tokens to third-party services (e.g. ad trackers)

### How should this be reviewed?

Visit a valid password reset page, and verify the meta tag appears.

### Any background context you want to provide?

Initially I tried adding a new middleware file to use over in [this branch](https://github.com/DoSomething/northstar/compare/referrer-policy), but couldn't access the response headers within the Blade file (seems that'd be more useful for an API response vs adding to HTML anyway)

### Relevant tickets

References [Pivotal #175644976](https://www.pivotaltracker.com/story/show/175644976).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
