### PR TITLE
Read user's display name directly from database!

### DIFF
--- a/app/Console/Commands/SetupCommand.php
+++ b/app/Console/Commands/SetupCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use Defuse\Crypto\Key;
 use DFurnes\Environmentalist\ConfiguresApplication;
 use Illuminate\Console\Command;
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Traits\HasCursor;
+use App\Models\User;
 use App\Notifications\PostTagged;
 use App\Services\GraphQL;
 use Hashids\Hashids;
@@ -13,10 +14,11 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Jenssegers\Mongodb\Eloquent\HybridRelations;
 
 class Post extends Model
 {
-    use HasCursor, Notifiable, SoftDeletes;
+    use HasCursor, HybridRelations, Notifiable, SoftDeletes;
 
     /**
      * Always load a user's own reaction,
@@ -162,6 +164,14 @@ class Post extends Model
     public function signup()
     {
         return $this->belongsTo(Signup::class);
+    }
+
+    /**
+     * Get the user associated with this signup.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'northstar_id');
     }
 
     /**
@@ -692,16 +702,11 @@ class Post extends Model
      */
     public function getReferralPostEventPayload()
     {
-        $userId = $this->northstar_id;
-
-        // The associated user for this post.
-        $user = User::find($userId);
-
         return array_merge(
             [
                 'id' => $this->id,
-                'user_id' => $userId,
-                'user_display_name' => $user->display_name,
+                'user_id' => $this->northstar_id,
+                'user_display_name' => $this->user->display_name,
                 'type' => $this->type,
                 'status' => $this->status,
                 'action_id' => $this->action_id,

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -695,13 +695,13 @@ class Post extends Model
         $userId = $this->northstar_id;
 
         // The associated user for this post.
-        $user = app(GraphQL::class)->getUserById($userId);
+        $user = User::find($userId);
 
         return array_merge(
             [
                 'id' => $this->id,
                 'user_id' => $userId,
-                'user_display_name' => Arr::get($user, 'displayName'),
+                'user_display_name' => $user->display_name,
                 'type' => $this->type,
                 'status' => $this->status,
                 'action_id' => $this->action_id,

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -265,7 +265,7 @@ class Signup extends Model
     public function getReferralSignupEventPayload()
     {
         $userId = $this->northstar_id;
-        $user = app(GraphQL::class)->getUserById($userId);
+        $user = User::find($userId);
 
         $campaignWebsite = app(GraphQL::class)->getCampaignWebsiteByCampaignId(
             $this->campaign_id,
@@ -274,7 +274,7 @@ class Signup extends Model
         return [
             'id' => $this->id,
             'user_id' => $userId,
-            'user_display_name' => Arr::get($user, 'displayName'),
+            'user_display_name' => $user->display_name,
             'campaign_id' => (string) $this->campaign_id,
             'campaign_title' => Arr::get($campaignWebsite, 'title'),
             'created_at' => $this->created_at->toIso8601String(),

--- a/app/Services/GraphQL.php
+++ b/app/Services/GraphQL.php
@@ -109,27 +109,4 @@ class GraphQL
 
         return $this->query($query, $variables)['campaignWebsiteByCampaignId'];
     }
-
-    /**
-     * Query for a User by ID.
-     *
-     * @deprecated
-     * @param  $userId String
-     * @return array
-     */
-    public function getUserById($userId)
-    {
-        $query = '
-        query GetUserById($userId: String!) {
-          user(id: $userId) {
-            displayName
-          }
-        }';
-
-        $variables = [
-            'userId' => $userId,
-        ];
-
-        return $this->query($query, $variables)['user'];
-    }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -2,7 +2,11 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
+use App\Models\Action;
+use App\Models\Campaign;
 use App\Models\Post;
+use App\Models\Signup;
+use App\Models\User;
 use Faker\Generator as Faker;
 
 $factory->define(Post::class, function (Faker $faker) {

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -30,7 +30,7 @@ $factory->define(Post::class, function (Faker $faker) {
                 'campaign_id' => $attributes['campaign_id'],
             ])->id;
         },
-        'northstar_id' => $this->faker->northstar_id,
+        'northstar_id' => factory(User::class)->create(),
         'text' => $faker->sentence(),
         'location' => 'US-' . $faker->stateAbbr(),
         'source' => 'phpunit',

--- a/database/factories/ReactionFactory.php
+++ b/database/factories/ReactionFactory.php
@@ -9,7 +9,7 @@ $factory->define(Reaction::class, function (Faker $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
 
     return [
-        'northstar_id' => $faker->northstar_id,
+        'northstar_id' => factory(User::class)->create(),
         'post_id' => $faker->randomNumber(7),
     ];
 });

--- a/database/factories/SignupFactory.php
+++ b/database/factories/SignupFactory.php
@@ -2,7 +2,9 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
+use App\Models\Campaign;
 use App\Models\Signup;
+use App\Models\User;
 use Faker\Generator as Faker;
 
 $factory->define(Signup::class, function (Faker $faker) {

--- a/database/factories/SignupFactory.php
+++ b/database/factories/SignupFactory.php
@@ -11,7 +11,7 @@ $factory->define(Signup::class, function (Faker $faker) {
     $faker->addProvider(new FakerNorthstarId($faker));
 
     return [
-        'northstar_id' => $faker->northstar_id,
+        'northstar_id' => factory(User::class)->create(),
         'campaign_id' => function () {
             return factory(Campaign::class)->create()->id;
         },


### PR DESCRIPTION
### What's this PR do?

This pull request replaces the `getUserById` GraphQL query with directly reading from the related model through Eloquent! This takes advantage of [jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb)'s [cross-database relationship](https://github.com/jenssegers/laravel-mongodb#cross-database-relationships) support.

I also added some missing model imports in factory classes.

### How should this be reviewed?

It may be easiest to review this commit-by-commit.

🏭 I added missing `App\Models` imports to factories in ac8137f.

👨‍👩‍👧‍👦 I updated our seeders to create real MongoDB users for activity (rather than [seeded IDs](https://github.com/DoSomething/northstar/blob/37a13e7969e4a46ba43bfa4a5182d0f2f2fdcfcf/database/faker/FakerNorthstarId.php)) in a41c794. This gives proper relationships between users & their activity on local.

🥞 I directly reads the user model from Eloquent, rather than GraphQL, in 624d610.

🏷️ Finally, I configured model relationships (e.g. `$signup->user`) in 1f289e2.

### Any background context you want to provide?

🥞

### Relevant tickets

References [Pivotal #176469276](https://www.pivotaltracker.com/story/show/176469276).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
