### PR TITLE
Add 'posts/{post}/reactions' routes.

### DIFF
--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -28,19 +28,20 @@ class ReactionController extends ActivityApiController
     {
         $this->transformer = new ReactionTransformer();
 
-        $this->middleware('scopes:activity');
         $this->middleware('auth:api', ['only' => ['store']]);
-        $this->middleware('scopes:write', ['only' => ['store']]);
+
+        $this->middleware('scope:activity');
+        $this->middleware('scope:write', ['only' => ['store']]);
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
      * @param \App\Models\Post $post
+     * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request, Post $post)
+    public function store(Post $post, Request $request)
     {
         $northstarId = getNorthstarId($request);
 
@@ -52,7 +53,7 @@ class ReactionController extends ActivityApiController
 
         if ($reaction->wasRecentlyCreated || $reaction->trashed()) {
             // We're adding a new reaction in these cases.
-            $code = 200;
+            $code = 200; // TODO: This should be a '201 Created'.
             $action = 'liked';
 
             if ($reaction->trashed()) {
@@ -61,7 +62,7 @@ class ReactionController extends ActivityApiController
             }
         } else {
             // Otherwise, we must be removing.
-            $code = 201;
+            $code = 201; // TODO: This should be a '200 OK'.
             $action = 'unliked';
             $reaction->delete();
         }

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -28,7 +28,7 @@ class Reaction extends Model
      *
      * @var array
      */
-    protected $fillable = ['id', 'northstar_id', 'post_id'];
+    protected $fillable = ['northstar_id', 'post_id'];
 
     /**
      * Each reaction has events.

--- a/database/factories/ReactionFactory.php
+++ b/database/factories/ReactionFactory.php
@@ -2,6 +2,7 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
+use App\Models\User;
 use App\Models\Reaction;
 use Faker\Generator as Faker;
 

--- a/database/factories/ReactionFactory.php
+++ b/database/factories/ReactionFactory.php
@@ -2,8 +2,8 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use App\Models\User;
 use App\Models\Reaction;
+use App\Models\User;
 use Faker\Generator as Faker;
 
 $factory->define(Reaction::class, function (Faker $faker) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,10 @@ Route::group(
         Route::patch('posts/{post}', 'PostsController@update');
         Route::delete('posts/{post}', 'PostsController@destroy');
 
+        // Posts: Reactions
+        Route::post('posts/{post}/reactions', 'ReactionController@store');
+        Route::get('posts/{post}/reactions', 'ReactionController@index');
+
         // Signups
         Route::post('signups', 'SignupsController@store');
         Route::get('signups', 'SignupsController@index');

--- a/tests/Http/ReactionTest.php
+++ b/tests/Http/ReactionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\User;
+
+class ReactionTest extends TestCase
+{
+    /**
+     * Test for retrieving all reactions of a post.
+     *
+     * GET /api/v3/post/:post_id/reactions
+     * @return void
+     */
+    public function testReactionsIndex()
+    {
+        $post = factory(Post::class)->create();
+        factory(Reaction::class, 10)->create(['post_id' => $post->id]);
+
+        $response = $this->getJson('api/v3/posts/' . $post->id . '/reactions');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'northstar_id',
+                    'post_id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Test that the POST /reactions request creates a reaction for a post.
+     * Also test that when POST /reactions is hit again by the same user
+     * for the same post, the reaction is soft deleted.
+     *
+     * POST /reactions
+     * @return void
+     */
+    public function testPostingAndSoftDeleteForReaction()
+    {
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create();
+
+        // Create a reaction.
+        $response = $this->asUser($user)->postJson(
+            'api/v3/posts/' . $post->id . '/reactions',
+        );
+
+        $response->assertSuccessful(); // TODO: This should be a 201.
+        $response->assertJson([
+            'meta' => [
+                'total_reactions' => 1,
+            ],
+        ]);
+
+        // If we "react" to the same post again, it should "un-like" it:
+        $response = $this->asUser($user)->postJson(
+            'api/v3/posts/' . $post->id . '/reactions',
+        );
+
+        $response->assertSuccessful(); // TODO: This should be a 200.
+        $response->assertJson([
+            'meta' => [
+                'total_reactions' => 0,
+            ],
+        ]);
+    }
+
+    /**
+     * Test that the aggregate of total reactions for a post is correct.
+     *
+     * POST /reactions
+     * @return void
+     */
+    public function testAggregateReactions()
+    {
+        // Given a post with 3 reactions...
+        $post = factory(Post::class)->create();
+        factory(Reaction::class, 3)->create(['post_id' => $post->id]);
+
+        // When we add a new reaction...
+        $response = $this->asNormalUser()->postJson(
+            'api/v3/posts/' . $post->id . '/reactions',
+        );
+
+        // We should see an increased total!
+        $response->assertSuccessful();
+        $response->assertJson([
+            'meta' => [
+                'total_reactions' => 4,
+            ],
+        ]);
+    }
+
+    /**
+     * Test that a post and signup's updated_at updates when a reaction is made.
+     *
+     * @return void
+     */
+    public function testUpdatedPostWithReaction()
+    {
+        // Given a post that was last updated a long time ago...
+        $post = factory(Post::class)->create([
+            'updated_at' => '2017-08-03 14:00:00',
+            'created_at' => '2017-08-03 14:00:00',
+        ]);
+
+        $reaction = factory(Reaction::class)->create([
+            'post_id' => $post->id,
+        ]);
+
+        $this->assertMysqlDatabaseHas('posts', [
+            'id' => $post->id,
+            'updated_at' => $reaction->created_at,
+        ]);
+    }
+
+    /**
+     * Test that non-authenticated user's/apps can't create reactions.
+     *
+     * @return void
+     */
+    public function testUnauthenticatedUserCreatingAReaction()
+    {
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create();
+
+        $response = $this->postJson(
+            'api/v3/posts/' . $post->id . '/reactions',
+            [
+                'northstar_id' => $user->id,
+            ],
+        );
+
+        $response->assertUnauthorized();
+    }
+}

--- a/tests/Http/ReactionTest.php
+++ b/tests/Http/ReactionTest.php
@@ -19,7 +19,7 @@ class ReactionTest extends TestCase
 
         $response = $this->getJson('api/v3/posts/' . $post->id . '/reactions');
 
-        $response->assertStatus(200);
+        $response->assertOk();
         $response->assertJsonStructure([
             'data' => [
                 '*' => [


### PR DESCRIPTION
### What's this PR do?

This pull request adds routes & tests for the `posts/{post}/reactions` routes.

### How should this be reviewed?

👀

### Any background context you want to provide?

❤️

### Relevant tickets

References [Pivotal #176851339](https://www.pivotaltracker.com/story/show/176851339).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
