### PR TITLE
Enable Campaign routes in Northstar

### DIFF
--- a/app/Http/Controllers/Web/CampaignsController.php
+++ b/app/Http/Controllers/Web/CampaignsController.php
@@ -16,7 +16,7 @@ class CampaignsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth:web');
         $this->middleware('role:admin,staff');
 
         $this->rules = [

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,11 @@ Route::group(
         Route::get('signups/{signup}', 'SignupsController@show');
         Route::patch('signups/{signup}', 'SignupsController@update');
         Route::delete('signups/{signup}', 'SignupsController@destroy');
+
+        // campaigns
+        Route::get('campaigns', 'CampaignsController@index');
+        Route::get('campaigns/{campaign}', 'CampaignsController@show');
+        Route::patch('campaigns/{campaign}', 'CampaignsController@update');
     },
 );
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,11 @@ Route::post('totp', 'TotpController@verify');
 Route::get('totp/configure', 'TotpController@configure');
 Route::post('totp/configure', 'TotpController@store');
 
+// Campaigns
+Route::resource('campaigns', 'CampaignsController', [
+    'except' => ['index', 'show'],
+]);
+
 // Facebook Continue
 Route::get('facebook/continue', 'FacebookController@redirectToProvider');
 Route::get('facebook/verify', 'FacebookController@handleProviderCallback');

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -1,0 +1,751 @@
+<?php
+
+use App\Models\Campaign;
+use App\Models\GroupType;
+use App\Models\Post;
+use App\Types\Cause;
+use Illuminate\Support\Facades\Artisan;
+
+class CampaignTest extends TestCase
+{
+    //     /**
+//      * Test that a GET request to /api/v3/campaigns returns an index of all campaigns.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCampaignIndex()
+//     {
+//         factory(Campaign::class, 5)->create();
+//         $response = $this->getJson('api/v3/campaigns');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $response->assertStatus(200);
+//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can filter open or closed campaigns.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testFilteredCampaignIndex()
+//     {
+//         factory(Campaign::class, 5)->create();
+//         factory(Campaign::class, 'closed', 3)->create();
+//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=true');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=false');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can filter campaigns with an associated Contentful 'Website' entry.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testWebsiteFilteredCampaignIndex()
+//     {
+//         factory(Campaign::class, 5)->create([
+//             'contentful_campaign_id' => '123',
+//         ]);
+//         factory(Campaign::class, 3)->create();
+//         $response = $this->getJson('api/v3/campaigns?filter[has_website]=true');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+//         $response = $this->getJson(
+//             'api/v3/campaigns?filter[has_website]=false',
+//         );
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can filter campaigns by cause.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCauseFilteredCampaignIndex()
+//     {
+//         $causes = Cause::all();
+//         // Let's test against pairs of three causes each so that we have a first, last, and middle cause
+//         // (ensuring we're testing our filtering logic against surrounding commas).
+//         $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
+//             'cause' => array_slice($causes, 0, 3),
+//         ]);
+//         $campaignWithLastThreeCauses = factory(Campaign::class, 1)->create([
+//             'cause' => array_slice($causes, -3),
+//         ]);
+//         foreach (array_slice($causes, 0, 3) as $index => $cause) {
+//             $response = $this->getJson(
+//                 'api/v3/campaigns?filter[cause]=' . $cause,
+//             );
+//             $decodedResponse = $response->decodeResponseJson();
+//             $this->assertEquals(
+//                 1,
+//                 $decodedResponse['meta']['pagination']['count'],
+//             );
+//             $this->assertEquals(
+//                 $campaignWithFirstThreeCauses->first()['id'],
+//                 $decodedResponse['data'][0]['id'],
+//             );
+//         }
+//         // Test that we can filter by multiple causes.
+//         $response = $this->getJson(
+//             'api/v3/campaigns?filter[cause]=' .
+//                 implode(',', array_slice($causes, 0, 3)),
+//         );
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+//         $this->assertEquals(
+//             $campaignWithFirstThreeCauses->first()['id'],
+//             $decodedResponse['data'][0]['id'],
+//         );
+//         // Test that invalid causes are rejected by the filter:
+//         $response = $this->getJson(
+//             'api/v3/campaigns?filter[cause]=this-is-not-a-cause,nor-this!',
+//         );
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can use cursor pagination.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCampaignCursor()
+//     {
+//         $campaigns = factory(Campaign::class, 5)->create();
+//         // First, let's get the three campaigns with the most pending posts:
+//         $endpoint = 'api/v3/campaigns?limit=3';
+//         $response = $this->withAdminAccessToken()->getJson($endpoint);
+//         $response->assertSuccessful();
+//         $json = $response->json();
+//         $this->assertCount(3, $json['data']);
+//         // Then, we'll use the last post's cursor to fetch the remaining two:
+//         $lastCursor = $json['data'][2]['cursor'];
+//         $response = $this->withAdminAccessToken()->getJson(
+//             $endpoint . '&cursor[after]=' . $lastCursor,
+//         );
+//         $response->assertSuccessful();
+//         $json = $response->json();
+//         $this->assertCount(2, $json['data']);
+//     }
+//     /**
+//      * Test that we can use cursor pagination with ordered results.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCampaignCursorWithOrderBy()
+//     {
+//         // Create campaigns with varied number of 'pending' posts:
+//         $one = $this->createCampaignWithPosts(1);
+//         $two = $this->createCampaignWithPosts(2);
+//         $three = $this->createCampaignWithPosts(3);
+//         $four = $this->createCampaignWithPosts(4);
+//         $five = $this->createCampaignWithPosts(5);
+//         // We need these counter caches for this to work properly:
+//         Artisan::call('rogue:recount');
+//         // First, let's get the three campaigns with the most pending posts:
+//         $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
+//         $response = $this->withAdminAccessToken()->getJson($endpoint);
+//         $response->assertJson([
+//             'data' => [0 => ['id' => $five->id, 'pending_count' => 5]],
+//         ]);
+//         $response->assertJson([
+//             'data' => [1 => ['id' => $four->id, 'pending_count' => 4]],
+//         ]);
+//         $response->assertJson([
+//             'data' => [2 => ['id' => $three->id, 'pending_count' => 3]],
+//         ]);
+//         // Then, we'll use the last post's cursor to fetch the remaining two:
+//         $lastCursor = $response->json()['data'][2]['cursor'];
+//         $response = $this->withAdminAccessToken()->getJson(
+//             $endpoint . '&cursor[after]=' . $lastCursor,
+//         );
+//         $response->assertJson([
+//             'data' => [0 => ['id' => $two->id, 'pending_count' => 2]],
+//         ]);
+//         $response->assertJson([
+//             'data' => [1 => ['id' => $one->id, 'pending_count' => 1]],
+//         ]);
+//     }
+//     /**
+//      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
+//      *
+//      * GET /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testCampaignShow()
+//     {
+//         // Create 5 campaigns.
+//         factory(Campaign::class, 5)->create();
+//         // Create 1 specific campaign to search for.
+//         $campaign = factory(Campaign::class)->create();
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $decodedResponse = $response->decodeResponseJson();
+//         $response->assertStatus(200);
+//         $this->assertEquals($campaign->id, $decodedResponse['data']['id']);
+//     }
+//     /**
+//      * Test that a PATCH request to /campaigns/:campaign_id updates a campaign.
+//      *
+//      * PATCH /campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaign()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         // Update the title.
+//         $response = $this->actingAsAdmin()->patch(
+//             'campaigns/' . $campaign->id,
+//             [
+//                 'internal_title' => 'Updated Title',
+//                 'impact_doc' => 'https://www.bing.com/',
+//                 'cause' => ['lgbtq-rights'],
+//                 'start_date' => '1/1/2018',
+//             ],
+//         );
+//         // Make sure the campaign update is persisted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $response->assertStatus(200);
+//         $response->assertJson([
+//             'data' => [
+//                 'internal_title' => 'Updated Title',
+//                 'cause' => ['lgbtq-rights'],
+//                 'start_date' => '2018-01-01T00:00:00-05:00',
+//             ],
+//         ]);
+//     }
+//     /**
+//      * Test for updating a campaign successfully with contentful campaign id.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithContentfulId()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         // Update the contentful campaign id.
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'contentful_campaign_id' => '123456',
+//             ],
+//         );
+//         // Make sure the campaign update is persisted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $response->assertStatus(200);
+//         $response->assertJson([
+//             'data' => [
+//                 'contentful_campaign_id' => '123456',
+//             ],
+//         ]);
+//         $this->assertDatabaseHas('campaigns', [
+//             'id' => $campaign->id,
+//             'contentful_campaign_id' => '123456',
+//         ]);
+//     }
+//     /**
+//      * Test for updating a campaign successfully with a group type id.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithGroupTypeId()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         // Create a GroupType
+//         $groupType = factory(GroupType::class)->create();
+//         // Update the group type id.
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'group_type_id' => $groupType->id,
+//             ],
+//         );
+//         // Make sure the campaign update is persisted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $response->assertStatus(200);
+//         $response->assertJson([
+//             'data' => [
+//                 'group_type_id' => $groupType->id,
+//             ],
+//         ]);
+//         $this->assertDatabaseHas('campaigns', [
+//             'id' => $campaign->id,
+//             'group_type_id' => $groupType->id,
+//         ]);
+//     }
+//     /**
+//      * Test for updating a campaign with invalid status.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithInvalidStatus()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'contentful_campaign_id' => 123456, // This should be a string
+//             ],
+//         );
+//         $response->assertStatus(422);
+//         $response->assertJsonValidationErrors(['contentful_campaign_id']);
+//     }
+//     /**
+//      * Test for updating a campaign with invalid status.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithInvalidStatusWithGroupTypeId()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'group_type_id' => 'four', // This should be an integer
+//             ],
+//         );
+//         $response->assertStatus(422);
+//         $response->assertJsonValidationErrors(['group_type_id']);
+//     }
+//     /**
+//      * Test that a DELETE request to /campaigns/:campaign_id deletes a campaign.
+//      *
+//      * DELETE /campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testDeleteACampaign()
+//     {
+//         // Create a campaign to delete.
+//         $campaign = factory(Campaign::class)->create();
+//         // Delete the campaign.
+//         $this->actingAsAdmin()->deleteJson('campaigns/' . $campaign->id);
+//         // Make sure the campaign is deleted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $decodedResponse = $response->decodeResponseJson();
+//         $response->assertStatus(404);
+//         $this->assertEquals(
+//             'That resource could not be found.',
+//             $decodedResponse['message'],
+//         );
+//     }
+//     /**
+//      * Create a campaign with the given number of pending posts.
+//      *
+//      * @return Campaign
+//      */
+//     public function createCampaignWithPosts($numberOfPosts)
+//     {
+//         $campaign = factory(Campaign::class)->create();
+//         factory(Post::class, $numberOfPosts)->create([
+//             'campaign_id' => $campaign->id,
+//         ]);
+//         return $campaign;
+//     }
+// use App\Models\Campaign;
+// use App\Models\GroupType;
+// use App\Models\Post;
+// use App\Types\Cause;
+// use Illuminate\Support\Facades\Artisan;
+// use Tests\TestCase;
+// class CampaignTest extends Testcase
+// {
+//     /**
+//      * Test that a POST request to /campaigns creates a new campaign.
+//      *
+//      * POST /campaigns
+//      * @return void
+//      */
+//     public function testCreatingACampaign()
+//     {
+//         // Create a campaign.
+//         $firstCampaignTitle = $this->faker->sentence;
+//         $firstCampaignStartDate = $this->faker->date($format = 'm/d/Y');
+//         // Make sure the end date is after the start date.
+//         $firstCampaignEndDate = date(
+//             'm/d/Y',
+//             strtotime('+3 months', strtotime($firstCampaignStartDate)),
+//         );
+//         // Create a GroupType
+//         $groupType = factory(GroupType::class)->create();
+//         $this->actingAsAdmin()->postJson('campaigns', [
+//             'internal_title' => $firstCampaignTitle,
+//             'cause' => ['animal-welfare'],
+//             'impact_doc' => 'https://www.google.com',
+//             'start_date' => $firstCampaignStartDate,
+//             'end_date' => $firstCampaignEndDate,
+//             'group_type_id' => $groupType->id,
+//         ]);
+//         // Make sure the campaign is persisted.
+//         $this->assertDatabaseHas('campaigns', [
+//             'internal_title' => $firstCampaignTitle,
+//         ]);
+//         // Try to create a second campaign with the same title and make sure it doesn't duplicate.
+//         $this->actingAsAdmin()->postJson('campaigns', [
+//             'internal_title' => $firstCampaignTitle,
+//         ]);
+//         $response = $this->getJson('api/v3/campaigns');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that a GET request to /api/v3/campaigns returns an index of all campaigns.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCampaignIndex()
+//     {
+//         factory(Campaign::class, 5)->create();
+//         $response = $this->getJson('api/v3/campaigns');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $response->assertStatus(200);
+//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can filter open or closed campaigns.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testFilteredCampaignIndex()
+//     {
+//         factory(Campaign::class, 5)->create();
+//         factory(Campaign::class, 'closed', 3)->create();
+//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=true');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=false');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can filter campaigns with an associated Contentful 'Website' entry.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testWebsiteFilteredCampaignIndex()
+//     {
+//         factory(Campaign::class, 5)->create([
+//             'contentful_campaign_id' => '123',
+//         ]);
+//         factory(Campaign::class, 3)->create();
+//         $response = $this->getJson('api/v3/campaigns?filter[has_website]=true');
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
+//         $response = $this->getJson(
+//             'api/v3/campaigns?filter[has_website]=false',
+//         );
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can filter campaigns by cause.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCauseFilteredCampaignIndex()
+//     {
+//         $causes = Cause::all();
+//         // Let's test against pairs of three causes each so that we have a first, last, and middle cause
+//         // (ensuring we're testing our filtering logic against surrounding commas).
+//         $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
+//             'cause' => array_slice($causes, 0, 3),
+//         ]);
+//         $campaignWithLastThreeCauses = factory(Campaign::class, 1)->create([
+//             'cause' => array_slice($causes, -3),
+//         ]);
+//         foreach (array_slice($causes, 0, 3) as $index => $cause) {
+//             $response = $this->getJson(
+//                 'api/v3/campaigns?filter[cause]=' . $cause,
+//             );
+//             $decodedResponse = $response->decodeResponseJson();
+//             $this->assertEquals(
+//                 1,
+//                 $decodedResponse['meta']['pagination']['count'],
+//             );
+//             $this->assertEquals(
+//                 $campaignWithFirstThreeCauses->first()['id'],
+//                 $decodedResponse['data'][0]['id'],
+//             );
+//         }
+//         // Test that we can filter by multiple causes.
+//         $response = $this->getJson(
+//             'api/v3/campaigns?filter[cause]=' .
+//                 implode(',', array_slice($causes, 0, 3)),
+//         );
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+//         $this->assertEquals(
+//             $campaignWithFirstThreeCauses->first()['id'],
+//             $decodedResponse['data'][0]['id'],
+//         );
+//         // Test that invalid causes are rejected by the filter:
+//         $response = $this->getJson(
+//             'api/v3/campaigns?filter[cause]=this-is-not-a-cause,nor-this!',
+//         );
+//         $decodedResponse = $response->decodeResponseJson();
+//         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
+//     }
+//     /**
+//      * Test that we can use cursor pagination.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCampaignCursor()
+//     {
+//         $campaigns = factory(Campaign::class, 5)->create();
+//         // First, let's get the three campaigns with the most pending posts:
+//         $endpoint = 'api/v3/campaigns?limit=3';
+//         $response = $this->withAdminAccessToken()->getJson($endpoint);
+//         $response->assertSuccessful();
+//         $json = $response->json();
+//         $this->assertCount(3, $json['data']);
+//         // Then, we'll use the last post's cursor to fetch the remaining two:
+//         $lastCursor = $json['data'][2]['cursor'];
+//         $response = $this->withAdminAccessToken()->getJson(
+//             $endpoint . '&cursor[after]=' . $lastCursor,
+//         );
+//         $response->assertSuccessful();
+//         $json = $response->json();
+//         $this->assertCount(2, $json['data']);
+//     }
+//     /**
+//      * Test that we can use cursor pagination with ordered results.
+//      *
+//      * GET /api/v3/campaigns
+//      * @return void
+//      */
+//     public function testCampaignCursorWithOrderBy()
+//     {
+//         // Create campaigns with varied number of 'pending' posts:
+//         $one = $this->createCampaignWithPosts(1);
+//         $two = $this->createCampaignWithPosts(2);
+//         $three = $this->createCampaignWithPosts(3);
+//         $four = $this->createCampaignWithPosts(4);
+//         $five = $this->createCampaignWithPosts(5);
+//         // We need these counter caches for this to work properly:
+//         Artisan::call('rogue:recount');
+//         // First, let's get the three campaigns with the most pending posts:
+//         $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
+//         $response = $this->withAdminAccessToken()->getJson($endpoint);
+//         $response->assertJson([
+//             'data' => [0 => ['id' => $five->id, 'pending_count' => 5]],
+//         ]);
+//         $response->assertJson([
+//             'data' => [1 => ['id' => $four->id, 'pending_count' => 4]],
+//         ]);
+//         $response->assertJson([
+//             'data' => [2 => ['id' => $three->id, 'pending_count' => 3]],
+//         ]);
+//         // Then, we'll use the last post's cursor to fetch the remaining two:
+//         $lastCursor = $response->json()['data'][2]['cursor'];
+//         $response = $this->withAdminAccessToken()->getJson(
+//             $endpoint . '&cursor[after]=' . $lastCursor,
+//         );
+//         $response->assertJson([
+//             'data' => [0 => ['id' => $two->id, 'pending_count' => 2]],
+//         ]);
+//         $response->assertJson([
+//             'data' => [1 => ['id' => $one->id, 'pending_count' => 1]],
+//         ]);
+//     }
+//     /**
+//      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
+//      *
+//      * GET /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testCampaignShow()
+//     {
+//         // Create 5 campaigns.
+//         factory(Campaign::class, 5)->create();
+//         // Create 1 specific campaign to search for.
+//         $campaign = factory(Campaign::class)->create();
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $decodedResponse = $response->decodeResponseJson();
+//         $response->assertStatus(200);
+//         $this->assertEquals($campaign->id, $decodedResponse['data']['id']);
+//     }
+//     /**
+//      * Test that a PATCH request to /campaigns/:campaign_id updates a campaign.
+//      *
+//      * PATCH /campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaign()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         // Update the title.
+//         $response = $this->actingAsAdmin()->patch(
+//             'campaigns/' . $campaign->id,
+//             [
+//                 'internal_title' => 'Updated Title',
+//                 'impact_doc' => 'https://www.bing.com/',
+//                 'cause' => ['lgbtq-rights'],
+//                 'start_date' => '1/1/2018',
+//             ],
+//         );
+//         // Make sure the campaign update is persisted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $response->assertStatus(200);
+//         $response->assertJson([
+//             'data' => [
+//                 'internal_title' => 'Updated Title',
+//                 'cause' => ['lgbtq-rights'],
+//                 'start_date' => '2018-01-01T00:00:00-05:00',
+//             ],
+//         ]);
+//     }
+//     /**
+//      * Test for updating a campaign successfully with contentful campaign id.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithContentfulId()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         // Update the contentful campaign id.
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'contentful_campaign_id' => '123456',
+//             ],
+//         );
+//         // Make sure the campaign update is persisted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $response->assertStatus(200);
+//         $response->assertJson([
+//             'data' => [
+//                 'contentful_campaign_id' => '123456',
+//             ],
+//         ]);
+//         $this->assertDatabaseHas('campaigns', [
+//             'id' => $campaign->id,
+//             'contentful_campaign_id' => '123456',
+//         ]);
+//     }
+//     /**
+//      * Test for updating a campaign successfully with a group type id.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithGroupTypeId()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         // Create a GroupType
+//         $groupType = factory(GroupType::class)->create();
+//         // Update the group type id.
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'group_type_id' => $groupType->id,
+//             ],
+//         );
+//         // Make sure the campaign update is persisted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $response->assertStatus(200);
+//         $response->assertJson([
+//             'data' => [
+//                 'group_type_id' => $groupType->id,
+//             ],
+//         ]);
+//         $this->assertDatabaseHas('campaigns', [
+//             'id' => $campaign->id,
+//             'group_type_id' => $groupType->id,
+//         ]);
+//     }
+//     /**
+//      * Test for updating a campaign with invalid status.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithInvalidStatus()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'contentful_campaign_id' => 123456, // This should be a string
+//             ],
+//         );
+//         $response->assertStatus(422);
+//         $response->assertJsonValidationErrors(['contentful_campaign_id']);
+//     }
+//     /**
+//      * Test for updating a campaign with invalid status.
+//      *
+//      * PATCH /api/v3/campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testUpdatingACampaignWithInvalidStatusWithGroupTypeId()
+//     {
+//         // Create a campaign to update.
+//         $campaign = factory(Campaign::class)->create();
+//         $response = $this->withAdminAccessToken()->patchJson(
+//             'api/v3/campaigns/' . $campaign->id,
+//             [
+//                 'group_type_id' => 'four', // This should be an integer
+//             ],
+//         );
+//         $response->assertStatus(422);
+//         $response->assertJsonValidationErrors(['group_type_id']);
+//     }
+//     /**
+//      * Test that a DELETE request to /campaigns/:campaign_id deletes a campaign.
+//      *
+//      * DELETE /campaigns/:campaign_id
+//      * @return void
+//      */
+//     public function testDeleteACampaign()
+//     {
+//         // Create a campaign to delete.
+//         $campaign = factory(Campaign::class)->create();
+//         // Delete the campaign.
+//         $this->actingAsAdmin()->deleteJson('campaigns/' . $campaign->id);
+//         // Make sure the campaign is deleted.
+//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+//         $decodedResponse = $response->decodeResponseJson();
+//         $response->assertStatus(404);
+//         $this->assertEquals(
+//             'That resource could not be found.',
+//             $decodedResponse['message'],
+//         );
+//     }
+//     /**
+//      * Create a campaign with the given number of pending posts.
+//      *
+//      * @return Campaign
+//      */
+//     public function createCampaignWithPosts($numberOfPosts)
+//     {
+//         $campaign = factory(Campaign::class)->create();
+//         factory(Post::class, $numberOfPosts)->create([
+//             'campaign_id' => $campaign->id,
+//         ]);
+//         return $campaign;
+//     }
+}

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -38,7 +38,7 @@ class CampaignTest extends TestCase
 
         $response = $this->getJson('api/v3/campaigns');
 
-        $response->assertStatus(200);
+        $response->assertOk();
         $response->assertJsonPath('meta.pagination.count', 5);
     }
 
@@ -56,12 +56,12 @@ class CampaignTest extends TestCase
 
         $responseOne = $this->getJson('api/v3/campaigns?filter[is_open]=true');
 
-        $responseOne->assertStatus(200);
+        $responseOne->assertOk();
         $responseOne->assertJsonPath('meta.pagination.count', 5);
 
         $responseTwo = $this->getJson('api/v3/campaigns?filter[is_open]=false');
 
-        $responseTwo->assertStatus(200);
+        $responseTwo->assertOk();
         $responseTwo->assertJsonPath('meta.pagination.count', 3);
     }
 
@@ -83,14 +83,14 @@ class CampaignTest extends TestCase
             'api/v3/campaigns?filter[has_website]=true',
         );
 
-        $responseOne->assertStatus(200);
+        $responseOne->assertOk();
         $responseOne->assertJsonPath('meta.pagination.count', 5);
 
         $responseTwo = $this->getJson(
             'api/v3/campaigns?filter[has_website]=false',
         );
 
-        $responseTwo->assertStatus(200);
+        $responseTwo->assertOk();
         $responseTwo->assertJsonPath('meta.pagination.count', 3);
     }
 
@@ -120,7 +120,7 @@ class CampaignTest extends TestCase
                 'api/v3/campaigns?filter[cause]=' . $cause,
             );
 
-            $response->assertStatus(200);
+            $response->assertOk();
             $response->assertJsonPath('meta.pagination.count', 1);
             $response->assertJsonPath(
                 'data.0.id',
@@ -134,7 +134,7 @@ class CampaignTest extends TestCase
                 implode(',', array_slice($causes, 0, 3)),
         );
 
-        $responseTwo->assertStatus(200);
+        $responseTwo->assertOk();
         $responseTwo->assertJsonPath('meta.pagination.count', 1);
         $responseTwo->assertJsonPath(
             'data.0.id',
@@ -244,7 +244,7 @@ class CampaignTest extends TestCase
 
         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
 
-        $response->assertStatus(200);
+        $response->assertOk();
         $response->assertJsonPath('data.id', $campaign->id);
     }
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -8,744 +8,354 @@ use Illuminate\Support\Facades\Artisan;
 
 class CampaignTest extends TestCase
 {
-    //     /**
-//      * Test that a GET request to /api/v3/campaigns returns an index of all campaigns.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCampaignIndex()
-//     {
-//         factory(Campaign::class, 5)->create();
-//         $response = $this->getJson('api/v3/campaigns');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $response->assertStatus(200);
-//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can filter open or closed campaigns.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testFilteredCampaignIndex()
-//     {
-//         factory(Campaign::class, 5)->create();
-//         factory(Campaign::class, 'closed', 3)->create();
-//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=true');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=false');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can filter campaigns with an associated Contentful 'Website' entry.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testWebsiteFilteredCampaignIndex()
-//     {
-//         factory(Campaign::class, 5)->create([
-//             'contentful_campaign_id' => '123',
-//         ]);
-//         factory(Campaign::class, 3)->create();
-//         $response = $this->getJson('api/v3/campaigns?filter[has_website]=true');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-//         $response = $this->getJson(
-//             'api/v3/campaigns?filter[has_website]=false',
-//         );
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can filter campaigns by cause.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCauseFilteredCampaignIndex()
-//     {
-//         $causes = Cause::all();
-//         // Let's test against pairs of three causes each so that we have a first, last, and middle cause
-//         // (ensuring we're testing our filtering logic against surrounding commas).
-//         $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
-//             'cause' => array_slice($causes, 0, 3),
-//         ]);
-//         $campaignWithLastThreeCauses = factory(Campaign::class, 1)->create([
-//             'cause' => array_slice($causes, -3),
-//         ]);
-//         foreach (array_slice($causes, 0, 3) as $index => $cause) {
-//             $response = $this->getJson(
-//                 'api/v3/campaigns?filter[cause]=' . $cause,
-//             );
-//             $decodedResponse = $response->decodeResponseJson();
-//             $this->assertEquals(
-//                 1,
-//                 $decodedResponse['meta']['pagination']['count'],
-//             );
-//             $this->assertEquals(
-//                 $campaignWithFirstThreeCauses->first()['id'],
-//                 $decodedResponse['data'][0]['id'],
-//             );
-//         }
-//         // Test that we can filter by multiple causes.
-//         $response = $this->getJson(
-//             'api/v3/campaigns?filter[cause]=' .
-//                 implode(',', array_slice($causes, 0, 3)),
-//         );
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
-//         $this->assertEquals(
-//             $campaignWithFirstThreeCauses->first()['id'],
-//             $decodedResponse['data'][0]['id'],
-//         );
-//         // Test that invalid causes are rejected by the filter:
-//         $response = $this->getJson(
-//             'api/v3/campaigns?filter[cause]=this-is-not-a-cause,nor-this!',
-//         );
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can use cursor pagination.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCampaignCursor()
-//     {
-//         $campaigns = factory(Campaign::class, 5)->create();
-//         // First, let's get the three campaigns with the most pending posts:
-//         $endpoint = 'api/v3/campaigns?limit=3';
-//         $response = $this->withAdminAccessToken()->getJson($endpoint);
-//         $response->assertSuccessful();
-//         $json = $response->json();
-//         $this->assertCount(3, $json['data']);
-//         // Then, we'll use the last post's cursor to fetch the remaining two:
-//         $lastCursor = $json['data'][2]['cursor'];
-//         $response = $this->withAdminAccessToken()->getJson(
-//             $endpoint . '&cursor[after]=' . $lastCursor,
-//         );
-//         $response->assertSuccessful();
-//         $json = $response->json();
-//         $this->assertCount(2, $json['data']);
-//     }
-//     /**
-//      * Test that we can use cursor pagination with ordered results.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCampaignCursorWithOrderBy()
-//     {
-//         // Create campaigns with varied number of 'pending' posts:
-//         $one = $this->createCampaignWithPosts(1);
-//         $two = $this->createCampaignWithPosts(2);
-//         $three = $this->createCampaignWithPosts(3);
-//         $four = $this->createCampaignWithPosts(4);
-//         $five = $this->createCampaignWithPosts(5);
-//         // We need these counter caches for this to work properly:
-//         Artisan::call('rogue:recount');
-//         // First, let's get the three campaigns with the most pending posts:
-//         $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
-//         $response = $this->withAdminAccessToken()->getJson($endpoint);
-//         $response->assertJson([
-//             'data' => [0 => ['id' => $five->id, 'pending_count' => 5]],
-//         ]);
-//         $response->assertJson([
-//             'data' => [1 => ['id' => $four->id, 'pending_count' => 4]],
-//         ]);
-//         $response->assertJson([
-//             'data' => [2 => ['id' => $three->id, 'pending_count' => 3]],
-//         ]);
-//         // Then, we'll use the last post's cursor to fetch the remaining two:
-//         $lastCursor = $response->json()['data'][2]['cursor'];
-//         $response = $this->withAdminAccessToken()->getJson(
-//             $endpoint . '&cursor[after]=' . $lastCursor,
-//         );
-//         $response->assertJson([
-//             'data' => [0 => ['id' => $two->id, 'pending_count' => 2]],
-//         ]);
-//         $response->assertJson([
-//             'data' => [1 => ['id' => $one->id, 'pending_count' => 1]],
-//         ]);
-//     }
-//     /**
-//      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
-//      *
-//      * GET /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testCampaignShow()
-//     {
-//         // Create 5 campaigns.
-//         factory(Campaign::class, 5)->create();
-//         // Create 1 specific campaign to search for.
-//         $campaign = factory(Campaign::class)->create();
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $decodedResponse = $response->decodeResponseJson();
-//         $response->assertStatus(200);
-//         $this->assertEquals($campaign->id, $decodedResponse['data']['id']);
-//     }
-//     /**
-//      * Test that a PATCH request to /campaigns/:campaign_id updates a campaign.
-//      *
-//      * PATCH /campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaign()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         // Update the title.
-//         $response = $this->actingAsAdmin()->patch(
-//             'campaigns/' . $campaign->id,
-//             [
-//                 'internal_title' => 'Updated Title',
-//                 'impact_doc' => 'https://www.bing.com/',
-//                 'cause' => ['lgbtq-rights'],
-//                 'start_date' => '1/1/2018',
-//             ],
-//         );
-//         // Make sure the campaign update is persisted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $response->assertStatus(200);
-//         $response->assertJson([
-//             'data' => [
-//                 'internal_title' => 'Updated Title',
-//                 'cause' => ['lgbtq-rights'],
-//                 'start_date' => '2018-01-01T00:00:00-05:00',
-//             ],
-//         ]);
-//     }
-//     /**
-//      * Test for updating a campaign successfully with contentful campaign id.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithContentfulId()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         // Update the contentful campaign id.
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'contentful_campaign_id' => '123456',
-//             ],
-//         );
-//         // Make sure the campaign update is persisted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $response->assertStatus(200);
-//         $response->assertJson([
-//             'data' => [
-//                 'contentful_campaign_id' => '123456',
-//             ],
-//         ]);
-//         $this->assertDatabaseHas('campaigns', [
-//             'id' => $campaign->id,
-//             'contentful_campaign_id' => '123456',
-//         ]);
-//     }
-//     /**
-//      * Test for updating a campaign successfully with a group type id.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithGroupTypeId()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         // Create a GroupType
-//         $groupType = factory(GroupType::class)->create();
-//         // Update the group type id.
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'group_type_id' => $groupType->id,
-//             ],
-//         );
-//         // Make sure the campaign update is persisted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $response->assertStatus(200);
-//         $response->assertJson([
-//             'data' => [
-//                 'group_type_id' => $groupType->id,
-//             ],
-//         ]);
-//         $this->assertDatabaseHas('campaigns', [
-//             'id' => $campaign->id,
-//             'group_type_id' => $groupType->id,
-//         ]);
-//     }
-//     /**
-//      * Test for updating a campaign with invalid status.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithInvalidStatus()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'contentful_campaign_id' => 123456, // This should be a string
-//             ],
-//         );
-//         $response->assertStatus(422);
-//         $response->assertJsonValidationErrors(['contentful_campaign_id']);
-//     }
-//     /**
-//      * Test for updating a campaign with invalid status.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithInvalidStatusWithGroupTypeId()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'group_type_id' => 'four', // This should be an integer
-//             ],
-//         );
-//         $response->assertStatus(422);
-//         $response->assertJsonValidationErrors(['group_type_id']);
-//     }
-//     /**
-//      * Test that a DELETE request to /campaigns/:campaign_id deletes a campaign.
-//      *
-//      * DELETE /campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testDeleteACampaign()
-//     {
-//         // Create a campaign to delete.
-//         $campaign = factory(Campaign::class)->create();
-//         // Delete the campaign.
-//         $this->actingAsAdmin()->deleteJson('campaigns/' . $campaign->id);
-//         // Make sure the campaign is deleted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $decodedResponse = $response->decodeResponseJson();
-//         $response->assertStatus(404);
-//         $this->assertEquals(
-//             'That resource could not be found.',
-//             $decodedResponse['message'],
-//         );
-//     }
-//     /**
-//      * Create a campaign with the given number of pending posts.
-//      *
-//      * @return Campaign
-//      */
-//     public function createCampaignWithPosts($numberOfPosts)
-//     {
-//         $campaign = factory(Campaign::class)->create();
-//         factory(Post::class, $numberOfPosts)->create([
-//             'campaign_id' => $campaign->id,
-//         ]);
-//         return $campaign;
-//     }
-// use App\Models\Campaign;
-// use App\Models\GroupType;
-// use App\Models\Post;
-// use App\Types\Cause;
-// use Illuminate\Support\Facades\Artisan;
-// use Tests\TestCase;
-// class CampaignTest extends Testcase
-// {
-//     /**
-//      * Test that a POST request to /campaigns creates a new campaign.
-//      *
-//      * POST /campaigns
-//      * @return void
-//      */
-//     public function testCreatingACampaign()
-//     {
-//         // Create a campaign.
-//         $firstCampaignTitle = $this->faker->sentence;
-//         $firstCampaignStartDate = $this->faker->date($format = 'm/d/Y');
-//         // Make sure the end date is after the start date.
-//         $firstCampaignEndDate = date(
-//             'm/d/Y',
-//             strtotime('+3 months', strtotime($firstCampaignStartDate)),
-//         );
-//         // Create a GroupType
-//         $groupType = factory(GroupType::class)->create();
-//         $this->actingAsAdmin()->postJson('campaigns', [
-//             'internal_title' => $firstCampaignTitle,
-//             'cause' => ['animal-welfare'],
-//             'impact_doc' => 'https://www.google.com',
-//             'start_date' => $firstCampaignStartDate,
-//             'end_date' => $firstCampaignEndDate,
-//             'group_type_id' => $groupType->id,
-//         ]);
-//         // Make sure the campaign is persisted.
-//         $this->assertDatabaseHas('campaigns', [
-//             'internal_title' => $firstCampaignTitle,
-//         ]);
-//         // Try to create a second campaign with the same title and make sure it doesn't duplicate.
-//         $this->actingAsAdmin()->postJson('campaigns', [
-//             'internal_title' => $firstCampaignTitle,
-//         ]);
-//         $response = $this->getJson('api/v3/campaigns');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that a GET request to /api/v3/campaigns returns an index of all campaigns.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCampaignIndex()
-//     {
-//         factory(Campaign::class, 5)->create();
-//         $response = $this->getJson('api/v3/campaigns');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $response->assertStatus(200);
-//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can filter open or closed campaigns.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testFilteredCampaignIndex()
-//     {
-//         factory(Campaign::class, 5)->create();
-//         factory(Campaign::class, 'closed', 3)->create();
-//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=true');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-//         $response = $this->getJson('api/v3/campaigns?filter[is_open]=false');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can filter campaigns with an associated Contentful 'Website' entry.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testWebsiteFilteredCampaignIndex()
-//     {
-//         factory(Campaign::class, 5)->create([
-//             'contentful_campaign_id' => '123',
-//         ]);
-//         factory(Campaign::class, 3)->create();
-//         $response = $this->getJson('api/v3/campaigns?filter[has_website]=true');
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(5, $decodedResponse['meta']['pagination']['count']);
-//         $response = $this->getJson(
-//             'api/v3/campaigns?filter[has_website]=false',
-//         );
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(3, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can filter campaigns by cause.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCauseFilteredCampaignIndex()
-//     {
-//         $causes = Cause::all();
-//         // Let's test against pairs of three causes each so that we have a first, last, and middle cause
-//         // (ensuring we're testing our filtering logic against surrounding commas).
-//         $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
-//             'cause' => array_slice($causes, 0, 3),
-//         ]);
-//         $campaignWithLastThreeCauses = factory(Campaign::class, 1)->create([
-//             'cause' => array_slice($causes, -3),
-//         ]);
-//         foreach (array_slice($causes, 0, 3) as $index => $cause) {
-//             $response = $this->getJson(
-//                 'api/v3/campaigns?filter[cause]=' . $cause,
-//             );
-//             $decodedResponse = $response->decodeResponseJson();
-//             $this->assertEquals(
-//                 1,
-//                 $decodedResponse['meta']['pagination']['count'],
-//             );
-//             $this->assertEquals(
-//                 $campaignWithFirstThreeCauses->first()['id'],
-//                 $decodedResponse['data'][0]['id'],
-//             );
-//         }
-//         // Test that we can filter by multiple causes.
-//         $response = $this->getJson(
-//             'api/v3/campaigns?filter[cause]=' .
-//                 implode(',', array_slice($causes, 0, 3)),
-//         );
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
-//         $this->assertEquals(
-//             $campaignWithFirstThreeCauses->first()['id'],
-//             $decodedResponse['data'][0]['id'],
-//         );
-//         // Test that invalid causes are rejected by the filter:
-//         $response = $this->getJson(
-//             'api/v3/campaigns?filter[cause]=this-is-not-a-cause,nor-this!',
-//         );
-//         $decodedResponse = $response->decodeResponseJson();
-//         $this->assertEquals(0, $decodedResponse['meta']['pagination']['count']);
-//     }
-//     /**
-//      * Test that we can use cursor pagination.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCampaignCursor()
-//     {
-//         $campaigns = factory(Campaign::class, 5)->create();
-//         // First, let's get the three campaigns with the most pending posts:
-//         $endpoint = 'api/v3/campaigns?limit=3';
-//         $response = $this->withAdminAccessToken()->getJson($endpoint);
-//         $response->assertSuccessful();
-//         $json = $response->json();
-//         $this->assertCount(3, $json['data']);
-//         // Then, we'll use the last post's cursor to fetch the remaining two:
-//         $lastCursor = $json['data'][2]['cursor'];
-//         $response = $this->withAdminAccessToken()->getJson(
-//             $endpoint . '&cursor[after]=' . $lastCursor,
-//         );
-//         $response->assertSuccessful();
-//         $json = $response->json();
-//         $this->assertCount(2, $json['data']);
-//     }
-//     /**
-//      * Test that we can use cursor pagination with ordered results.
-//      *
-//      * GET /api/v3/campaigns
-//      * @return void
-//      */
-//     public function testCampaignCursorWithOrderBy()
-//     {
-//         // Create campaigns with varied number of 'pending' posts:
-//         $one = $this->createCampaignWithPosts(1);
-//         $two = $this->createCampaignWithPosts(2);
-//         $three = $this->createCampaignWithPosts(3);
-//         $four = $this->createCampaignWithPosts(4);
-//         $five = $this->createCampaignWithPosts(5);
-//         // We need these counter caches for this to work properly:
-//         Artisan::call('rogue:recount');
-//         // First, let's get the three campaigns with the most pending posts:
-//         $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
-//         $response = $this->withAdminAccessToken()->getJson($endpoint);
-//         $response->assertJson([
-//             'data' => [0 => ['id' => $five->id, 'pending_count' => 5]],
-//         ]);
-//         $response->assertJson([
-//             'data' => [1 => ['id' => $four->id, 'pending_count' => 4]],
-//         ]);
-//         $response->assertJson([
-//             'data' => [2 => ['id' => $three->id, 'pending_count' => 3]],
-//         ]);
-//         // Then, we'll use the last post's cursor to fetch the remaining two:
-//         $lastCursor = $response->json()['data'][2]['cursor'];
-//         $response = $this->withAdminAccessToken()->getJson(
-//             $endpoint . '&cursor[after]=' . $lastCursor,
-//         );
-//         $response->assertJson([
-//             'data' => [0 => ['id' => $two->id, 'pending_count' => 2]],
-//         ]);
-//         $response->assertJson([
-//             'data' => [1 => ['id' => $one->id, 'pending_count' => 1]],
-//         ]);
-//     }
-//     /**
-//      * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
-//      *
-//      * GET /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testCampaignShow()
-//     {
-//         // Create 5 campaigns.
-//         factory(Campaign::class, 5)->create();
-//         // Create 1 specific campaign to search for.
-//         $campaign = factory(Campaign::class)->create();
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $decodedResponse = $response->decodeResponseJson();
-//         $response->assertStatus(200);
-//         $this->assertEquals($campaign->id, $decodedResponse['data']['id']);
-//     }
-//     /**
-//      * Test that a PATCH request to /campaigns/:campaign_id updates a campaign.
-//      *
-//      * PATCH /campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaign()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         // Update the title.
-//         $response = $this->actingAsAdmin()->patch(
-//             'campaigns/' . $campaign->id,
-//             [
-//                 'internal_title' => 'Updated Title',
-//                 'impact_doc' => 'https://www.bing.com/',
-//                 'cause' => ['lgbtq-rights'],
-//                 'start_date' => '1/1/2018',
-//             ],
-//         );
-//         // Make sure the campaign update is persisted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $response->assertStatus(200);
-//         $response->assertJson([
-//             'data' => [
-//                 'internal_title' => 'Updated Title',
-//                 'cause' => ['lgbtq-rights'],
-//                 'start_date' => '2018-01-01T00:00:00-05:00',
-//             ],
-//         ]);
-//     }
-//     /**
-//      * Test for updating a campaign successfully with contentful campaign id.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithContentfulId()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         // Update the contentful campaign id.
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'contentful_campaign_id' => '123456',
-//             ],
-//         );
-//         // Make sure the campaign update is persisted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $response->assertStatus(200);
-//         $response->assertJson([
-//             'data' => [
-//                 'contentful_campaign_id' => '123456',
-//             ],
-//         ]);
-//         $this->assertDatabaseHas('campaigns', [
-//             'id' => $campaign->id,
-//             'contentful_campaign_id' => '123456',
-//         ]);
-//     }
-//     /**
-//      * Test for updating a campaign successfully with a group type id.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithGroupTypeId()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         // Create a GroupType
-//         $groupType = factory(GroupType::class)->create();
-//         // Update the group type id.
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'group_type_id' => $groupType->id,
-//             ],
-//         );
-//         // Make sure the campaign update is persisted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $response->assertStatus(200);
-//         $response->assertJson([
-//             'data' => [
-//                 'group_type_id' => $groupType->id,
-//             ],
-//         ]);
-//         $this->assertDatabaseHas('campaigns', [
-//             'id' => $campaign->id,
-//             'group_type_id' => $groupType->id,
-//         ]);
-//     }
-//     /**
-//      * Test for updating a campaign with invalid status.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithInvalidStatus()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'contentful_campaign_id' => 123456, // This should be a string
-//             ],
-//         );
-//         $response->assertStatus(422);
-//         $response->assertJsonValidationErrors(['contentful_campaign_id']);
-//     }
-//     /**
-//      * Test for updating a campaign with invalid status.
-//      *
-//      * PATCH /api/v3/campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testUpdatingACampaignWithInvalidStatusWithGroupTypeId()
-//     {
-//         // Create a campaign to update.
-//         $campaign = factory(Campaign::class)->create();
-//         $response = $this->withAdminAccessToken()->patchJson(
-//             'api/v3/campaigns/' . $campaign->id,
-//             [
-//                 'group_type_id' => 'four', // This should be an integer
-//             ],
-//         );
-//         $response->assertStatus(422);
-//         $response->assertJsonValidationErrors(['group_type_id']);
-//     }
-//     /**
-//      * Test that a DELETE request to /campaigns/:campaign_id deletes a campaign.
-//      *
-//      * DELETE /campaigns/:campaign_id
-//      * @return void
-//      */
-//     public function testDeleteACampaign()
-//     {
-//         // Create a campaign to delete.
-//         $campaign = factory(Campaign::class)->create();
-//         // Delete the campaign.
-//         $this->actingAsAdmin()->deleteJson('campaigns/' . $campaign->id);
-//         // Make sure the campaign is deleted.
-//         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
-//         $decodedResponse = $response->decodeResponseJson();
-//         $response->assertStatus(404);
-//         $this->assertEquals(
-//             'That resource could not be found.',
-//             $decodedResponse['message'],
-//         );
-//     }
-//     /**
-//      * Create a campaign with the given number of pending posts.
-//      *
-//      * @return Campaign
-//      */
-//     public function createCampaignWithPosts($numberOfPosts)
-//     {
-//         $campaign = factory(Campaign::class)->create();
-//         factory(Post::class, $numberOfPosts)->create([
-//             'campaign_id' => $campaign->id,
-//         ]);
-//         return $campaign;
-//     }
+    /**
+     * Create a campaign with the given number of pending posts.
+     *
+     * @return Campaign
+     */
+    public function createCampaignWithPosts($numberOfPosts)
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        factory(Post::class, $numberOfPosts)->create([
+            'campaign_id' => $campaign->id,
+        ]);
+
+        return $campaign;
+    }
+
+    /**
+     * Test that a GET request to /api/v3/campaigns returns an index of all campaigns.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testCampaignIndex()
+    {
+        $this->withoutExceptionHandling();
+
+        factory(Campaign::class, 5)->create();
+
+        $response = $this->getJson('api/v3/campaigns');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonPath('meta.pagination.count', 5);
+    }
+
+    /**
+     * Test that we can filter open or closed campaigns.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testFilteredCampaignIndex()
+    {
+        factory(Campaign::class, 5)->create();
+
+        factory(Campaign::class, 'closed', 3)->create();
+
+        $responseOne = $this->getJson('api/v3/campaigns?filter[is_open]=true');
+
+        $responseOne->assertStatus(200);
+        $responseOne->assertJsonPath('meta.pagination.count', 5);
+
+        $responseTwo = $this->getJson('api/v3/campaigns?filter[is_open]=false');
+
+        $responseTwo->assertStatus(200);
+        $responseTwo->assertJsonPath('meta.pagination.count', 3);
+    }
+
+    /**
+     * Test that we can filter campaigns with an associated Contentful 'Website' entry.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testWebsiteFilteredCampaignIndex()
+    {
+        factory(Campaign::class, 5)->create([
+            'contentful_campaign_id' => '123',
+        ]);
+
+        factory(Campaign::class, 3)->create();
+
+        $responseOne = $this->getJson(
+            'api/v3/campaigns?filter[has_website]=true',
+        );
+
+        $responseOne->assertStatus(200);
+        $responseOne->assertJsonPath('meta.pagination.count', 5);
+
+        $responseTwo = $this->getJson(
+            'api/v3/campaigns?filter[has_website]=false',
+        );
+
+        $responseTwo->assertStatus(200);
+        $responseTwo->assertJsonPath('meta.pagination.count', 3);
+    }
+
+    /**
+     * Test that we can filter campaigns by cause.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testCauseFilteredCampaignIndex()
+    {
+        $causes = Cause::all();
+
+        // Let's test against pairs of three causes each so that we have a first, last, and middle cause
+        // (ensuring we're testing our filtering logic against surrounding commas).
+        $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
+            'cause' => array_slice($causes, 0, 3),
+        ]);
+
+        // Add some additional filler campaigns with causes.
+        factory(Campaign::class, 1)->create([
+            'cause' => array_slice($causes, -3),
+        ]);
+
+        foreach (array_slice($causes, 0, 3) as $index => $cause) {
+            $response = $this->getJson(
+                'api/v3/campaigns?filter[cause]=' . $cause,
+            );
+
+            $response->assertStatus(200);
+            $response->assertJsonPath('meta.pagination.count', 1);
+            $response->assertJsonPath(
+                'data.0.id',
+                $campaignWithFirstThreeCauses->first()['id'],
+            );
+        }
+
+        // Test that we can filter by multiple causes.
+        $responseTwo = $this->getJson(
+            'api/v3/campaigns?filter[cause]=' .
+                implode(',', array_slice($causes, 0, 3)),
+        );
+
+        $responseTwo->assertStatus(200);
+        $responseTwo->assertJsonPath('meta.pagination.count', 1);
+        $responseTwo->assertJsonPath(
+            'data.0.id',
+            $campaignWithFirstThreeCauses->first()['id'],
+        );
+
+        // Test that invalid causes are rejected by the filter:
+        $responseThree = $this->getJson(
+            'api/v3/campaigns?filter[cause]=this-is-not-a-cause,nor-this!',
+        );
+
+        $responseThree->assertOk();
+        $responseThree->assertJsonPath('meta.pagination.count', 0);
+    }
+
+    /**
+     * Test that we can use cursor pagination.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testCampaignCursor()
+    {
+        factory(Campaign::class, 5)->create();
+
+        // First, let's get the three campaigns with the most pending posts:
+        $endpoint = 'api/v3/campaigns?limit=3';
+
+        $responseOne = $this->asAdminUser()->getJson($endpoint);
+
+        $responseOne->assertOk();
+        $responseOne->assertJsonCount(3, 'data');
+
+        // Then, we'll use the last post's cursor to fetch the remaining two:
+        $json = $responseOne->json();
+
+        $lastCursor = $json['data'][2]['cursor'];
+
+        $responseTwo = $this->asAdminUser()->getJson(
+            $endpoint . '&cursor[after]=' . $lastCursor,
+        );
+
+        $responseTwo->assertOk();
+        $responseTwo->assertJsonCount(2, 'data');
+    }
+
+    /**
+     * Test that we can use cursor pagination with ordered results.
+     *
+     * GET /api/v3/campaigns
+     * @return void
+     */
+    public function testCampaignCursorWithOrderBy()
+    {
+        // Create campaigns with varied number of 'pending' posts:
+        $one = $this->createCampaignWithPosts(1);
+        $two = $this->createCampaignWithPosts(2);
+        $three = $this->createCampaignWithPosts(3);
+        $four = $this->createCampaignWithPosts(4);
+        $five = $this->createCampaignWithPosts(5);
+
+        // We need these counter caches for this to work properly:
+        Artisan::call('rogue:recount');
+
+        // First, let's get the three campaigns with the most pending posts:
+        $endpoint = 'api/v3/campaigns?orderBy=pending_count,desc&limit=3';
+
+        $responseOne = $this->asAdminUser()->getJson($endpoint);
+
+        $responseOne->assertJson([
+            'data' => [0 => ['id' => $five->id, 'pending_count' => 5]],
+        ]);
+        $responseOne->assertJson([
+            'data' => [1 => ['id' => $four->id, 'pending_count' => 4]],
+        ]);
+        $responseOne->assertJson([
+            'data' => [2 => ['id' => $three->id, 'pending_count' => 3]],
+        ]);
+
+        // Then, we'll use the last post's cursor to fetch the remaining two:
+        $lastCursor = $responseOne->json()['data'][2]['cursor'];
+
+        $responseTwo = $this->asAdminUser()->getJson(
+            $endpoint . '&cursor[after]=' . $lastCursor,
+        );
+
+        $responseTwo->assertJson([
+            'data' => [0 => ['id' => $two->id, 'pending_count' => 2]],
+        ]);
+        $responseTwo->assertJson([
+            'data' => [1 => ['id' => $one->id, 'pending_count' => 1]],
+        ]);
+    }
+
+    /**
+     * Test that a GET request to /api/v3/campaigns/:campaign_id returns the intended campaign.
+     *
+     * GET /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testCampaignShow()
+    {
+        factory(Campaign::class, 5)->create();
+
+        // Create 1 specific campaign to search for.
+        $campaign = factory(Campaign::class)->create();
+
+        $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.id', $campaign->id);
+    }
+
+    /**
+     * Test for updating a campaign successfully with contentful campaign id.
+     *
+     * PATCH /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testUpdatingACampaignWithContentfulId()
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        // Update the contentful campaign id.
+        $response = $this->asAdminUser()->patchJson(
+            'api/v3/campaigns/' . $campaign->id,
+            [
+                'contentful_campaign_id' => '123456',
+            ],
+        );
+
+        // Make sure the campaign update is persisted.
+        $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+
+        $response->assertOk();
+        $response->assertJson([
+            'data' => [
+                'contentful_campaign_id' => '123456',
+            ],
+        ]);
+        $this->assertMysqlDatabaseHas('campaigns', [
+            'id' => $campaign->id,
+            'contentful_campaign_id' => '123456',
+        ]);
+    }
+
+    /**
+     * Test for updating a campaign successfully with a group type id.
+     *
+     * PATCH /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testUpdatingACampaignWithGroupTypeId()
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        $groupType = factory(GroupType::class)->create();
+
+        // Update the group type id.
+        $response = $this->asAdminUser()->patchJson(
+            'api/v3/campaigns/' . $campaign->id,
+            [
+                'group_type_id' => $groupType->id,
+            ],
+        );
+
+        // Make sure the campaign update is persisted.
+        $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+
+        $response->assertOk();
+        $response->assertJson([
+            'data' => [
+                'group_type_id' => $groupType->id,
+            ],
+        ]);
+        $this->assertMysqlDatabaseHas('campaigns', [
+            'id' => $campaign->id,
+            'group_type_id' => $groupType->id,
+        ]);
+    }
+
+    /**
+     * Test for updating a campaign with invalid status.
+     *
+     * PATCH /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testUpdatingACampaignWithInvalidStatus()
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        $response = $this->asAdminUser()->patchJson(
+            'api/v3/campaigns/' . $campaign->id,
+            [
+                'contentful_campaign_id' => 123456, // This should be a string
+            ],
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['contentful_campaign_id']);
+    }
+
+    /**
+     * Test for updating a campaign with invalid status.
+     *
+     * PATCH /api/v3/campaigns/:campaign_id
+     * @return void
+     */
+    public function testUpdatingACampaignWithInvalidStatusWithGroupTypeId()
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        $response = $this->asAdminUser()->patchJson(
+            'api/v3/campaigns/' . $campaign->id,
+            [
+                'group_type_id' => 'four', // This should be an integer
+            ],
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['group_type_id']);
+    }
 }

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -39,7 +39,6 @@ class CampaignTest extends TestCase
         $response = $this->getJson('api/v3/campaigns');
 
         $response->assertStatus(200);
-
         $response->assertJsonPath('meta.pagination.count', 5);
     }
 

--- a/tests/Http/CampaignTest.php
+++ b/tests/Http/CampaignTest.php
@@ -32,8 +32,6 @@ class CampaignTest extends TestCase
      */
     public function testCampaignIndex()
     {
-        $this->withoutExceptionHandling();
-
         factory(Campaign::class, 5)->create();
 
         $response = $this->getJson('api/v3/campaigns');
@@ -106,7 +104,7 @@ class CampaignTest extends TestCase
 
         // Let's test against pairs of three causes each so that we have a first, last, and middle cause
         // (ensuring we're testing our filtering logic against surrounding commas).
-        $campaignWithFirstThreeCauses = factory(Campaign::class, 1)->create([
+        $campaignWithFirstThreeCauses = factory(Campaign::class)->create([
             'cause' => array_slice($causes, 0, 3),
         ]);
 
@@ -124,7 +122,7 @@ class CampaignTest extends TestCase
             $response->assertJsonPath('meta.pagination.count', 1);
             $response->assertJsonPath(
                 'data.0.id',
-                $campaignWithFirstThreeCauses->first()['id'],
+                $campaignWithFirstThreeCauses->id,
             );
         }
 
@@ -138,7 +136,7 @@ class CampaignTest extends TestCase
         $responseTwo->assertJsonPath('meta.pagination.count', 1);
         $responseTwo->assertJsonPath(
             'data.0.id',
-            $campaignWithFirstThreeCauses->first()['id'],
+            $campaignWithFirstThreeCauses->id,
         );
 
         // Test that invalid causes are rejected by the filter:
@@ -169,9 +167,7 @@ class CampaignTest extends TestCase
         $responseOne->assertJsonCount(3, 'data');
 
         // Then, we'll use the last post's cursor to fetch the remaining two:
-        $json = $responseOne->json();
-
-        $lastCursor = $json['data'][2]['cursor'];
+        $lastCursor = $responseOne->json('data.2.cursor');
 
         $responseTwo = $this->asAdminUser()->getJson(
             $endpoint . '&cursor[after]=' . $lastCursor,

--- a/tests/Http/Web/WebCampaignTest.php
+++ b/tests/Http/Web/WebCampaignTest.php
@@ -107,12 +107,6 @@ class WebCampaignTest extends TestCase
         // Make sure the campaign is deleted.
         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
 
-        $response->dump();
-
         $response->assertNotFound();
-        $response->assertJsonPath(
-            'error.message',
-            'That resource could not be found.',
-        );
     }
 }

--- a/tests/Http/Web/WebCampaignTest.php
+++ b/tests/Http/Web/WebCampaignTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\GroupType;
+
+class WebCampaignTest extends TestCase
+{
+    /**
+     * Test that a POST request to /campaigns creates a new campaign.
+     *
+     * POST /campaigns
+     * @return void
+     */
+    public function testCreatingACampaign()
+    {
+        $this->withoutExceptionHandling(); // @TODO: delete!
+
+        // Create a campaign.
+        $firstCampaignTitle = $this->faker->sentence;
+
+        // Make sure the end date is after the start date.
+        $firstCampaignStartDate = $this->faker->date($format = 'm/d/Y');
+        $firstCampaignEndDate = date(
+            'm/d/Y',
+            strtotime('+3 months', strtotime($firstCampaignStartDate)),
+        );
+
+        // Create a GroupType
+        $groupType = factory(GroupType::class)->create();
+
+        $response = $this->asAdminUser()->postJson('/campaigns', [
+            'internal_title' => $firstCampaignTitle,
+            'cause' => ['animal-welfare'],
+            'impact_doc' => 'https://www.google.com',
+            'start_date' => $firstCampaignStartDate,
+            'end_date' => $firstCampaignEndDate,
+            'group_type_id' => $groupType->id,
+        ]);
+
+        $response->dump();
+
+        dd([
+            $firstCampaignTitle,
+            $firstCampaignStartDate,
+            $firstCampaignEndDate,
+        ]);
+
+        // Make sure the campaign is persisted.
+        $this->assertDatabaseHas('campaigns', [
+            'internal_title' => $firstCampaignTitle,
+        ]);
+
+        // Try to create a second campaign with the same title and make sure it doesn't duplicate.
+        $this->asAdminUser()->postJson('campaigns', [
+            'internal_title' => $firstCampaignTitle,
+        ]);
+
+        $response = $this->getJson('api/v3/campaigns');
+        $decodedResponse = $response->decodeResponseJson();
+
+        $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
+    }
+}

--- a/tests/Http/Web/WebCampaignTest.php
+++ b/tests/Http/Web/WebCampaignTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use App\Models\GroupType;
+use App\Models\User;
 
 class WebCampaignTest extends TestCase
 {
     /**
-     * Test that a POST request to /campaigns creates a new campaign.
+     * Test that a POST request to /ca8mpaigns creates a new campaign.
      *
      * POST /campaigns
      * @return void
@@ -14,7 +15,6 @@ class WebCampaignTest extends TestCase
     {
         $this->withoutExceptionHandling(); // @TODO: delete!
 
-        // Create a campaign.
         $firstCampaignTitle = $this->faker->sentence;
 
         // Make sure the end date is after the start date.
@@ -24,10 +24,11 @@ class WebCampaignTest extends TestCase
             strtotime('+3 months', strtotime($firstCampaignStartDate)),
         );
 
-        // Create a GroupType
         $groupType = factory(GroupType::class)->create();
 
-        $response = $this->asAdminUser()->postJson('/campaigns', [
+        $admin = $this->makeAuthAdminUser();
+
+        $response = $this->actingAs($admin)->post('/campaigns', [
             'internal_title' => $firstCampaignTitle,
             'cause' => ['animal-welfare'],
             'impact_doc' => 'https://www.google.com',
@@ -43,20 +44,69 @@ class WebCampaignTest extends TestCase
             $firstCampaignStartDate,
             $firstCampaignEndDate,
         ]);
-
         // Make sure the campaign is persisted.
         $this->assertDatabaseHas('campaigns', [
             'internal_title' => $firstCampaignTitle,
         ]);
-
         // Try to create a second campaign with the same title and make sure it doesn't duplicate.
         $this->asAdminUser()->postJson('campaigns', [
             'internal_title' => $firstCampaignTitle,
         ]);
-
         $response = $this->getJson('api/v3/campaigns');
         $decodedResponse = $response->decodeResponseJson();
-
         $this->assertEquals(1, $decodedResponse['meta']['pagination']['count']);
     }
+
+    // /**
+    //      * Test that a PATCH request to /campaigns/:campaign_id updates a campaign.
+    //      *
+    //      * PATCH /campaigns/:campaign_id
+    //      * @return void
+    //      */
+    //     public function testUpdatingACampaign()
+    //     {
+    //         // Create a campaign to update.
+    //         $campaign = factory(Campaign::class)->create();
+    //         // Update the title.
+    //         $response = $this->actingAsAdmin()->patch(
+    //             'campaigns/' . $campaign->id,
+    //             [
+    //                 'internal_title' => 'Updated Title',
+    //                 'impact_doc' => 'https://www.bing.com/',
+    //                 'cause' => ['lgbtq-rights'],
+    //                 'start_date' => '1/1/2018',
+    //             ],
+    //         );
+    //         // Make sure the campaign update is persisted.
+    //         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+    //         $response->assertStatus(200);
+    //         $response->assertJson([
+    //             'data' => [
+    //                 'internal_title' => 'Updated Title',
+    //                 'cause' => ['lgbtq-rights'],
+    //                 'start_date' => '2018-01-01T00:00:00-05:00',
+    //             ],
+    //         ]);
+    //     }
+    //     /**
+    //      * Test that a DELETE request to /campaigns/:campaign_id deletes a campaign.
+    //      *
+    //      * DELETE /campaigns/:campaign_id
+    //      * @return void
+    //      */
+    //     public function testDeleteACampaign()
+    //     {
+    //         // Create a campaign to delete.
+    //         $campaign = factory(Campaign::class)->create();
+    //         // Delete the campaign.
+    //         $this->actingAsAdmin()->deleteJson('campaigns/' . $campaign->id);
+    //         // Make sure the campaign is deleted.
+    //         $response = $this->getJson('api/v3/campaigns/' . $campaign->id);
+    //         $decodedResponse = $response->decodeResponseJson();
+    //         $response->assertStatus(404);
+    //         $this->assertEquals(
+    //             'That resource could not be found.',
+    //             $decodedResponse['message'],
+    //         );
+    //     }
 }

--- a/tests/Models/CampaignModelTest.php
+++ b/tests/Models/CampaignModelTest.php
@@ -4,7 +4,7 @@ use App\Models\Action;
 use App\Models\Campaign;
 use App\Models\GroupType;
 
-class CampaignTest extends TestCase
+class CampaignModelTest extends TestCase
 {
     /**
      * Test expected payload for Laravel Scout / Algolia.

--- a/tests/Models/CampaignModelTest.php
+++ b/tests/Models/CampaignModelTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\Action;
+use App\Models\Campaign;
+use App\Models\GroupType;
+
+class CampaignTest extends TestCase
+{
+    /**
+     * Test expected payload for Laravel Scout / Algolia.
+     *
+     * @return void
+     */
+    public function testToSearchableArray()
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        $action = factory(Action::class)->create([
+            'campaign_id' => $campaign->id,
+        ]);
+
+        $searchableArray = $campaign->toSearchableArray();
+
+        // The Campaign's Actions should be in the payload.
+        $this->assertEquals(
+            $searchableArray['actions'][0]['name'],
+            $action->name,
+        );
+        // The date fields should be transformed to a UNIX timestamp.
+        $this->assertEquals(
+            $searchableArray['start_date'],
+            $campaign->start_date->timestamp,
+        );
+        $this->assertEquals(
+            $searchableArray['end_date'],
+            $campaign->end_date->timestamp,
+        );
+
+        // There should be computed boolean attributes determining:
+        // - if the campaign is a Website Campaign
+        // - if the campaign is evergreen (has no end date)
+        // - if the campaign is a group campaign
+
+        // With a non-populated contentful_campaign_id:
+        $this->assertFalse($searchableArray['has_website']);
+        // With a populated end_date:
+        $this->assertFalse($searchableArray['is_evergreen']);
+        // Without a group_type_id:
+        $this->assertFalse($searchableArray['is_group_campaign']);
+
+        // With a populated contentful_campaign_id and no end_date.
+        $evergreenWebsiteCampaign = factory(Campaign::class)->create([
+            'contentful_campaign_id' => '123',
+            'end_date' => null,
+            'group_type_id' => factory(GroupType::class)->create()->id,
+        ]);
+
+        $this->assertTrue(
+            $evergreenWebsiteCampaign->toSearchableArray()['has_website'],
+        );
+        $this->assertTrue(
+            $evergreenWebsiteCampaign->toSearchableArray()['is_evergreen'],
+        );
+        $this->assertTrue(
+            $evergreenWebsiteCampaign->toSearchableArray()['is_group_campaign'],
+        );
+
+        // We should only index the first 20 actions of the campaign.
+        $multiActionCampaign = factory(Campaign::class)->create();
+
+        factory(Action::class, 30)->create([
+            'campaign_id' => $multiActionCampaign->id,
+        ]);
+
+        $this->assertEquals(
+            $multiActionCampaign->toSearchableArray()['actions']->count(),
+            20,
+        );
+    }
+}

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -28,6 +28,20 @@ trait WithAuthentication
     }
 
     /**
+     * Make a new authenticated admin user.
+     *
+     * @return \App\Models\User
+     */
+    protected function makeAuthAdminUser()
+    {
+        $admin = factory(User::class, 'admin')->create();
+
+        $this->be($admin, 'web');
+
+        return $admin;
+    }
+
+    /**
      * Use the given API key for this request.
      *
      * @param Client $client

--- a/tests/WithAuthentication.php
+++ b/tests/WithAuthentication.php
@@ -28,20 +28,6 @@ trait WithAuthentication
     }
 
     /**
-     * Make a new authenticated admin user.
-     *
-     * @return \App\Models\User
-     */
-    protected function makeAuthAdminUser()
-    {
-        $admin = factory(User::class, 'admin')->create();
-
-        $this->be($admin, 'web');
-
-        return $admin;
-    }
-
-    /**
      * Use the given API key for this request.
      *
      * @param Client $client


### PR DESCRIPTION
### What's this PR do?

This pull request enables `v3/campaigns` API routes, and `/campaign` web routes in Northstar 🎉

All the business logic was already copied over from Rogue, so this pull request just worked on getting the tests for these routes working again! ✅ 


### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #176469276](https://www.pivotaltracker.com/story/show/176469276).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
