### PR TITLE
Fix hack that uses malformed user auth to hijack redirect.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -250,9 +250,9 @@ function is_dosomething_domain(string $url): bool
         return false;
     }
 
-    // Reject a host that includes an escaped '.', which could be used to
-    // bypass our domain check below (e.g. 'cobalt.io\.dosomething.org'):
-    if (str_contains($host, '\.')) {
+    // Reject a host that includes an escaped '.' or '@', which could be used to
+    // fool our domain check below (e.g. 'cobalt.io\.dosomething.org'):
+    if (str_contains($host, '\.') || str_contains($host, '\@')) {
         return false;
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug in the `is_dosomething_domain` helper function under PHP 7.14.14. This was causing a spooky issue where this test would fail on CircleCI (which runs 7.4.14), but not on our local Homestead (which is on 7.4.12).

### How should this be reviewed?

For full context, see the following two comments: https://github.com/DoSomething/northstar/pull/1087#issuecomment-759568830 and https://github.com/DoSomething/northstar/pull/1087#issuecomment-759574337.

In short, there was a bug in `parse_url` where a malformed username in a URL in a domain could be used to override the parsed host (e.g. `http://dosomething.org\@cobalt.io/xyz` would be parsed as a `cobalt.io` URL instead of a `dosomething.org` URL with a funky path). Chrome also falls for this, which could allow someone to use one of these funky URLs to "trick" someone into following a redirect through our domain to a third-party.

Since this PHP bug was fixed, we'll just check for the icky `\@` manually to cover this scenario & get the test passing.

### Any background context you want to provide?

It turns out parsing URLs is a lot harder than you'd think!

### Relevant tickets

N/A. Blocked #1087.

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
