### PR TITLE
Add 'v3/posts/{post}/tags' route.

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -34,9 +34,10 @@ class TagsController extends ActivityApiController
         $this->transformer = new PostTransformer();
 
         $this->middleware('auth:api');
+
         $this->middleware('role:admin,staff');
-        $this->middleware('scopes:write');
-        $this->middleware('scopes:activity');
+        $this->middleware('scope:write');
+        $this->middleware('scope:activity');
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,9 @@ Route::group(
         Route::post('posts/{post}/reactions', 'ReactionController@store');
         Route::get('posts/{post}/reactions', 'ReactionController@index');
 
+        // Posts: Tags
+        Route::post('posts/{post}/tags', 'TagsController@store');
+
         // Signups
         Route::post('signups', 'SignupsController@store');
         Route::get('signups', 'SignupsController@index');

--- a/tests/Http/TagsTest.php
+++ b/tests/Http/TagsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use App\Models\Post;
+
+class TagsTest extends TestCase
+{
+    /**
+     * Test that a POST request to /tags updates the post's tags and
+     * creates a new event and tagged entry.
+     *
+     * POST /v3/posts/:post_id/tag
+     * @return void
+     */
+    public function testTaggingAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->asAdminUser()->postJson(
+            'api/v3/posts/' . $post->id . '/tags',
+            [
+                'tag_name' => 'Good Submission',
+            ],
+        );
+
+        $response->assertOk();
+
+        // Make sure that the post's tags are updated.
+        $this->assertContains('Good Submission', $post->tagNames());
+    }
+
+    /**
+     * Test that a POST request to /tags updates the post's tags.
+     *
+     * POST /v3/posts/:post_id/tag
+     * @return void
+     */
+    public function testUntaggingAPost()
+    {
+        $post = factory(Post::class)->create();
+        $post->tag('Good Submission');
+
+        $response = $this->asAdminUser()->postJson(
+            'api/v3/posts/' . $post->id . '/tags',
+            [
+                'tag_name' => 'Good Submission',
+            ],
+        );
+
+        $response->assertOk();
+
+        $this->assertEmpty($post->fresh()->tagNames());
+    }
+
+    /**
+     * Test that a non-admin cannot tag a post.
+     *
+     * POST /v3/posts/:post_id/tag
+     * @return void
+     */
+    public function testNormalUserCannotTagAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->asUser($post->user)->postJson(
+            'api/v3/posts/' . $post->id . '/tags',
+            [
+                'tag_name' => 'Good Submission',
+            ],
+        );
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test that a guest cannot tag a post.
+     *
+     * POST /v3/posts/:post_id/tag
+     * @return void
+     */
+    public function testUnauthenticatedUserCannotTagAPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->postJson('api/v3/posts/' . $post->id . '/tags', [
+            'tag_name' => 'Good Submission',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test deleting one tag on a post only deletes that tag.
+     *
+     * POST /posts/:post_id/tag
+     * @return void
+     */
+    public function testAddMultipleTagsAndDeleteOne()
+    {
+        $post = factory(Post::class)->create();
+
+        $post->tag('Good Submission');
+        $post->tag('Tag To Delete');
+
+        $response = $this->asAdminUser()->postJson(
+            'api/v3/posts/' . $post->id . '/tags',
+            [
+                'tag_name' => 'Tag To Delete',
+            ],
+        );
+
+        $response->assertOk();
+
+        $this->assertContains('Good Submission', $post->fresh()->tagNames());
+        $this->assertNotContains('Tag To Delete', $post->fresh()->tagNames());
+    }
+
+    /**
+     * Test post updated_at is updated when a new tag is applied to it.
+     *
+     * @return void
+     */
+    public function testPostTimestampUpdatedWhenTagAdded()
+    {
+        $post = factory(Post::class)->create([
+            'created_at' => '2017-09-15 12:01:00',
+            'updated_at' => '2017-09-15 12:01:00',
+        ]);
+
+        $this->mockTime('2018-10-21 13:05:00');
+
+        $this->asAdminUser()->postJson('api/v3/posts/' . $post->id . '/tags', [
+            'tag_name' => 'Good Submission',
+        ]);
+
+        $this->assertMysqlDatabaseHas('posts', [
+            'id' => $post->id,
+            'updated_at' => '2018-10-21 13:05:00',
+        ]);
+    }
+
+    /**
+     * Test withoutTag scope.
+     *
+     * @return void
+     */
+    public function testWithoutTagScope()
+    {
+        // Create the models that we will be using
+        $posts = factory(Post::class, 20)->create();
+
+        // Later, apply the tag to the post
+        $this->asAdminUser()->postJson(
+            'api/v3/posts/' . $posts->first()->id . '/tags',
+            [
+                'tag_name' => 'get-outta-here',
+            ],
+        );
+
+        $postsQuery = Post::withoutTag('get-outta-here')->get();
+
+        $this->assertEquals(19, $postsQuery->count());
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds Rogue's `v3/posts/{post}/tags` route & tests to this application.

### How should this be reviewed?

👀

### Any background context you want to provide?

🏷️

### Relevant tickets

References [Pivotal #176851337](https://www.pivotaltracker.com/story/show/176851337).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
