### PR TITLE
BrowserKit Purge Part Uno (it begins...)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,12 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 /**
  * Here is where you can register web routes for your application. These
  * routes are loaded by the RouteServiceProvider within a group which
  * contains the "web" middleware group. Now create something great!
  *
- * @var \Illuminate\Routing\Router $router
  * @see \App\Providers\RouteServiceProvider
  */
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 
-/**
+/*
  * Here is where you can register web routes for your application. These
  * routes are loaded by the RouteServiceProvider within a group which
  * contains the "web" middleware group. Now create something great!

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -88,6 +88,23 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
     }
 
     /**
+     * Register a new user account with updated registration page.
+     */
+    public function registerUpdated()
+    {
+        // Make sure we're logged out before trying to register.
+        auth('web')->logout();
+
+        $this->visit('register');
+        $this->submitForm('register-submit', [
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+            'email' => $this->faker->unique->email,
+            'password' => 'my-top-secret-passphrase',
+        ]);
+    }
+
+    /**
      * Set a header on the request.
      *
      * @param $name
@@ -147,22 +164,5 @@ abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
         }
 
         return $this;
-    }
-
-    /**
-     * Register a new user account with updated registration page.
-     */
-    public function registerUpdated()
-    {
-        // Make sure we're logged out before trying to register.
-        auth('web')->logout();
-
-        $this->visit('register');
-        $this->submitForm('register-submit', [
-            'first_name' => $this->faker->firstName,
-            'last_name' => $this->faker->lastName,
-            'email' => $this->faker->unique->email,
-            'password' => 'my-top-secret-passphrase',
-        ]);
     }
 }

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -264,7 +264,9 @@ class FacebookTest extends TestCase
 
         $this->mockSocialiteFromUserToken($abstractUser);
 
-        $this->get('/facebook/verify');
+        $response = $this->followingRedirects()->get('/facebook/verify');
+
+        $response->assertStatus(200);
 
         $user = auth()->user();
 
@@ -289,7 +291,9 @@ class FacebookTest extends TestCase
 
         $this->mockSocialiteFromUserToken($abstractUser);
 
-        $this->get('/facebook/verify');
+        $response = $this->followingRedirects()->get('/facebook/verify');
+
+        $response->assertStatus(200);
 
         $user = auth()->user();
 

--- a/tests/Http/Web/FacebookTest.php
+++ b/tests/Http/Web/FacebookTest.php
@@ -261,7 +261,6 @@ class FacebookTest extends TestCase
         );
 
         $this->mockSocialiteFromUser($abstractUser);
-
         $this->mockSocialiteFromUserToken($abstractUser);
 
         $response = $this->followingRedirects()->get('/facebook/verify');
@@ -288,7 +287,6 @@ class FacebookTest extends TestCase
         );
 
         $this->mockSocialiteFromUser($abstractUser);
-
         $this->mockSocialiteFromUserToken($abstractUser);
 
         $response = $this->followingRedirects()->get('/facebook/verify');
@@ -315,7 +313,6 @@ class FacebookTest extends TestCase
         );
 
         $this->mockSocialiteFromUser($abstractUser);
-
         $this->mockSocialiteFromUserToken($abstractUser);
 
         $response = $this->get('/facebook/verify');

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -131,7 +131,7 @@ class GoogleTest extends TestCase
 
         $redirectDomain = parse_url($response->headers->get('Location'));
 
-        // We just care that the domain matches the expected value, excluding all the query params.
+        // We just care that the host domain matches the expected value, excluding all the query params.
         $this->assertEquals('accounts.google.com', $redirectDomain['host']);
     }
 

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -131,7 +131,7 @@ class GoogleTest extends TestCase
 
         $redirectDomain = parse_url($response->headers->get('Location'));
 
-        // We just care that the domain is correct and not all the query params included in the redirect URL.
+        // We just care that the domain matches the expected value, excluding all the query params.
         $this->assertEquals('accounts.google.com', $redirectDomain['host']);
     }
 

--- a/tests/Http/Web/GoogleTest.php
+++ b/tests/Http/Web/GoogleTest.php
@@ -3,12 +3,12 @@
 use App\Models\User;
 use App\Services\Google;
 use Laravel\Socialite\AbstractUser;
+use Laravel\Socialite\Facades\Socialite;
 
-class GoogleTest extends BrowserKitTestCase
+class GoogleTest extends TestCase
 {
     /**
-     * Mock a Socialite user for the given
-     * method and user fields.
+     * Mock a Socialite user for the given method and user fields.
      *
      * @param  AbstractUser  $user
      * @param  string        $method
@@ -48,6 +48,7 @@ class GoogleTest extends BrowserKitTestCase
         $fields = compact('id', 'email', 'token');
 
         $user = new Laravel\Socialite\Two\User();
+
         $user->map($fields);
 
         $user->user['given_name'] = $first_name;
@@ -57,6 +58,8 @@ class GoogleTest extends BrowserKitTestCase
     }
 
     /**
+     * Mock a Google profile.
+     *
      * @see https://developers.google.com/people/api/rest/v1/people/get
      * @return object
      */
@@ -101,6 +104,7 @@ class GoogleTest extends BrowserKitTestCase
     private function defaultMock()
     {
         $googleId = '12345';
+
         $abstractUser = $this->mockSocialiteAbstractUser(
             'test@dosomething.org',
             'Puppet',
@@ -108,7 +112,9 @@ class GoogleTest extends BrowserKitTestCase
             $googleId,
             'token',
         );
+
         $this->mockSocialiteFromUser($abstractUser);
+
         $this->mock(Google::class)
             ->shouldReceive('getProfile')
             ->andReturn($this->mockGoogleProfile($googleId));
@@ -119,9 +125,14 @@ class GoogleTest extends BrowserKitTestCase
      */
     public function testGoogleRedirect()
     {
-        // $this->visit('/google/continue');
-        // @TODO: Test below results in a 404: "A request to [https://accounts.google.com/o/oauth2/auth?client_id=....M9] failed. Received status code [404]."
-        // $this->assertRedirectedTo('https://accounts.google.com');
+        $response = $this->get('/google/continue');
+
+        $response->assertStatus(302);
+
+        $redirectDomain = parse_url($response->headers->get('Location'));
+
+        // We just care that the domain is correct and not all the query params included in the redirect URL.
+        $this->assertEquals('accounts.google.com', $redirectDomain['host']);
     }
 
     /**
@@ -145,10 +156,15 @@ class GoogleTest extends BrowserKitTestCase
             ],
         ]);
 
-        $this->visit('/google/verify')->seePageIs('/profile/about');
-        $this->seeIsAuthenticated('web');
+        $response = $this->get('/google/verify');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/profile/about');
+
+        $this->isAuthenticated('web');
 
         $user = auth()->user();
+
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->source, 'northstar');
         $this->assertEquals(
@@ -175,10 +191,15 @@ class GoogleTest extends BrowserKitTestCase
     {
         $this->defaultMock();
 
-        $this->visit('/google/verify')->seePageIs('/profile/about');
-        $this->seeIsAuthenticated('web');
+        $response = $this->get('/google/verify');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/profile/about');
+
+        $this->isAuthenticated('web');
 
         $user = auth()->user();
+
         $this->assertEquals($user->email, 'test@dosomething.org');
         $this->assertEquals($user->first_name, 'Puppet');
         $this->assertEquals($user->last_name, 'Sloth');
@@ -194,6 +215,7 @@ class GoogleTest extends BrowserKitTestCase
     public function testGoogleMissingProfileFields()
     {
         $googleId = '12345';
+
         $abstractUser = $this->mockSocialiteAbstractUser(
             'test@dosomething.org',
             null,
@@ -201,13 +223,21 @@ class GoogleTest extends BrowserKitTestCase
             $googleId,
             'token',
         );
+
         $this->mockSocialiteFromUser($abstractUser);
+
         $this->mock(Google::class)
             ->shouldReceive('getProfile')
             ->andReturn($this->mockGoogleProfile($googleId));
 
-        $this->visit('/google/verify')->seePageIs('/register');
-        $this->see(
+        $response = $this->get('/google/verify');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/register');
+
+        $redirectResponse = $this->followRedirects($response);
+
+        $redirectResponse->assertSeeText(
             'We need your first and last name to create your account! Please confirm that these are set on your Google profile and try again.',
         );
     }
@@ -219,6 +249,7 @@ class GoogleTest extends BrowserKitTestCase
     public function testGoogleMissingBirthday()
     {
         $googleId = '12345';
+
         $abstractUser = $this->mockSocialiteAbstractUser(
             'test@dosomething.org',
             'Puppet',
@@ -226,9 +257,11 @@ class GoogleTest extends BrowserKitTestCase
             $googleId,
             'token',
         );
+
         $this->mockSocialiteFromUser($abstractUser);
 
         $mockGoogleProfile = $this->mockGoogleProfile($googleId);
+
         // Remove the birthdays attribute from the mocked Google Profile payload.
         unset($mockGoogleProfile->birthdays);
 
@@ -236,8 +269,12 @@ class GoogleTest extends BrowserKitTestCase
             ->shouldReceive('getProfile')
             ->andReturn($mockGoogleProfile);
 
-        $this->visit('/google/verify')->seePageIs('/profile/about');
-        $this->seeIsAuthenticated('web');
+        $response = $this->get('/google/verify');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/profile/about');
+
+        $this->isAuthenticated('web');
     }
 
     /**
@@ -254,9 +291,13 @@ class GoogleTest extends BrowserKitTestCase
 
         $this->defaultMock();
 
-        $this->visit('/google/verify')->seePageIs('/');
+        $response = $this->get('/google/verify');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/');
 
         $user = auth()->user();
+
         $this->assertEquals($user->first_name, 'Joe');
         $this->assertEquals($user->last_name, 'Sloth');
         $this->assertEquals($user->birthdate, $factoryUser->birthdate);

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -63,19 +63,14 @@ class PasswordResetTest extends TestCase
         info('testForgotPasswordResetFlow ' . $resetPasswordUrl);
 
         // The user should visit the link that was sent via email & set a new password.
-<<<<<<< HEAD
-        $this->visit($resetPasswordUrl);
-        $this->dontSee('window.snowplow');
-        $this->postForm('Reset Password', [
-=======
         $stepThreeResponse = $this->get($resetPasswordUrl);
 
+        $stepThreeResponse->assertDontSee('window.snowplow');
         $stepThreeResponse->assertSeeText('Forgot your password?');
 
         $stepFourResponse = $this->post('/password/reset/forgot-password', [
             'email' => $user->email,
             'token' => $this->getUserTokenFromResetUrl($resetPasswordUrl),
->>>>>>> Removing BrowserKit from PasswordResetTest.
             'password' => 'new-top-secret-passphrase',
             'password_confirmation' => 'new-top-secret-passphrase',
         ]);

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -65,6 +65,7 @@ class PasswordResetTest extends TestCase
         // The user should visit the link that was sent via email & set a new password.
         $stepThreeResponse = $this->get($resetPasswordUrl);
 
+        $stepThreeResponse->assertStatus(200);
         $stepThreeResponse->assertDontSee('window.snowplow');
         $stepThreeResponse->assertSeeText('Forgot your password?');
 

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -158,6 +158,7 @@ class PasswordResetTest extends TestCase
         // User goes to password reset URL.
         $stepTwoResponse = $this->get($resetPasswordUrl);
 
+        $stepTwoResponse->assertStatus(200);
         $stepTwoResponse->assertSeeText(
             'Welcome to your DoSomething.org account!',
         );


### PR DESCRIPTION
### What's this PR do?

This pull request starts on some cleanup for tests in Northstar to remove the use of the older `BrowserKitTestCase`.

### How should this be reviewed?

👀 🚥 

### Any background context you want to provide?

The `BrowserKitTestCase` class exists to provide compatibility between Laravel 5.3's testing API and the newer API introduced in Laravel 5.4 and currently in use. It'll make our lives a lot easier if we can switch to using the newer Laravel Test API so we stay up-to-date on current approaches to testing, unify all our tests using the same API and it would allow us to remove the  `BrowserKitTesting` support package.

### Relevant tickets

References [Pivotal #174652230](https://www.pivotaltracker.com/story/show/174652230).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
