### PR TITLE
Adds middleware for Referrer Policy header

### DIFF
--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -34,7 +34,7 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
-        $this->middleware('referrer');
+        $this->middleware('no-referrer');
     }
 
     /**

--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -34,6 +34,7 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+        $this->middleware('referrer');
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,7 +54,7 @@ class Kernel extends HttpKernel
         'auth' => \App\Http\Middleware\Authenticate::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'referrer' => \App\Http\Middleware\ReferrerPolicy::class,
+        'no-referrer' => \App\Http\Middleware\ReferrerPolicy::class,
         'scope' => \App\Http\Middleware\RequireScope::class,
         'role' => \App\Http\Middleware\RequireRole::class,
         'throttle' => \App\Http\Middleware\ThrottleRequests::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,6 +54,7 @@ class Kernel extends HttpKernel
         'auth' => \App\Http\Middleware\Authenticate::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'referrer' => \App\Http\Middleware\ReferrerPolicy::class,
         'scope' => \App\Http\Middleware\RequireScope::class,
         'role' => \App\Http\Middleware\RequireRole::class,
         'throttle' => \App\Http\Middleware\ThrottleRequests::class,

--- a/app/Http/Middleware/ReferrerPolicy.php
+++ b/app/Http/Middleware/ReferrerPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class ReferrerPolicy
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        $response->header('Referrer-Policy', 'no-referrer');
+
+        return $response;
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,11 +21,6 @@
     @show
     
     <meta name="csrf-token" content="{{ csrf_token() }}">
-
-    <!-- TODO: This should be wrapped in conditional if referrer-policy header exists -->
-        <meta name="Referrer-Policy" content="{{ request()->headers->get('referrer-policy') }}">
-    <!-- TODO: End if -->
-
 </head>
 
 <body class="chromeless modernizr-no-js">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,11 @@
     @show
     
     <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <!-- TODO: This should be wrapped in conditional if referrer-policy header exists -->
+        <meta name="Referrer-Policy" content="{{ request()->headers->get('referrer-policy') }}">
+    <!-- TODO: End if -->
+
 </head>
 
 <body class="chromeless modernizr-no-js">

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -127,7 +127,7 @@ class PasswordResetTest extends BrowserKitTestCase
         $this->see(
             'Create a password to join a movement of young people dedicated to making their communities a better place for everyone.',
         );
-        $this->seeHeader('referrer', 'no-referrer');
+        $this->seeHeader('Referrer-Policy', 'no-referrer');
 
         $this->postForm('Activate Account', [
             'password' => 'new-top-secret-passphrase',

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -127,6 +127,7 @@ class PasswordResetTest extends BrowserKitTestCase
         $this->see(
             'Create a password to join a movement of young people dedicated to making their communities a better place for everyone.',
         );
+        $this->seeHeader('referrer', 'no-referrer');
 
         $this->postForm('Activate Account', [
             'password' => 'new-top-secret-passphrase',


### PR DESCRIPTION
### What's this PR do?

This pull request adds a  `Referrer-Policy` header set to a `no-referrer` on all password reset pages, to prevent leaking password reset tokens to third-party services (e.g. ad trackers).

### How should this be reviewed?

👀 

### Any background context you want to provide?

I still get failed tests per the thread in https://github.com/DoSomething/northstar/pull/1082, so I'm testing in the blind a little bit 🐭 😢 . Does seem like an issue specific to my machine... 

### Relevant tickets

References [Pivotal #175644976](https://www.pivotaltracker.com/story/show/175644976).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
