### PR TITLE
Updating create customer io event job usage

### DIFF
--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -5,9 +5,16 @@ namespace App\Jobs;
 use App\Jobs\Middleware\CustomerIoRateLimit;
 use App\Models\Post;
 use App\Services\CustomerIo;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
-class SendPostToCustomerIo extends Job
+class SendPostToCustomerIo implements ShouldQueue
 {
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
     /**
      * The post to send to Customer.io.
      *

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -5,9 +5,16 @@ namespace App\Jobs;
 use App\Jobs\Middleware\CustomerIoRateLimit;
 use App\Models\Signup;
 use App\Services\CustomerIo;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
-class SendSignupToCustomerIo extends Job
+class SendSignupToCustomerIo implements ShouldQueue
 {
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
     /**
      * The signup to send to Customer.io.
      *

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -70,10 +70,6 @@ class PostManager
             });
         }
 
-        // return optional(User::find($id), function ($user) {
-        //     return $user->name;
-        // });
-
         // Log that a post was created.
         info('post_created', [
             'id' => $post->id,

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -6,6 +6,7 @@ use App\Jobs\CreateCustomerIoEvent;
 use App\Jobs\SendPostToCustomerIo;
 use App\Jobs\SendReviewedPostToCustomerIo;
 use App\Models\Post;
+use App\Models\User;
 use App\Repositories\PostRepository;
 use App\Services\Fastly;
 
@@ -58,12 +59,20 @@ class PostManager
         SendPostToCustomerIo::dispatch($post);
 
         if ($post->referrer_user_id) {
-            CreateCustomerIoEvent::dispatch(
-                $post->referrer_user_id,
-                'referral_post_created',
-                $post->getReferralPostEventPayload(),
-            );
+            optional(User::find($post->referrer_user_id), function (
+                $referrerUser
+            ) use ($post) {
+                CreateCustomerIoEvent::dispatch(
+                    $referrerUser,
+                    'referral_post_created',
+                    $post->getReferralPostEventPayload(),
+                );
+            });
         }
+
+        // return optional(User::find($id), function ($user) {
+        //     return $user->name;
+        // });
 
         // Log that a post was created.
         info('post_created', [
@@ -91,11 +100,15 @@ class PostManager
         SendPostToCustomerIo::dispatch($post);
 
         if ($post->referrer_user_id) {
-            CreateCustomerIoEvent::dispatch(
-                $post->referrer_user_id,
-                'referral_post_updated',
-                $post->getReferralPostEventPayload(),
-            );
+            optional(User::find($post->referrer_user_id), function (
+                $referrerUser
+            ) use ($post) {
+                CreateCustomerIoEvent::dispatch(
+                    $referrerUser,
+                    'referral_post_updated',
+                    $post->getReferralPostEventPayload(),
+                );
+            });
         }
 
         if ($log) {


### PR DESCRIPTION
### What's this PR do?

This pull request updates instances of `CreateCustomerIoEvent()`, that came from imported Rogue code, to switch the arguments passed to match what Northstar uses. Northstar passes in a `$user` object instead of just a user id string. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

My code editor also highlighted that the `SendPostToCustomerIo()` and `SendSignupToCustomerIo()` methods where missing their `dispatch()` calls, so I also updated those respective classes to import and use the same traits other Northstar jobs use.

In Rogue, these classes [extended a `Jobs`]() abstract class, which didn't do much other than provide the list of traits and set a property on the class. I preferred to follow Northstar's approach and not use this convenience class (we didn't import it from Rogue), since it's not too hard to just import the traits needed and makes each class less opaque. We _may_ want to add the property it added to each class though... 🤔 

```php
    /**
     * Delete jobs if their model(s) no longer exist. This prevents things that
     * have been deleted (either as part of automated testing or account deletions)
     * from cluttering up our failed jobs table with false negatives.
     *
     * @var bool
     */
    public $deleteWhenMissingModels = true;
```

### Relevant tickets

References [Pivotal #176469276](https://www.pivotaltracker.com/story/show/176469276).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
