### PR TITLE
Fix up some test/factory issues.

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -19,6 +19,7 @@ $factory->define(App\Models\User::class, function (
         'mobile' => $faker->unique()->phoneNumber,
         'mobilecommons_id' => $faker->randomNumber(5),
         'sms_status' => $faker->randomElement(['active', 'less']),
+        'email_subscription_status' => $faker->boolean,
         'facebook_id' => $faker->unique()->randomNumber(),
         'google_id' => $faker->unique()->randomNumber(),
         'password' => $faker->password,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -30,7 +30,6 @@ $factory->define(App\Models\User::class, function (
         'country' => $faker->countryCode,
         'language' => $faker->languageCode,
         'source' => 'factory',
-        'school_id' => '12500012',
         'club_id' => 1,
         'causes' => $faker->randomElements(
             [

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -24,7 +24,7 @@ $factory->define(App\Models\User::class, function (
         'password' => $faker->password,
         'birthdate' => $faker->dateTimeBetween('1/1/1980', '-1 year'),
         'addr_street1' => $faker->streetAddress,
-        'city' => $faker->city,
+        'addr_city' => $faker->city,
         'addr_state' => $faker->stateAbbr,
         'addr_zip' => $faker->postcode,
         'country' => $faker->countryCode,

--- a/tests/Console/UnsetFieldsTest.php
+++ b/tests/Console/UnsetFieldsTest.php
@@ -13,7 +13,7 @@ class UnsetFieldsTest extends TestCase
 
         // Make sure all users have a `city`
         $usersWithCity = User::whereRaw([
-            'city' => [
+            'addr_city' => [
                 '$exists' => true,
             ],
         ])->count();
@@ -37,13 +37,13 @@ class UnsetFieldsTest extends TestCase
 
         // Run the command to unset `city` and `country`
         Artisan::call('northstar:unset', [
-            'field' => ['city', 'country'],
+            'field' => ['addr_city', 'country'],
             '--force' => true,
         ]);
 
         // Make sure NO users have a `city`
         $usersWithCity = User::whereRaw([
-            'city' => [
+            'addr_city' => [
                 '$exists' => true,
             ],
         ])->count();

--- a/tests/Http/MergeTest.php
+++ b/tests/Http/MergeTest.php
@@ -32,7 +32,7 @@ class MergeTest extends BrowserKitTestCase
             'first_name' => 'Phil',
             'last_name' => 'Dunfy',
             'addr_street1' => '19 W 21st St',
-            'city' => 'New York',
+            'addr_city' => 'New York',
             'addr_state' => 'NY',
             'addr_zip' => '10010',
             'country' => 'USA',

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -181,6 +181,7 @@ class UserTest extends BrowserKitTestCase
             'mobile' => '+18602035512',
             'birthdate' => '01/01/1993',
             'referrer_user_id' => '559442cca59dbfca578b4bed',
+            'school_id' => '12500012',
         ]);
 
         $this->asStaffUser()->get('v2/users/' . $user->id);

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -13,6 +13,9 @@ class UserModelTest extends BrowserKitTestCase
         /** @var User $user */
         $user = factory(User::class)->create([
             'birthdate' => '1/2/1990',
+            'email_subscription_status' => true,
+            'email_subscription_topics' => ['news', 'community'],
+            'sms_subscription_topics' => ['general'],
             'school_id' => '12500012',
             'causes' => [
                 'animal_welfare',
@@ -37,6 +40,8 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => $user->sms_status,
             'sms_paused' => (bool) $user->sms_paused,
             'sms_status_source' => 'northstar',
+            'email_subscription_status' => true,
+            'unsubscribed' => false,
             'facebook_id' => $user->facebook_id,
             'google_id' => $user->google_id,
             'addr_city' => $user->addr_city,
@@ -57,41 +62,15 @@ class UserModelTest extends BrowserKitTestCase
             'last_messaged_at' => null,
             'updated_at' => $user->updated_at->timestamp,
             'created_at' => $user->created_at->timestamp,
-            'news_email_subscription_status' => isset(
-                $user->email_subscription_topics,
-            )
-                ? in_array('news', $user->email_subscription_topics)
-                : false,
-            'lifestyle_email_subscription_status' => isset(
-                $user->email_subscription_topics,
-            )
-                ? in_array('lifestyle', $user->email_subscription_topics)
-                : false,
-            'community_email_subscription_status' => isset(
-                $user->email_subscription_topics,
-            )
-                ? in_array('community', $user->email_subscription_topics)
-                : false,
-            'scholarship_email_subscription_status' => isset(
-                $user->email_subscription_topics,
-            )
-                ? in_array('scholarships', $user->email_subscription_topics)
-                : false,
-            'clubs_email_subscription_status' => isset(
-                $user->email_subscription_topics,
-            )
-                ? in_array('clubs', $user->email_subscription_topics)
-                : false,
-            'general_sms_subscription_status' => isset(
-                $user->sms_subscription_topics,
-            )
-                ? in_array('general', $user->sms_subscription_topics)
-                : false,
-            'voting_sms_subscription_status' => isset(
-                $user->sms_subscription_topics,
-            )
-                ? in_array('voting', $user->sms_subscription_topics)
-                : false,
+
+            // These boolean fields are computed based on whether or not array values exist:
+            'news_email_subscription_status' => true,
+            'lifestyle_email_subscription_status' => false,
+            'community_email_subscription_status' => true,
+            'scholarship_email_subscription_status' => false,
+            'clubs_email_subscription_status' => false,
+            'general_sms_subscription_status' => true,
+            'voting_sms_subscription_status' => false,
             'animal_welfare' => true,
             'bullying' => false,
             'education' => true,

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -298,7 +298,6 @@ class UserModelTest extends BrowserKitTestCase
         $newClubName = 'DoSomething Staffers Club';
 
         // Ensure we query this Rogue club via GraphQL.
-        $this->graphqlMock = $this->mock(GraphQL::class);
         $this->graphqlMock
             ->shouldReceive('getClubById')
             ->with($newClubId)
@@ -345,7 +344,7 @@ class UserModelTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
 
         // Ensure we don't find a Rogue club via GraphQL.
-        $this->mock(GraphQL::class)
+        $this->graphqlMock
             ->shouldReceive('getClubById', 'getSchoolById')
             ->andReturn(null);
 

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -29,7 +29,7 @@ class UserModelTest extends BrowserKitTestCase
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->once();
 
         // The Customer.io payload should be serialized correctly:
-        $this->assertEquals($user->toCustomerIoPayload(), [
+        $expected = [
             'id' => $user->id,
             'first_name' => $user->first_name,
             'display_name' => $user->display_name,
@@ -83,12 +83,15 @@ class UserModelTest extends BrowserKitTestCase
             'physical_health' => false,
             'racial_justice_equity' => false,
             'sexual_harassment_assault' => true,
+
             'voting_method' => null,
             'voting_plan_status' => null,
             'voting_plan_method_of_transport' => null,
             'voting_plan_time_of_day' => null,
             'voting_plan_attending_with' => null,
-        ]);
+        ];
+
+        $this->assertEquals($expected, $user->toCustomerIoPayload());
     }
 
     /** @test */

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -13,6 +13,7 @@ class UserModelTest extends BrowserKitTestCase
         /** @var User $user */
         $user = factory(User::class)->create([
             'birthdate' => '1/2/1990',
+            'school_id' => '12500012',
             'causes' => [
                 'animal_welfare',
                 'education',
@@ -42,8 +43,8 @@ class UserModelTest extends BrowserKitTestCase
             'addr_state' => $user->addr_state,
             'addr_zip' => $user->addr_zip,
             'country' => $user->country,
-            'school_id' => $user->school_id,
             'club_id' => $user->club_id,
+            'school_id' => '12500012',
             'school_name' => 'San Dimas High School',
             'school_state' => 'CA',
             'voter_registration_status' => $user->voter_registration_status,


### PR DESCRIPTION
### What's this PR do?

This pull request removes `school_id` from our default User factory in 2b96ba1, because each read/write hits our `toCustomerIo` transformer (to log the payload), which blocks on a request to GraphQL. (In theory, this should be mocked [in our test suite](https://github.com/DoSomething/northstar/blob/43a7c6504ebde98f842fd15f87877b4f645b8ab5/tests/CreatesApplication.php#L52-L55) but we overwrite the mock in two different places 7b96e62 where it wouldn't have taken effect!)

Finally, I've corrected the typo'd `city` field to `addr_city` (gah, schema-less databases strike again!) in cf476c2, and made our `email_subscription_status` and `email_subscription_topics` tests more explicit in e12084c.

### How should this be reviewed?

I'd recommend reviewing commit-by-commit!

### Any background context you want to provide?

Hoping this makes tests and seeds a bit faster! We'll continue to try to optimize as we go.

cc: @katiecrane @aaronschachter re: slow tests!

### Relevant tickets

N/A

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
