### PR TITLE
Enable use of RefreshDatabase trait.

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,13 +1,14 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\CreatesApplication;
 use Tests\WithAuthentication;
 use Tests\WithMocks;
 
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
-    use CreatesApplication, WithMocks, WithAuthentication;
+    use CreatesApplication, RefreshDatabase, WithMocks, WithAuthentication;
 
     /**
      * The base URL to use while testing the application.


### PR DESCRIPTION
### What's this PR do?

This pull request enables the use of the `RefreshDatabase` trait within the `TestCase` for Northstar. While working on moving over the `CampaignTest`'s, even after the updates in #1103 I was getting errors with the `rogue_test` database and corresponding table for mysql not existing. 

```shell
1) CampaignTest::testCreatingACampaign
Illuminate\Database\QueryException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'rogue_test.group_types' doesn't exist

...
```

Adding the `RefreshDatabase` trait did end up working though! It seemed to register the mysql database, refresh it and then we still have the call in the `setup()` command to reset the MongoDB for the mongo related tests. I confirmed the mysql DB does get migrated 🎉 

After adding the trait, I reran the tests and it all worked as expected, throwing the one error in `CampaignTest.php` that I was initially importing in I am missing the `actingAsAdmin()` method:

```shell
1) CampaignTest::testCreatingACampaign
Error: Call to undefined method CampaignTest::actingAsAdmin()
```

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #176469276](https://www.pivotaltracker.com/story/show/176469276).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
