### PR TITLE
Enable Group Type routes in Northstar

### DIFF
--- a/app/Http/Controllers/Web/GroupTypesController.php
+++ b/app/Http/Controllers/Web/GroupTypesController.php
@@ -14,7 +14,7 @@ class GroupTypesController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth:web');
         $this->middleware('role:admin');
 
         $this->rules = [
@@ -40,7 +40,7 @@ class GroupTypesController extends Controller
         $values = $this->validate(
             $request,
             array_merge_recursive($this->rules, [
-                'name' => [Rule::unique('group_types')],
+                'name' => [Rule::unique('mysql.group_types')],
             ]),
         );
         // @see ActionsController->fillInOmittedCheckboxes
@@ -77,7 +77,9 @@ class GroupTypesController extends Controller
         $values = $this->validate(
             $request,
             array_merge_recursive($this->rules, [
-                'name' => [Rule::unique('group_types')->ignore($groupType->id)],
+                'name' => [
+                    Rule::unique('mysql.group_types')->ignore($groupType->id),
+                ],
             ]),
         );
         // @see ActionsController->fillInOmittedCheckboxes

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,10 @@ Route::group(
         Route::get('groups', 'GroupsController@index');
         Route::get('groups/{group}', 'GroupsController@show');
 
+        // Group Types
+        Route::get('group-types', 'GroupTypesController@index');
+        Route::get('group-types/{groupType}', 'GroupTypesController@show');
+
         // Posts
         Route::post('posts', 'PostsController@store');
         Route::get('posts', 'PostsController@index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,12 @@ Route::resource('groups', 'GroupsController', [
     'except' => ['create', 'index', 'show'],
 ]);
 
+// Group Types
+Route::resource('group-types', 'GroupTypesController', [
+    'except' => ['index', 'show'],
+]);
+Route::get('group-types/{id}/groups/create', 'GroupsController@create');
+
 // Registration
 Route::get('register', 'AuthController@getRegister');
 Route::post('register', 'AuthController@postRegister');

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -17,7 +17,7 @@ class GroupTypeTest extends TestCase
 
         $response->assertOk();
 
-        $this->assertEquals('meta.pagination.count', 5);
+        $response->assertJsonPath('meta.pagination.count', 5);
     }
 
     /**
@@ -35,6 +35,6 @@ class GroupTypeTest extends TestCase
 
         $response->assertOk();
 
-        $this->assertEquals('data.id', $groupType->id);
+        $response->assertJsonPath('data.id', $groupType->id);
     }
 }

--- a/tests/Http/GroupTypeTest.php
+++ b/tests/Http/GroupTypeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\GroupType;
+
+class GroupTypeTest extends TestCase
+{
+    /**
+     * Test that a GET request to /api/v3/group-types returns an index of all group types.
+     *
+     * @return void
+     */
+    public function testGroupTypeIndex()
+    {
+        factory(GroupType::class, 5)->create();
+
+        $response = $this->getJson('/api/v3/group-types');
+
+        $response->assertOk();
+
+        $this->assertEquals('meta.pagination.count', 5);
+    }
+
+    /**
+     * Test that a GET request to /api/v3/group-types/:id returns the intended group type.
+     *
+     * @return void
+     */
+    public function testGroupTypeShow()
+    {
+        factory(GroupType::class, 5)->create();
+
+        $groupType = factory(GroupType::class)->create();
+
+        $response = $this->getJson('/api/v3/group-types/' . $groupType->id);
+
+        $response->assertOk();
+
+        $this->assertEquals('data.id', $groupType->id);
+    }
+}

--- a/tests/Http/Web/WebGroupTest.php
+++ b/tests/Http/Web/WebGroupTest.php
@@ -9,7 +9,7 @@ class WebGroupTest extends TestCase
     /** @test */
     public function testAdminCanCreateGroup()
     {
-        $admin = factory(User::class, 'admin')->make();
+        $admin = factory(User::class, 'admin')->create();
 
         $groupType = factory(GroupType::class)->create();
 
@@ -31,7 +31,7 @@ class WebGroupTest extends TestCase
     /** @test */
     public function testAdminCannotCreateDuplicateGroup()
     {
-        $admin = factory(User::class, 'admin')->make();
+        $admin = factory(User::class, 'admin')->create();
 
         $group = factory(Group::class)->create();
 
@@ -49,7 +49,7 @@ class WebGroupTest extends TestCase
     /** @test */
     public function testStaffCanCreateGroup()
     {
-        $staff = factory(User::class, 'staff')->make();
+        $staff = factory(User::class, 'staff')->create();
 
         $groupType = factory(GroupType::class)->create();
 

--- a/tests/Http/Web/WebGroupTest.php
+++ b/tests/Http/Web/WebGroupTest.php
@@ -9,7 +9,7 @@ class WebGroupTest extends TestCase
     /** @test */
     public function testAdminCanCreateGroup()
     {
-        $admin = factory(User::class, 'admin')->create();
+        $admin = factory(User::class, 'admin')->make();
 
         $groupType = factory(GroupType::class)->create();
 
@@ -31,11 +31,11 @@ class WebGroupTest extends TestCase
     /** @test */
     public function testAdminCannotCreateDuplicateGroup()
     {
-        $admin = factory(User::class, 'admin')->create();
+        $admin = factory(User::class, 'admin')->make();
 
         $group = factory(Group::class)->create();
 
-        $response = $this->actingAs($admin, 'web')->post('groups', [
+        $response = $this->actingAs($admin, 'web')->post('/groups', [
             'group_type_id' => $group->group_type_id,
             'name' => $group->name,
         ]);
@@ -49,13 +49,13 @@ class WebGroupTest extends TestCase
     /** @test */
     public function testStaffCanCreateGroup()
     {
-        $staff = factory(User::class, 'staff')->create();
+        $staff = factory(User::class, 'staff')->make();
 
         $groupType = factory(GroupType::class)->create();
 
         $name = $this->faker->sentence;
 
-        $response = $this->actingAs($staff, 'web')->post('groups', [
+        $response = $this->actingAs($staff, 'web')->post('/groups', [
             'group_type_id' => $groupType->id,
             'name' => $name,
         ]);

--- a/tests/Http/Web/WebGroupTypeTest.php
+++ b/tests/Http/Web/WebGroupTypeTest.php
@@ -8,7 +8,7 @@ class WebGroupTypeTest extends TestCase
     /** @test */
     public function testAdminCanCreateGroupType()
     {
-        $admin = factory(User::class, 'admin')->make();
+        $admin = factory(User::class, 'admin')->create();
 
         $name = $this->faker->sentence;
 
@@ -28,7 +28,7 @@ class WebGroupTypeTest extends TestCase
     /** @test */
     public function testAdminCannotCreateDuplicateGroupType()
     {
-        $admin = factory(User::class, 'admin')->make();
+        $admin = factory(User::class, 'admin')->create();
 
         $groupType = factory(GroupType::class)->create();
 
@@ -42,7 +42,7 @@ class WebGroupTypeTest extends TestCase
     /** @test */
     public function testStaffCannotCreateGroupType()
     {
-        $staff = factory(User::class, 'staff')->make();
+        $staff = factory(User::class, 'staff')->create();
 
         $name = $this->faker->sentence;
 
@@ -64,7 +64,7 @@ class WebGroupTypeTest extends TestCase
     /** @test */
     public function testUnsettingFilterByState()
     {
-        $admin = factory(User::class, 'admin')->make();
+        $admin = factory(User::class, 'admin')->create();
 
         $groupType = factory(GroupType::class)->create([
             'filter_by_location' => true,

--- a/tests/Http/Web/WebGroupTypeTest.php
+++ b/tests/Http/Web/WebGroupTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\GroupType;
+use App\Models\User;
+
+class WebGroupTypeTest extends TestCase
+{
+    /** @test */
+    public function testAdminCanCreateGroupType()
+    {
+        $admin = factory(User::class, 'admin')->make();
+
+        $name = $this->faker->sentence;
+
+        $responseOne = $this->actingAs($admin, 'web')->post('/group-types', [
+            'name' => $name,
+            'filter_by_location' => true,
+        ]);
+
+        $responseOne->assertRedirect();
+
+        $this->assertMysqlDatabaseHas('group_types', [
+            'name' => $name,
+            'filter_by_location' => 1,
+        ]);
+    }
+
+    /** @test */
+    public function testAdminCannotCreateDuplicateGroupType()
+    {
+        $admin = factory(User::class, 'admin')->make();
+
+        $groupType = factory(GroupType::class)->create();
+
+        $response = $this->actingAs($admin, 'web')->post('/group-types', [
+            'name' => $groupType->name,
+        ]);
+
+        $response->assertSessionHasErrors();
+    }
+
+    /** @test */
+    public function testStaffCannotCreateGroupType()
+    {
+        $staff = factory(User::class, 'staff')->make();
+
+        $name = $this->faker->sentence;
+
+        $response = $this->actingAs($staff, 'web')->post('/group-types', [
+            'name' => $name,
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseMissing(
+            'group_types',
+            [
+                'name' => $name,
+            ],
+            'mysql',
+        );
+    }
+
+    /** @test */
+    public function testUnsettingFilterByState()
+    {
+        $admin = factory(User::class, 'admin')->make();
+
+        $groupType = factory(GroupType::class)->create([
+            'filter_by_location' => true,
+        ]);
+
+        $response = $this->actingAs($admin, 'web')->put(
+            '/group-types' . '/' . $groupType->id,
+            ['name' => 'Test 123'],
+        );
+
+        $response->assertRedirect();
+
+        $this->assertMysqlDatabaseHas('group_types', [
+            'id' => $groupType->id,
+            'filter_by_location' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request enables `v3/group-types` API routes and `/group-types` Web routes in Northstar 🎉

All the business logic was already copied over from Rogue, so this pull request just worked on getting the tests for these routes working again! ✅ 


### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #176851325](https://www.pivotaltracker.com/story/show/176851325).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
