### PR TITLE
Adds password reset form to admin UI

### DIFF
--- a/app/Http/Controllers/Web/Admin/UserController.php
+++ b/app/Http/Controllers/Web/Admin/UserController.php
@@ -137,7 +137,7 @@ class UserController extends Controller
     }
 
     /**
-     * Send a Northstar user a password reset email.
+     * Sends user a password reset email.
      *
      * @param User $user
      * @return \Illuminate\Http\Response

--- a/app/Http/Controllers/Web/Admin/UserController.php
+++ b/app/Http/Controllers/Web/Admin/UserController.php
@@ -133,4 +133,23 @@ class UserController extends Controller
             ->route('admin.users.index')
             ->with('flash', 'User deleted.');
     }
+
+    /**
+     * Send a Northstar user a password reset email.
+     *
+     * @param User $user
+     * @return \Illuminate\Http\Response
+     */
+    public function sendPasswordReset(User $user, Request $request)
+    {
+        $this->authorize('delete', $user);
+
+        $type = $request['type'];
+
+        $user->sendPasswordReset($type);
+
+        return redirect()
+            ->route('admin.users.show', $user->id)
+            ->with('flash', 'Sent ' . $type . ' email to user.');
+    }
 }

--- a/app/Http/Controllers/Web/Admin/UserController.php
+++ b/app/Http/Controllers/Web/Admin/UserController.php
@@ -7,6 +7,7 @@ use App\Auth\Role;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Types\CauseInterestType;
+use App\Types\PasswordResetType;
 use Illuminate\Http\Request;
 
 class UserController extends Controller
@@ -54,6 +55,7 @@ class UserController extends Controller
         return view('admin.users.show', [
             'user' => $user,
             'title' => $user->display_name,
+            'passwordResetTypes' => PasswordResetType::labels(),
         ]);
     }
 

--- a/app/Listeners/ReportPasswordUpdated.php
+++ b/app/Listeners/ReportPasswordUpdated.php
@@ -5,7 +5,7 @@ namespace App\Listeners;
 use App\Events\PasswordUpdated;
 use App\Jobs\CreateCustomerIoEvent;
 use App\Jobs\SendCustomerIoEmail;
-use Illuminate\Support\Str;
+use App\Types\PasswordResetType;
 
 class ReportPasswordUpdated
 {
@@ -17,11 +17,13 @@ class ReportPasswordUpdated
      */
     public function handle(PasswordUpdated $event)
     {
+        $passwordResetType = $event->updatedVia;
+
         /*
          * Use Customer.io events to track account activations, so admins can customize the
          * user's messaging journey per their source (e.g., Rock The Vote, newsletter subscription).
          */
-        if (Str::contains($event->updatedVia, 'activate-account')) {
+        if (PasswordResetType::isActivateAccount($passwordResetType)) {
             return CreateCustomerIoEvent::dispatch(
                 $event->user,
                 /*
@@ -30,7 +32,7 @@ class ReportPasswordUpdated
                  */
                 'password_updated',
                 [
-                    'updated_via' => $event->updatedVia,
+                    'updated_via' => $passwordResetType,
                 ]
             );
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -877,6 +877,18 @@ class User extends MongoModel implements
      */
     public function getPasswordResetUrl($token, $type)
     {
+        if (!$token) {
+            $tokenRepository = new DatabaseTokenRepository(
+                app('db')->connection('mongodb'),
+                app('hash'),
+                config('auth.passwords.users.table'),
+                config('app.key'),
+                config('auth.passwords.users.expire'),
+            );
+
+            $token = $tokenRepository->create($this);
+        }
+
         return route('password.reset', [
             $token,
             'email' => $this->email,
@@ -907,17 +919,6 @@ class User extends MongoModel implements
      */
     public function sendPasswordReset($type, $token = null)
     {
-        if (!$token) {
-            $tokenRepository = new DatabaseTokenRepository(
-                app('db')->connection('mongodb'),
-                app('hash'),
-                config('auth.passwords.users.table'),
-                config('app.key'),
-                config('auth.passwords.users.expire'),
-            );
-            $token = $tokenRepository->create($this);
-        }
-
         $data = [
             'actionUrl' => $this->getPasswordResetUrl($token, $type),
             'type' => $this->type,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -929,7 +929,7 @@ class User extends MongoModel implements
          * Use Customer.io events to track activate account emails, so admins can customize the
          * user's messaging journey per their source (e.g., Rock The Vote, newsletter subscription).
          */
-        if (Str::contains($type, 'activate-account')) {
+        if (PasswordResetType::isActivateAccount($type)) {
             return CreateCustomerIoEvent::dispatch($this, 'call_to_action_email', $data);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -877,18 +877,6 @@ class User extends MongoModel implements
      */
     public function getPasswordResetUrl($token, $type)
     {
-        if (!$token) {
-            $tokenRepository = new DatabaseTokenRepository(
-                app('db')->connection('mongodb'),
-                app('hash'),
-                config('auth.passwords.users.table'),
-                config('app.key'),
-                config('auth.passwords.users.expire'),
-            );
-
-            $token = $tokenRepository->create($this);
-        }
-
         return route('password.reset', [
             $token,
             'email' => $this->email,
@@ -919,6 +907,18 @@ class User extends MongoModel implements
      */
     public function sendPasswordReset($type, $token = null)
     {
+        if (!$token) {
+            $tokenRepository = new DatabaseTokenRepository(
+                app('db')->connection('mongodb'),
+                app('hash'),
+                config('auth.passwords.users.table'),
+                config('app.key'),
+                config('auth.passwords.users.expire'),
+            );
+
+            $token = $tokenRepository->create($this);
+        }
+
         $data = [
             'actionUrl' => $this->getPasswordResetUrl($token, $type),
             'type' => $this->type,

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -153,11 +153,13 @@ class CustomerIo
      */
     public function sendEmail($to, $transactionalMessageId, $messageData = [])
     {
+        $logInfo = [
+            'transactional_message_id' => $transactionalMessageId,
+            'data' => $messageData,
+        ];
+
         if (!$this->enabled()) {
-            info('Transactional email would have been sent from Customer.io', [
-                'transactional_message_id' => $transactionalMessageId,
-                'data' => $messageData,
-            ]);
+            info('Transactional email would have been sent from Customer.io', $logInfo);
 
             return;
         }
@@ -173,6 +175,8 @@ class CustomerIo
         if ($messageData) {
             $payload['message_data'] = $messageData;
         }
+
+        logger('Sending Customer.io email', $logInfo);
 
         $response = $this->appApiClient->post('send/email', ['json' => $payload]);
     }

--- a/app/Types/PasswordResetType.php
+++ b/app/Types/PasswordResetType.php
@@ -2,14 +2,20 @@
 
 namespace App\Types;
 
+use Illuminate\Support\Str;
+
 class PasswordResetType extends Type
 {
+    // Suffix used to indicate a type is an activate account type of password reset.
+    private const ACTIVATE_ACCOUNT_KEY = 'activate-account';
+
+    // Password reset types
     private const FORGOT_PASSWORD = 'forgot-password';
-    private const BOOST_ACTIVATE_ACCOUNT = 'boost-activate-account';
-    private const BREAKDOWN_ACTIVATE_ACCOUNT = 'breakdown-activate-account';
-    private const PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT = 'pays-to-do-good-activate-account';
-    private const ROCK_THE_VOTE_ACTIVATE_ACCOUNT = 'rock-the-vote-activate-account';
-    private const WYD_ACTIVATE_ACCOUNT = 'wyd-activate-account';
+    private const BOOST_ACTIVATE_ACCOUNT = 'boost-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const BREAKDOWN_ACTIVATE_ACCOUNT = 'breakdown-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT = 'pays-to-do-good-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const ROCK_THE_VOTE_ACTIVATE_ACCOUNT = 'rock-the-vote-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const WYD_ACTIVATE_ACCOUNT = 'wyd-' . self::ACTIVATE_ACCOUNT_KEY;
 
     /**
      * Returns labeled list of values.
@@ -26,5 +32,16 @@ class PasswordResetType extends Type
             self::PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT => 'Pays To Do Good Activate Account',
             self::WYD_ACTIVATE_ACCOUNT => 'WYD Activate Account',
         ];
+    }
+
+    /**
+     * Returns whether a password reset type value the contains activate account key.
+     *
+     * @param string $passwordResetTypeValue
+     * @return bool
+     */
+    public static function isActivateAccount(string $passwordResetTypeValue)
+    {
+        return Str::contains($passwordResetTypeValue, self::ACTIVATE_ACCOUNT_KEY);
     }
 }

--- a/app/Types/PasswordResetType.php
+++ b/app/Types/PasswordResetType.php
@@ -10,4 +10,21 @@ class PasswordResetType extends Type
     private const PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT = 'pays-to-do-good-activate-account';
     private const ROCK_THE_VOTE_ACTIVATE_ACCOUNT = 'rock-the-vote-activate-account';
     private const WYD_ACTIVATE_ACCOUNT = 'wyd-activate-account';
+
+    /**
+     * Returns labeled list of values.
+     *
+     * @return array
+     */
+    public static function labels()
+    {
+        return [
+            self::FORGOT_PASSWORD => 'Forgot Password',
+            self::ROCK_THE_VOTE_ACTIVATE_ACCOUNT => 'Rock The Vote Activate Account',
+            self::BOOST_ACTIVATE_ACCOUNT => 'Boost Activate Account',
+            self::BREAKDOWN_ACTIVATE_ACCOUNT => 'Breakdown Activate Account',
+            self::PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT => 'Pays To Do Good Activate Account',
+            self::WYD_ACTIVATE_ACCOUNT => 'WYD Activate Account',
+        ];
+    }
 }

--- a/resources/views/admin/users/partials/danger-zone.blade.php
+++ b/resources/views/admin/users/partials/danger-zone.blade.php
@@ -1,5 +1,31 @@
 <div class="danger-zone">
     <h4 class="danger-zone__heading">Danger Zone&#8482;</h4>
+
+    <div class="danger-zone__block">
+        <form method="POST" action="{{ route('admin.users.resets.create', ['user' => $user->id]) }}">
+            {{ method_field('POST')}}
+            {{ csrf_field() }}
+
+            <div class="form-item">  
+                <label for="password-reset-type" class="field-label">Send Password Reset</label>
+
+                <select id="password-reset-type" name="type">
+                  <option value="forgot-password">Forgot Password</option>
+
+                  <option value="rock-the-vote-activate-account">Rock The Vote Activate Account</option>
+                </select>
+
+                <p class="footnote">This will email the user a link to reset their password.</p>
+            </div>
+
+            <div class="form-actions">
+                <button type="submit" class="button -secondary">
+                    Send
+                </button>
+            </div>
+        </form>
+    </div>
+
     <div class="danger-zone__block">
         <form method="POST" action="{{ route('admin.users.destroy', ['user' => $user->id]) }}">
             {{ method_field('DELETE')}}

--- a/resources/views/admin/users/partials/danger-zone.blade.php
+++ b/resources/views/admin/users/partials/danger-zone.blade.php
@@ -10,9 +10,9 @@
                 <label for="password-reset-type" class="field-label">Send Password Reset</label>
 
                 <select id="password-reset-type" name="type">
-                  <option value="forgot-password">Forgot Password</option>
-
-                  <option value="rock-the-vote-activate-account">Rock The Vote Activate Account</option>
+                  @foreach ( $passwordResetTypes as $value => $label )
+                      <option value="{{$value}}">{{$label}}</option>
+                  @endforeach
                 </select>
 
                 <p class="footnote">This will email the user a link to reset their password.</p>

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -49,7 +49,7 @@
             <div class="container__block -half">
                 <div class="container -padded">
                     @if(Auth::user()->hasRole('admin'))
-                      @include('admin.users.partials.danger-zone')
+                      @include('admin.users.partials.danger-zone', ['passwordResetTypes' => $passwordResetTypes])
                     @endif
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,10 @@ if (config('features.admin')) {
             Route::resource('users', 'Admin\UserController', [
                 'except' => ['create', 'store'],
             ]);
+            Route::post('users/{user}/resets', [
+                'as' => 'users.resets.create',
+                'uses' => 'Admin\UserController@sendPasswordReset',
+            ]);
 
             // Fastly Redirects
             Route::resource('redirects', 'Admin\RedirectsController');


### PR DESCRIPTION
### What's this PR do?

Branching from #1113, this pull request adds Aurora's "Send Password Reset" form to the danger zone section of the admin view of a user (it was left out of migrating the admin UI in #1087).

It also adds to new methods new static `labels` and `isActivateAccount` methods to our `PasswordResetType` class to DRY.

<img src="https://user-images.githubusercontent.com/1236811/107571077-3f3f0980-6b9f-11eb-99b6-8268cab38f88.png" width="400">
<img src="https://user-images.githubusercontent.com/1236811/107571083-40703680-6b9f-11eb-916c-5345686fcd78.png" width="400">

### How should this be reviewed?

👀 

### Any background context you want to provide?

✉️ 

### Relevant tickets

References [Pivotal #176873288](https://www.pivotaltracker.com/story/show/176873288), [#175943296](https://www.pivotaltracker.com/story/show/175943296)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
