### PR TITLE
Hide analytics scripts on password reset pages

### DIFF
--- a/app/Http/Controllers/Web/ResetPasswordController.php
+++ b/app/Http/Controllers/Web/ResetPasswordController.php
@@ -125,6 +125,8 @@ class ResetPasswordController extends Controller
         $data['token'] = $token;
         $data['type'] = $type;
         $data['email'] = $request->email;
+        // Hide analytics scripts to prevent leaking password reset tokens to third-party services.
+        $data['hide_analytics'] = true;
 
         return view('auth.passwords.reset')->with($data);
     }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,8 +12,10 @@
     <link rel="shortcut icon" href="{{ asset('favicon.ico') }}">
     <link rel="apple-touch-icon-precomposed" href="{{ asset('apple-touch-icon-precomposed.png') }}">
 
-    @include('layouts.google_tag_manager')
-    @include('layouts.snowplow')
+    @if (!isset($hide_analytics))
+        @include('layouts.google_tag_manager')
+        @include('layouts.snowplow')
+    @endif
 
     @section('scripts')
         <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}">

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -48,6 +48,7 @@ class PasswordResetTest extends BrowserKitTestCase
 
         // The user should visit the link that was sent via email & set a new password.
         $this->visit($resetPasswordUrl);
+        $this->dontSee('window.snowplow');
         $this->postForm('Reset Password', [
             'password' => 'new-top-secret-passphrase',
             'password_confirmation' => 'new-top-secret-passphrase',


### PR DESCRIPTION
### What's this PR do?

This pull request avoids loading our analytics scripts on the password reset pages, so we don't leak password reset tokens to third party services. Refs https://github.com/DoSomething/northstar/pull/1083#issuecomment-756348921.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I'm still writing the unit test blind on this one -- my local tests for the `ResetPasswordController` still fail per https://github.com/DoSomething/northstar/pull/1083#issuecomment-755367276 

### Relevant tickets

References [Pivotal #175644976](https://www.pivotaltracker.com/n/projects/2328687/stories/175644976).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
