### PR TITLE
BrowserKit Purge Part Tres

### DIFF
--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -313,13 +313,17 @@ class UserTest extends TestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff', 'write'])
-            ->json('PUT', 'v2/users/' . $user->id, [
-                'first_name' => 'Alexander',
-                'last_name' => 'Hamilton',
-                'club_id' => 2,
-            ])
-            ->assertStatus(200);
+        $response = $this->asUser($staff, [
+            'user',
+            'role:staff',
+            'write',
+        ])->json('PUT', 'v2/users/' . $user->id, [
+            'first_name' => 'Alexander',
+            'last_name' => 'Hamilton',
+            'club_id' => 2,
+        ]);
+
+        $response->assertStatus(200);
 
         // The user should be updated.
         $this->assertMongoDatabaseHas('users', [
@@ -339,14 +343,18 @@ class UserTest extends TestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asUser($user, ['user', 'write'])
-            ->json('PUT', 'v2/users/' . $user->id, [
+        $response = $this->asUser($user, ['user', 'write'])->json(
+            'PUT',
+            'v2/users/' . $user->id,
+            [
                 'first_name' => 'Pepper',
                 'last_name' => 'Puppy',
                 'school_id' => '7110001',
                 'club_id' => 2,
-            ])
-            ->assertStatus(200);
+            ],
+        );
+
+        $response->assertStatus(200);
 
         // The user should be updated.
         $this->assertMongoDatabaseHas('users', [
@@ -370,12 +378,16 @@ class UserTest extends TestCase
 
         $user = factory(User::class)->create();
 
-        $this->asUser($user, ['user', 'write'])
-            ->json('PUT', 'v2/users/' . $user->id, [
+        $response = $this->asUser($user, ['user', 'write'])->json(
+            'PUT',
+            'v2/users/' . $user->id,
+            [
                 'first_name' => 'Pepper',
                 'last_name' => 'Puppy',
-            ])
-            ->assertStatus(200);
+            ],
+        );
+
+        $response->assertStatus(200);
 
         // Should not see the badges feature flag.
         $user->refresh();
@@ -393,12 +405,16 @@ class UserTest extends TestCase
         $user1 = factory(User::class)->create();
         $user2 = factory(User::class)->create();
 
-        $this->asUser($user2, ['user', 'role:staff', 'write'])
-            ->json('PUT', 'v2/users/' . $user1->id, [
-                'first_name' => 'Burt',
-                'last_name' => 'Macklin',
-            ])
-            ->assertStatus(401);
+        $response = $this->asUser($user2, [
+            'user',
+            'role:staff',
+            'write',
+        ])->json('PUT', 'v2/users/' . $user1->id, [
+            'first_name' => 'Burt',
+            'last_name' => 'Macklin',
+        ]);
+
+        $response->assertStatus(401);
 
         // The user should be updated.
         $this->assertMongoDatabaseHas('users', [
@@ -417,15 +433,15 @@ class UserTest extends TestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asMachine()
-            ->json('PUT', 'v2/users/' . $user->id, [
-                'first_name' => 'Wilhelmina',
-                'last_name' => 'Grubbly-Plank',
-                'school_id' => '11122019',
-                'club_id' => 2,
-                'referrer_user_id' => '5e7aa023fdce2754fc584dea',
-            ])
-            ->assertStatus(200);
+        $response = $this->asMachine()->json('PUT', 'v2/users/' . $user->id, [
+            'first_name' => 'Wilhelmina',
+            'last_name' => 'Grubbly-Plank',
+            'school_id' => '11122019',
+            'club_id' => 2,
+            'referrer_user_id' => '5e7aa023fdce2754fc584dea',
+        ]);
+
+        $response->assertStatus(200);
 
         // The user should be updated.
         $this->assertMongoDatabaseHas('users', [
@@ -471,11 +487,15 @@ class UserTest extends TestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff', 'write'])
-            ->json('PUT', 'v2/users/' . $user->id, [
-                'mobile' => '',
-            ])
-            ->assertStatus(200);
+        $response = $this->asUser($staff, [
+            'user',
+            'role:staff',
+            'write',
+        ])->json('PUT', 'v2/users/' . $user->id, [
+            'mobile' => '',
+        ]);
+
+        $response->assertStatus(200);
 
         // The user field should have been removed.
         $this->assertNull($user->fresh()->mobile);
@@ -487,11 +507,15 @@ class UserTest extends TestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff', 'write'])
-            ->json('PUT', 'v2/users/' . $user->id, [
-                'mobile' => null,
-            ])
-            ->assertStatus(200);
+        $response = $this->asUser($staff, [
+            'user',
+            'role:staff',
+            'write',
+        ])->json('PUT', 'v2/users/' . $user->id, [
+            'mobile' => null,
+        ]);
+
+        $response->assertStatus(200);
 
         // The user field should have been removed.
         $this->assertNull($user->fresh()->mobile);
@@ -507,11 +531,15 @@ class UserTest extends TestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff'])
-            ->json('PUT', 'v2/users/' . $user->id, [
+        $response = $this->asUser($staff, ['user', 'role:staff'])->json(
+            'PUT',
+            'v2/users/' . $user->id,
+            [
                 'role' => 'admin',
-            ])
-            ->assertStatus(401);
+            ],
+        );
+
+        $response->assertStatus(401);
     }
 
     /**
@@ -612,19 +640,19 @@ class UserTest extends TestCase
      */
     public function testV2ValidatesCountryCode()
     {
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'email' => 'american@example.com',
-                'country' => 'united states',
-            ])
-            ->assertStatus(422);
+        $responseOne = $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'american@example.com',
+            'country' => 'united states',
+        ]);
 
-        $this->asAdminUser()
-            ->json('POST', 'v1/users', [
-                'email' => 'american@example.com',
-                'country' => 'us',
-            ])
-            ->assertStatus(201);
+        $responseOne->assertStatus(422);
+
+        $responseTwo = $this->asAdminUser()->json('POST', 'v1/users', [
+            'email' => 'american@example.com',
+            'country' => 'us',
+        ]);
+
+        $responseTwo->assertStatus(201);
     }
 
     /**
@@ -674,26 +702,26 @@ class UserTest extends TestCase
      */
     public function testV2ValidatesSmsSubscriptionTopics()
     {
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'email' => 'test@example.com',
-                'sms_subscription_topics' => ['bugs'],
-            ])
-            ->assertStatus(422);
+        $responseOne = $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'sms_subscription_topics' => ['bugs'],
+        ]);
 
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'email' => 'test@example.com',
-                'sms_subscription_topics' => 'bugs',
-            ])
-            ->assertStatus(500);
+        $responseOne->assertStatus(422);
 
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'email' => 'test@example.com',
-                'sms_subscription_topics' => ['voting'],
-            ])
-            ->assertStatus(201);
+        $responseTwo = $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'sms_subscription_topics' => 'bugs',
+        ]);
+
+        $responseTwo->assertStatus(500);
+
+        $responseThree = $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'sms_subscription_topics' => ['voting'],
+        ]);
+
+        $responseThree->assertStatus(201);
     }
 
     /**
@@ -703,17 +731,17 @@ class UserTest extends TestCase
      */
     public function testV2ValidatesMobile()
     {
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'mobile' => '000-00-0000',
-            ])
-            ->assertStatus(422);
+        $responseOne = $this->asAdminUser()->json('POST', 'v2/users', [
+            'mobile' => '000-00-0000',
+        ]);
 
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'mobile' => '212-254-2390',
-            ])
-            ->assertStatus(201);
+        $responseOne->assertStatus(422);
+
+        $responseTwo = $this->asAdminUser()->json('POST', 'v2/users', [
+            'mobile' => '212-254-2390',
+        ]);
+
+        $responseTwo->assertStatus(201);
     }
 
     /**
@@ -723,19 +751,19 @@ class UserTest extends TestCase
      */
     public function testV2ValidatesClubId()
     {
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'email' => 'test@example.com',
-                'club_id' => 'something bad',
-            ])
-            ->assertStatus(422);
+        $responseOne = $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'club_id' => 'something bad',
+        ]);
 
-        $this->asAdminUser()
-            ->json('POST', 'v2/users', [
-                'email' => 'test@example.com',
-                'club_id' => 1,
-            ])
-            ->assertStatus(201);
+        $responseOne->assertStatus(422);
+
+        $responseTwo = $this->asAdminUser()->json('POST', 'v2/users', [
+            'email' => 'test@example.com',
+            'club_id' => 1,
+        ]);
+
+        $responseTwo->assertStatus(201);
     }
 
     /**

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 use App\Services\Gambit;
 use App\Services\Rogue;
 
-class UserTest extends BrowserKitTestCase
+class UserTest extends TestCase
 {
     /**
      * Test retrieving multiple users.
@@ -19,8 +19,9 @@ class UserTest extends BrowserKitTestCase
         // Make some test users to see in the index.
         factory(User::class, 5)->create();
 
-        $this->asUser($user, ['role:admin'])->get('v2/users');
-        $this->assertResponseStatus(401);
+        $response = $this->asUser($user, ['role:admin'])->get('v2/users');
+
+        $response->assertStatus(401);
     }
 
     /**
@@ -34,8 +35,11 @@ class UserTest extends BrowserKitTestCase
         $staff = factory(User::class, 'staff')->create();
         factory(User::class, 5)->create();
 
-        $this->asUser($staff, ['role:staff', 'user'])->get('v2/users');
-        $this->assertResponseStatus(200);
+        $response = $this->asUser($staff, ['role:staff', 'user'])->get(
+            'v2/users',
+        );
+
+        $response->assertStatus(200);
     }
 
     /**
@@ -49,8 +53,11 @@ class UserTest extends BrowserKitTestCase
         $admin = factory(User::class, 'admin')->create();
         factory(User::class, 5)->create();
 
-        $this->asUser($admin, ['role:admin', 'user'])->get('v2/users');
-        $this->assertResponseStatus(200);
+        $response = $this->asUser($admin, ['role:admin', 'user'])->get(
+            'v2/users',
+        );
+
+        $response->assertStatus(200);
     }
 
     /**
@@ -66,12 +73,14 @@ class UserTest extends BrowserKitTestCase
                 '12/31/2009',
             ),
         ]);
+
         factory(User::class, 5)->create([
             'updated_at' => $this->faker->dateTimeBetween(
                 '1/1/2010',
                 '1/1/2015',
             ),
         ]);
+
         factory(User::class, 6)->create([
             'updated_at' => $this->faker->dateTimeBetween(
                 '1/2/2015',
@@ -79,33 +88,36 @@ class UserTest extends BrowserKitTestCase
             ),
         ]);
 
-        $this->withAccessToken(['admin', 'user'])->json(
+        $responseOne = $this->withAccessToken(['admin', 'user'])->json(
             'GET',
             'v2/users?before[updated_at]=1/1/2010',
         );
+
         $this->assertCount(
             4,
-            $this->decodeResponseJson()['data'],
+            $responseOne->decodeResponseJson('data'),
             'can filter `updated_at` before timestamp',
         );
 
-        $this->withAccessToken(['admin', 'user'])->json(
+        $responseTwo = $this->withAccessToken(['admin', 'user'])->json(
             'GET',
             'v2/users?after[updated_at]=1/1/2015',
         );
+
         $this->assertCount(
             6,
-            $this->decodeResponseJson()['data'],
+            $responseTwo->decodeResponseJson('data'),
             'can filter `updated_at` after timestamp',
         );
 
-        $this->withAccessToken(['admin', 'user'])->json(
+        $responseThree = $this->withAccessToken(['admin', 'user'])->json(
             'GET',
             'v2/users?before[updated_at]=1/2/2015&after[updated_at]=12/31/2009',
         );
+
         $this->assertCount(
             5,
-            $this->decodeResponseJson()['data'],
+            $responseThree->decodeResponseJson('data'),
             'can filter `updated_at` between two timestamps',
         );
     }
@@ -120,11 +132,13 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
 
         // Test that we can view public profile as another user.
-        $this->get('v2/users/' . $user->id);
-        $this->assertResponseStatus(200);
+        $response = $this->get('v2/users/' . $user->id);
+
+        $response->assertStatus(200);
 
         // And test that private profile fields are hidden for the other user.
-        $data = $this->decodeResponseJson()['data'];
+        $data = $response->decodeResponseJson('data');
+
         $this->assertArrayHasKey('first_name', $data);
         $this->assertArrayNotHasKey('last_name', $data);
         $this->assertArrayNotHasKey('email', $data);
@@ -148,21 +162,22 @@ class UserTest extends BrowserKitTestCase
         $viewer = factory(User::class)->create();
 
         // Test that we can view public profile as another user.
-        $this->asUser($viewer, ['user', 'user:admin'])->get(
+        $response = $this->asUser($viewer, ['user', 'user:admin'])->get(
             'v2/users/' . $user->id,
         );
-        $this->assertResponseStatus(200);
-        $this->seeJsonField('data.first_name', 'Puppet');
-        $this->seeJsonField('data.display_name', 'Puppet S.');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.first_name', 'Puppet');
+        $response->assertJsonPath('data.display_name', 'Puppet S.');
 
         // And test that private profile fields are hidden for the other user.
-        $this->dontSeeJsonField('data.last_name');
-        $this->dontSeeJsonField('data.age');
-        $this->dontSeeJsonField('data.email');
-        $this->dontSeeJsonField('data.mobile');
-        $this->dontSeeJsonField('data.facebook_id');
-        $this->dontSeeJsonField('data.school_id');
-        $this->dontSeeJsonField('data.club_id');
+        $response->assertJsonMissingExact(['data' => 'last_name']);
+        $response->assertJsonMissingExact(['data' => 'age']);
+        $response->assertJsonMissingExact(['data' => 'email']);
+        $response->assertJsonMissingExact(['data' => 'mobile']);
+        $response->assertJsonMissingExact(['data' => 'facebook_id']);
+        $response->assertJsonMissingExact(['data' => 'school_id']);
+        $response->assertJsonMissingExact(['data' => 'club_id']);
     }
 
     /**
@@ -184,21 +199,25 @@ class UserTest extends BrowserKitTestCase
             'school_id' => '12500012',
         ]);
 
-        $this->asStaffUser()->get('v2/users/' . $user->id);
-        $this->assertResponseStatus(200);
+        $response = $this->asStaffUser()->get('v2/users/' . $user->id);
+
+        $response->assertStatus(200);
 
         // Check that public & private profile fields are visible
-        $this->seeJsonField('data.first_name', 'Puppet');
-        $this->seeJsonField('data.display_name', 'Puppet S.');
-        $this->seeJsonField('data.last_name', 'Sloth');
-        $this->seeJsonField('data.email', 'puppet.sloth@dosomething.org');
-        $this->seeJsonField('data.email_preview', 'pup...@dosomething.org');
-        $this->seeJsonField('data.mobile', '8602035512'); // @TODO: This should be E.164!
-        $this->seeJsonField('data.mobile_preview', '(860) 203-XXXX');
-        $this->seeJsonField('data.school_id', '12500012');
-        $this->seeJsonField('data.school_id_preview', '125XXXXX');
-        $this->seeJsonField('data.club_id', 1);
-        $this->seeJsonField(
+        $response->assertJsonPath('data.first_name', 'Puppet');
+        $response->assertJsonPath('data.display_name', 'Puppet S.');
+        $response->assertJsonPath('data.last_name', 'Sloth');
+        $response->assertJsonPath('data.email', 'puppet.sloth@dosomething.org');
+        $response->assertJsonPath(
+            'data.email_preview',
+            'pup...@dosomething.org',
+        );
+        $response->assertJsonPath('data.mobile', '8602035512'); // @TODO: This should be E.164!
+        $response->assertJsonPath('data.mobile_preview', '(860) 203-XXXX');
+        $response->assertJsonPath('data.school_id', '12500012');
+        $response->assertJsonPath('data.school_id_preview', '125XXXXX');
+        $response->assertJsonPath('data.club_id', 1);
+        $response->assertJsonPath(
             'data.referrer_user_id',
             '559442cca59dbfca578b4bed',
         );
@@ -214,13 +233,14 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
         $admin = factory(User::class, 'admin')->create();
 
-        $this->asUser($admin, ['user', 'user:admin'])->get(
+        $response = $this->asUser($admin, ['user', 'user:admin'])->get(
             'v2/users/' . $user->id,
         );
-        $this->assertResponseStatus(200);
+
+        $response->assertStatus(200);
 
         // Check that public & private profile fields are visible
-        $this->seeJsonStructure([
+        $response->assertJsonStructure([
             'data' => [
                 'id',
                 'email',
@@ -245,13 +265,14 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
 
         // Normal users should not be able to query sensitive values for others:
-        $this->asNormalUser()->get(
+        $response = $this->asNormalUser()->get(
             'v2/users/' . $user->id . '?include=email,addr_street1,school_id',
         );
-        $this->assertResponseOk()
-            ->dontSeeJsonField('data.email')
-            ->dontSeeJsonField('data.addr_street1')
-            ->dontSeeJsonField('data.school_id');
+
+        $response->assertStatus(200);
+        $response->assertJsonMissingExact(['data' => 'email']);
+        $response->assertJsonMissingExact(['data' => 'addr_street1']);
+        $response->assertJsonMissingExact(['data' => 'school_id']);
     }
 
     /**
@@ -266,17 +287,20 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
 
         // Check that sensitive fields are not included by default:
-        $this->asStaffUser()->get('v2/users/' . $user->id);
-        $this->assertResponseOk()->dontSeeJsonField('data.email');
+        $responseOne = $this->asStaffUser()->get('v2/users/' . $user->id);
+
+        $responseOne->assertStatus(200);
+        $responseOne->assertJsonMissingExact(['data' => 'email']);
 
         // When we re-query with `?include=`, we should see them!
-        $this->asStaffUser()->get(
+        $responseTwo = $this->asStaffUser()->get(
             'v2/users/' . $user->id . '?include=email,addr_street1,school_id',
         );
-        $this->assertResponseOk()
-            ->seeJsonField('data.email', $user->email)
-            ->seeJsonField('data.addr_street1', $user->addr_street1)
-            ->seeJsonField('data.school_id', $user->school_id);
+
+        $responseTwo->assertStatus(200);
+        $responseTwo->assertJsonPath('data.email', $user->email);
+        $responseTwo->assertJsonPath('data.addr_street1', $user->addr_street1);
+        $responseTwo->assertJsonPath('data.school_id', $user->school_id);
     }
 
     /**
@@ -289,20 +313,16 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff', 'write'])->json(
-            'PUT',
-            'v2/users/' . $user->id,
-            [
+        $this->asUser($staff, ['user', 'role:staff', 'write'])
+            ->json('PUT', 'v2/users/' . $user->id, [
                 'first_name' => 'Alexander',
                 'last_name' => 'Hamilton',
                 'club_id' => 2,
-            ],
-        );
-
-        $this->assertResponseStatus(200);
+            ])
+            ->assertStatus(200);
 
         // The user should be updated.
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             'first_name' => 'Alexander',
             'last_name' => 'Hamilton',
             'club_id' => 2,
@@ -319,21 +339,17 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asUser($user, ['user', 'write'])->json(
-            'PUT',
-            'v2/users/' . $user->id,
-            [
+        $this->asUser($user, ['user', 'write'])
+            ->json('PUT', 'v2/users/' . $user->id, [
                 'first_name' => 'Pepper',
                 'last_name' => 'Puppy',
                 'school_id' => '7110001',
                 'club_id' => 2,
-            ],
-        );
-
-        $this->assertResponseStatus(200);
+            ])
+            ->assertStatus(200);
 
         // The user should be updated.
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             'first_name' => 'Pepper',
             'last_name' => 'Puppy',
             '_id' => $user->id,
@@ -354,19 +370,16 @@ class UserTest extends BrowserKitTestCase
 
         $user = factory(User::class)->create();
 
-        $this->asUser($user, ['user', 'write'])->json(
-            'PUT',
-            'v2/users/' . $user->id,
-            [
+        $this->asUser($user, ['user', 'write'])
+            ->json('PUT', 'v2/users/' . $user->id, [
                 'first_name' => 'Pepper',
                 'last_name' => 'Puppy',
-            ],
-        );
-
-        $this->assertResponseStatus(200);
+            ])
+            ->assertStatus(200);
 
         // Should not see the badges feature flag.
         $user->refresh();
+
         $this->assertNull($user->feature_flags);
     }
 
@@ -380,19 +393,15 @@ class UserTest extends BrowserKitTestCase
         $user1 = factory(User::class)->create();
         $user2 = factory(User::class)->create();
 
-        $this->asUser($user2, ['user', 'role:staff', 'write'])->json(
-            'PUT',
-            'v2/users/' . $user1->id,
-            [
+        $this->asUser($user2, ['user', 'role:staff', 'write'])
+            ->json('PUT', 'v2/users/' . $user1->id, [
                 'first_name' => 'Burt',
                 'last_name' => 'Macklin',
-            ],
-        );
-
-        $this->assertResponseStatus(401);
+            ])
+            ->assertStatus(401);
 
         // The user should be updated.
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             'first_name' => $user1->first_name,
             'last_name' => $user1->last_name,
             '_id' => $user1->id,
@@ -408,18 +417,18 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asMachine()->json('PUT', 'v2/users/' . $user->id, [
-            'first_name' => 'Wilhelmina',
-            'last_name' => 'Grubbly-Plank',
-            'school_id' => '11122019',
-            'club_id' => 2,
-            'referrer_user_id' => '5e7aa023fdce2754fc584dea',
-        ]);
-
-        $this->assertResponseStatus(200);
+        $this->asMachine()
+            ->json('PUT', 'v2/users/' . $user->id, [
+                'first_name' => 'Wilhelmina',
+                'last_name' => 'Grubbly-Plank',
+                'school_id' => '11122019',
+                'club_id' => 2,
+                'referrer_user_id' => '5e7aa023fdce2754fc584dea',
+            ])
+            ->assertStatus(200);
 
         // The user should be updated.
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             'first_name' => 'Wilhelmina',
             'last_name' => 'Grubbly-Plank',
             '_id' => $user->id,
@@ -448,10 +457,11 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->assertResponseStatus(401);
+        $response->assertStatus(401);
+
         $this->assertEquals(
             'Requires the `write` scope.',
-            $response->decodeResponseJson()['hint'],
+            $response->decodeResponseJson('hint'),
         );
     }
 
@@ -461,15 +471,11 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff', 'write'])->json(
-            'PUT',
-            'v2/users/' . $user->id,
-            [
+        $this->asUser($staff, ['user', 'role:staff', 'write'])
+            ->json('PUT', 'v2/users/' . $user->id, [
                 'mobile' => '',
-            ],
-        );
-
-        $this->assertResponseStatus(200);
+            ])
+            ->assertStatus(200);
 
         // The user field should have been removed.
         $this->assertNull($user->fresh()->mobile);
@@ -481,15 +487,11 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff', 'write'])->json(
-            'PUT',
-            'v2/users/' . $user->id,
-            [
+        $this->asUser($staff, ['user', 'role:staff', 'write'])
+            ->json('PUT', 'v2/users/' . $user->id, [
                 'mobile' => null,
-            ],
-        );
-
-        $this->assertResponseStatus(200);
+            ])
+            ->assertStatus(200);
 
         // The user field should have been removed.
         $this->assertNull($user->fresh()->mobile);
@@ -505,15 +507,11 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
         $staff = factory(User::class, 'staff')->create();
 
-        $this->asUser($staff, ['user', 'role:staff'])->json(
-            'PUT',
-            'v2/users/' . $user->id,
-            [
+        $this->asUser($staff, ['user', 'role:staff'])
+            ->json('PUT', 'v2/users/' . $user->id, [
                 'role' => 'admin',
-            ],
-        );
-
-        $this->assertResponseStatus(401);
+            ])
+            ->assertStatus(401);
     }
 
     /**
@@ -523,17 +521,17 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2CreateUser()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
+        $response = $this->asAdminUser()->json('POST', 'v2/users', [
             'first_name' => 'Hercules',
             'last_name' => 'Mulligan',
             'email' => $this->faker->email,
             'country' => 'us',
         ]);
 
-        $this->assertResponseStatus(201);
-        $this->seeJsonField('data.first_name', 'Hercules');
-        $this->seeJsonField('data.last_name', 'Mulligan');
-        $this->seeJsonField('data.country', 'US'); // mutator should capitalize country codes!
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.first_name', 'Hercules');
+        $response->assertJsonPath('data.last_name', 'Mulligan');
+        $response->assertJsonPath('data.country', 'US'); // mutator should capitalize country codes!
     }
 
     /**
@@ -556,7 +554,8 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->assertResponseStatus(401);
+        $response->assertStatus(401);
+
         $this->assertEquals(
             'Requires the `write` scope.',
             $response->decodeResponseJson()['hint'],
@@ -572,16 +571,16 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asAdminUser()->json('PUT', 'v2/users/' . $user->id, [
+        $response = $this->asAdminUser()->json('PUT', 'v2/users/' . $user->id, [
             'first_name' => 'Hercules',
             'last_name' => 'Mulligan',
             'role' => 'admin',
         ]);
 
-        $this->assertResponseStatus(200);
-        $this->seeJsonField('data.first_name', 'Hercules');
-        $this->seeJsonField('data.last_name', 'Mulligan');
-        $this->seeJsonField('data.role', 'admin');
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.first_name', 'Hercules');
+        $response->assertJsonPath('data.last_name', 'Mulligan');
+        $response->assertJsonPath('data.role', 'admin');
     }
 
     /**
@@ -591,14 +590,15 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2FieldsAreNormalized()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
+        $response = $this->asAdminUser()->json('POST', 'v2/users', [
             'first_name' => 'Batman',
             'email' => 'BatMan@example.com',
             'mobile' => '1 (222) 333-5555',
         ]);
 
-        $this->assertResponseStatus(201);
-        $this->seeInMongoDatabase('users', [
+        $response->assertStatus(201);
+
+        $this->assertMongoDatabaseHas('users', [
             'first_name' => 'Batman',
             'email' => 'batman@example.com',
             'mobile' => '+12223335555',
@@ -612,19 +612,19 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2ValidatesCountryCode()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'email' => 'american@example.com',
-            'country' => 'united states',
-        ]);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'email' => 'american@example.com',
+                'country' => 'united states',
+            ])
+            ->assertStatus(422);
 
-        $this->assertResponseStatus(422);
-
-        $this->asAdminUser()->json('POST', 'v1/users', [
-            'email' => 'american@example.com',
-            'country' => 'us',
-        ]);
-
-        $this->assertResponseStatus(201);
+        $this->asAdminUser()
+            ->json('POST', 'v1/users', [
+                'email' => 'american@example.com',
+                'country' => 'us',
+            ])
+            ->assertStatus(201);
     }
 
     /**
@@ -634,14 +634,14 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2UTF8Fields()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
+        $response = $this->asAdminUser()->json('POST', 'v2/users', [
             'email' => 'woot-woot@example.com',
             'last_name' => '└(^o^)┘',
         ]);
 
-        $this->assertResponseStatus(201);
-        $this->seeJsonField('data.last_name', '└(^o^)┘');
-        $this->seeJsonField('data.last_initial', '└');
+        $response->assertStatus(201);
+        $response->assertJsonPath('data.last_name', '└(^o^)┘');
+        $response->assertJsonPath('data.last_initial', '└');
     }
 
     /**
@@ -654,11 +654,13 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create();
 
         $newTimestamp = '2017-11-02T18:42:00.000Z';
-        $this->asAdminUser()->putJson('v2/users/' . $user->id, [
+
+        $response = $this->asAdminUser()->putJson('v2/users/' . $user->id, [
             'last_messaged_at' => $newTimestamp,
         ]);
 
-        $this->assertResponseStatus(200);
+        $response->assertStatus(200);
+
         $this->assertEquals(
             '2017-11-02T18:42:00+00:00',
             $user->fresh()->last_messaged_at->toIso8601String(),
@@ -672,26 +674,26 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2ValidatesSmsSubscriptionTopics()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'email' => 'test@example.com',
-            'sms_subscription_topics' => ['bugs'],
-        ]);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'email' => 'test@example.com',
+                'sms_subscription_topics' => ['bugs'],
+            ])
+            ->assertStatus(422);
 
-        $this->assertResponseStatus(422);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'email' => 'test@example.com',
+                'sms_subscription_topics' => 'bugs',
+            ])
+            ->assertStatus(500);
 
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'email' => 'test@example.com',
-            'sms_subscription_topics' => 'bugs',
-        ]);
-
-        $this->assertResponseStatus(500);
-
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'email' => 'test@example.com',
-            'sms_subscription_topics' => ['voting'],
-        ]);
-
-        $this->assertResponseStatus(201);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'email' => 'test@example.com',
+                'sms_subscription_topics' => ['voting'],
+            ])
+            ->assertStatus(201);
     }
 
     /**
@@ -701,17 +703,17 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2ValidatesMobile()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'mobile' => '000-00-0000',
-        ]);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'mobile' => '000-00-0000',
+            ])
+            ->assertStatus(422);
 
-        $this->assertResponseStatus(422);
-
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'mobile' => '212-254-2390',
-        ]);
-
-        $this->assertResponseStatus(201);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'mobile' => '212-254-2390',
+            ])
+            ->assertStatus(201);
     }
 
     /**
@@ -721,19 +723,19 @@ class UserTest extends BrowserKitTestCase
      */
     public function testV2ValidatesClubId()
     {
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'email' => 'test@example.com',
-            'club_id' => 'something bad',
-        ]);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'email' => 'test@example.com',
+                'club_id' => 'something bad',
+            ])
+            ->assertStatus(422);
 
-        $this->assertResponseStatus(422);
-
-        $this->asAdminUser()->json('POST', 'v2/users', [
-            'email' => 'test@example.com',
-            'club_id' => 1,
-        ]);
-
-        $this->assertResponseStatus(201);
+        $this->asAdminUser()
+            ->json('POST', 'v2/users', [
+                'email' => 'test@example.com',
+                'club_id' => 1,
+            ])
+            ->assertStatus(201);
     }
 
     /**
@@ -751,28 +753,34 @@ class UserTest extends BrowserKitTestCase
         ]);
 
         // Test that an exception is thrown if the user exists.
-        $this->asAdminUser()->json('POST', 'v2/users', [
+        $responseOne = $this->asAdminUser()->json('POST', 'v2/users', [
             'email' => $user->email,
             'first_name' => 'Daizy',
         ]);
 
         // It should return a 422 error.
-        $this->assertResponseStatus(422);
+        $responseOne->assertStatus(422);
+
         $this->assertEquals(
-            $this->decodeResponseJson()['error']['fields']['id'][0],
+            $responseOne->decodeResponseJson('error.fields.id.0'),
             'A record matching one of the given indexes already exists.',
         );
 
         // Test that the user is returned with changes if ?upsert=true is present.
-        $this->asAdminUser()->json('POST', 'v2/users?upsert=true', [
-            'email' => $user->email,
-            'first_name' => 'Daizy',
-        ]);
+        $responseTwo = $this->asAdminUser()->json(
+            'POST',
+            'v2/users?upsert=true',
+            [
+                'email' => $user->email,
+                'first_name' => 'Daizy',
+            ],
+        );
 
         // It should return the upserted record.
-        $this->assertResponseStatus(200);
-        $this->seeJsonField('data.email', $user->email);
-        $this->seeJsonField('data.first_name', 'Daizy');
+        $responseTwo->assertStatus(200);
+
+        $responseTwo->assertJsonPath('data.email', $user->email);
+        $responseTwo->assertJsonPath('data.first_name', 'Daizy');
     }
 
     /**
@@ -785,23 +793,25 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create(['email' => $this->faker->email]);
 
-        $this->withAccessToken(['admin', 'user'])->json(
+        $responseOne = $this->withAccessToken(['admin', 'user'])->json(
             'GET',
             'v2/users?search[email]=' . $user->email,
         );
-        $this->assertCount(1, $this->decodeResponseJson()['data']);
+
+        $this->assertCount(1, $responseOne->decodeResponseJson('data'));
         $this->assertEquals(
-            $this->decodeResponseJson()['data'][0]['email'],
+            $responseOne->decodeResponseJson('data.0.email'),
             $user->email,
         );
 
-        $this->withAccessToken(['admin', 'user'])->json(
+        $responseTwo = $this->withAccessToken(['admin', 'user'])->json(
             'GET',
             'v2/users?search=' . $user->email,
         );
-        $this->assertCount(1, $this->decodeResponseJson()['data']);
+
+        $this->assertCount(1, $responseTwo->decodeResponseJson('data'));
         $this->assertEquals(
-            $this->decodeResponseJson()['data'][0]['email'],
+            $responseTwo->decodeResponseJson('data.0.email'),
             $user->email,
         );
     }
@@ -819,13 +829,15 @@ class UserTest extends BrowserKitTestCase
         $viewer = factory(User::class)->create();
 
         // Test that we can view user information if not staff or admin.
-        $this->asUser($viewer, ['user', 'role:staff'])->get(
+        $response = $this->asUser($viewer, ['user', 'role:staff'])->get(
             'v2/mobile/' . $user->mobile,
         );
-        $this->assertResponseStatus(401);
+
+        $response->assertStatus(401);
+
         $this->assertEquals(
             'The resource owner or authorization server denied the request.',
-            $this->decodeResponseJson()['message'],
+            $response->decodeResponseJson('message'),
         );
     }
 
@@ -841,13 +853,14 @@ class UserTest extends BrowserKitTestCase
         ]);
         $admin = factory(User::class, 'staff')->create();
 
-        $this->asUser($admin, ['role:staff'])->get(
+        $response = $this->asUser($admin, ['role:staff'])->get(
             'v2/mobile/' . $user->mobile,
         );
-        $this->assertResponseStatus(200);
+
+        $response->assertStatus(200);
 
         // Check that fields are visible
-        $this->seeJsonStructure([
+        $response->assertJsonStructure([
             'data' => ['id', 'email', 'first_name', 'last_name', 'facebook_id'],
         ]);
     }
@@ -864,13 +877,14 @@ class UserTest extends BrowserKitTestCase
         ]);
         $admin = factory(User::class, 'admin')->create();
 
-        $this->asUser($admin, ['user', 'role:admin'])->get(
+        $response = $this->asUser($admin, ['user', 'role:admin'])->get(
             'v2/mobile/' . $user->mobile,
         );
-        $this->assertResponseStatus(200);
+
+        $response->assertStatus(200);
 
         // Check that fields are visible
-        $this->seeJsonStructure([
+        $response->assertJsonStructure([
             'data' => ['id', 'email', 'first_name', 'last_name', 'facebook_id'],
         ]);
     }
@@ -886,13 +900,15 @@ class UserTest extends BrowserKitTestCase
         $viewer = factory(User::class)->create();
 
         // Test that we cannot view public profile as another user.
-        $this->asUser($viewer, ['user', 'user:admin'])->get(
+        $response = $this->asUser($viewer, ['user', 'user:admin'])->get(
             'v2/email/' . $user->email,
         );
-        $this->assertResponseStatus(401);
+
+        $response->assertStatus(401);
+
         $this->assertEquals(
             'The resource owner or authorization server denied the request.',
-            $this->decodeResponseJson()['message'],
+            $response->decodeResponseJson('message'),
         );
     }
 
@@ -906,11 +922,14 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create(['email' => $this->faker->email]);
         $admin = factory(User::class, 'staff')->create();
 
-        $this->asUser($admin, ['role:staff'])->get('v2/email/' . $user->email);
-        $this->assertResponseStatus(200);
+        $response = $this->asUser($admin, ['role:staff'])->get(
+            'v2/email/' . $user->email,
+        );
+
+        $response->assertStatus(200);
 
         // Check that public & private profile fields are visible
-        $this->seeJsonStructure([
+        $response->assertJsonStructure([
             'data' => ['id', 'email', 'first_name', 'last_name', 'facebook_id'],
         ]);
     }
@@ -925,13 +944,14 @@ class UserTest extends BrowserKitTestCase
         $user = factory(User::class)->create(['email' => $this->faker->email]);
         $admin = factory(User::class, 'admin')->create();
 
-        $this->asUser($admin, ['user', 'role:admin'])->get(
+        $response = $this->asUser($admin, ['user', 'role:admin'])->get(
             'v2/email/' . $user->email,
         );
-        $this->assertResponseStatus(200);
+
+        $response->assertStatus(200);
 
         // Check that public & private profile fields are visible
-        $this->seeJsonStructure([
+        $response->assertJsonStructure([
             'data' => ['id', 'email', 'first_name', 'last_name', 'facebook_id'],
         ]);
     }
@@ -957,7 +977,8 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->assertResponseStatus(401);
+        $response->assertStatus(401);
+
         $this->assertEquals(
             'Requires the `write` scope.',
             $response->decodeResponseJson()['hint'],
@@ -976,9 +997,11 @@ class UserTest extends BrowserKitTestCase
         $this->mock(Rogue::class)
             ->shouldReceive('deleteUser')
             ->once();
+
         $this->mock(Gambit::class)
             ->shouldReceive('deleteUser')
             ->once();
+
         $this->customerIoMock->shouldReceive('deleteUser')->once();
 
         $response = $this->asAdminUser()->json(
@@ -992,7 +1015,7 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->assertResponseStatus(200);
+        $response->assertStatus(200);
     }
 
     /**
@@ -1004,14 +1027,14 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asAdminUser()->json('PUT', 'v2/users/' . $user->id, [
+        $response = $this->asAdminUser()->json('PUT', 'v2/users/' . $user->id, [
             'email_subscription_topics' => ['news', 'news'],
         ]);
 
-        $this->assertResponseStatus(200);
+        $response->assertStatus(200);
 
         // The email_subscription_topics should be updated with no duplicates
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $user->id,
             'email_subscription_topics' => ['news'],
         ]);
@@ -1026,14 +1049,14 @@ class UserTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asAdminUser()->json('PUT', 'v2/users/' . $user->id, [
+        $response = $this->asAdminUser()->json('PUT', 'v2/users/' . $user->id, [
             'sms_subscription_topics' => ['voting', 'voting'],
         ]);
 
-        $this->assertResponseStatus(200);
+        $response->assertStatus(200);
 
         // The email_subscription_topics should be updated with no duplicates
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $user->id,
             'sms_subscription_topics' => ['voting'],
         ]);
@@ -1056,7 +1079,7 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $nullStatusUser->id,
             'email_subscription_status' => true,
         ]);
@@ -1081,7 +1104,7 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $unsubscribedUser->id,
             'email_subscription_status' => true,
         ]);
@@ -1106,7 +1129,7 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $subscribedUser->id,
             'email_subscription_status' => true,
         ]);
@@ -1131,7 +1154,7 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $subscribedUser->id,
             'email_subscription_status' => false,
             'email_subscription_topics' => null,
@@ -1157,7 +1180,7 @@ class UserTest extends BrowserKitTestCase
             ],
         );
 
-        $this->seeInMongoDatabase('users', [
+        $this->assertMongoDatabaseHas('users', [
             '_id' => $subscribedUser->id,
             'sms_status' => 'stop',
             'sms_subscription_topics' => null,

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\User;
 
-class ModelTest extends BrowserKitTestCase
+class ModelTest extends TestCase
 {
     /** @test */
     public function it_should_unset_null_fields()

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -20,6 +20,7 @@ class ModelTest extends TestCase
 
         // Make sure the field is unset on the actual document.
         $document = $this->getMongoDocument('users', $user->id);
+
         $this->assertArrayNotHasKey('mobile', $document);
         $this->assertArrayNotHasKey('last_name', $document);
     }
@@ -39,6 +40,7 @@ class ModelTest extends TestCase
 
         // Make sure the audit prop with audit info is added for the set attribute.
         $document = $this->getMongoDocument('users', $user->id);
+
         $this->assertArrayHasKey('audit', $document);
         $this->assertEquals(
             ['source' => 'northstar', 'updated_at' => $time],

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -3,7 +3,7 @@
 use App\Models\User;
 use App\Services\GraphQL;
 
-class UserModelTest extends BrowserKitTestCase
+class UserModelTest extends TestCase
 {
     /** @test */
     public function it_should_send_new_users_to_customer_io()
@@ -253,7 +253,7 @@ class UserModelTest extends BrowserKitTestCase
             'sms_status' => 'stop',
         ]);
 
-        $this->assertEquals($subscribedUser->sms_subscription_topics, []);
+        $this->assertEquals($unsubscribedUser->sms_subscription_topics, []);
     }
 
     public function doesNotChangeSubscriptionTopicsIfExistsWhenChangingSubscribedStatus()

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -136,6 +136,7 @@ class UserModelTest extends TestCase
         $type = 'forgot-password';
 
         $user = factory(User::class)->create(['email' => $email]);
+
         $result = $user->getPasswordResetUrl($token, $type);
 
         $this->assertEquals(
@@ -154,6 +155,7 @@ class UserModelTest extends TestCase
         $subscribedStatusUser = factory(User::class)
             ->states('email-subscribed')
             ->create();
+
         $result = $subscribedStatusUser->toCustomerIoPayload();
 
         $this->assertTrue($result['email_subscription_status']);
@@ -166,6 +168,7 @@ class UserModelTest extends TestCase
         $unsubscribedStatusUser = factory(User::class)
             ->states('email-unsubscribed')
             ->create();
+
         $result = $unsubscribedStatusUser->toCustomerIoPayload();
 
         $this->assertFalse($result['email_subscription_status']);
@@ -176,6 +179,7 @@ class UserModelTest extends TestCase
     public function it_should_exclude_unsubscribed_in_customerio_payload_if_email_subscription_status_not_set()
     {
         $unknownStatusUser = factory(User::class)->create();
+
         $result = $unknownStatusUser->toCustomerIoPayload();
 
         $this->assertFalse(isset($result['email_subscription_status']));

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\User;
-use App\Services\GraphQL;
 
 class UserModelTest extends TestCase
 {


### PR DESCRIPTION
### What's this PR do?

This pull request starts on some cleanup for tests in Northstar to remove the use of the older `BrowserKitTestCase`.

### How should this be reviewed?

👀 🚥 

### Any background context you want to provide?

Related to the work in #1091 & #1093 that began and continued The Purge™.

### Relevant tickets

References [Pivotal #174652230](https://www.pivotaltracker.com/story/show/174652230).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
