### PR TITLE
Enable Club routes in Northstar

### DIFF
--- a/app/Http/Controllers/Web/ClubsController.php
+++ b/app/Http/Controllers/Web/ClubsController.php
@@ -14,7 +14,7 @@ class ClubsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth:web');
         $this->middleware('role:admin,staff');
 
         $this->rules = [
@@ -43,7 +43,7 @@ class ClubsController extends Controller
         $this->validate(
             $request,
             array_merge_recursive($this->rules, [
-                'leader_id' => 'required|objectid|unique:clubs',
+                'leader_id' => 'required|objectid|unique:mysql.clubs',
             ]),
         );
 
@@ -84,7 +84,7 @@ class ClubsController extends Controller
                 'leader_id' => [
                     'required',
                     'objectid',
-                    Rule::unique('clubs')->ignore($club),
+                    Rule::unique('mysql.clubs')->ignore($club),
                 ],
             ]),
         );

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,10 @@ Route::group(
         Route::get('campaigns/{campaign}', 'CampaignsController@show');
         Route::patch('campaigns/{campaign}', 'CampaignsController@update');
 
+        // Clubs
+        Route::get('clubs', 'ClubsController@index');
+        Route::get('clubs/{club}', 'ClubsController@show');
+
         // Groups
         Route::get('groups', 'GroupsController@index');
         Route::get('groups/{group}', 'GroupsController@show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,11 @@ Route::resource('campaigns', 'CampaignsController', [
     'except' => ['index', 'show'],
 ]);
 
+// Clubs
+Route::resource('clubs', 'ClubsController', [
+    'except' => ['index', 'show', 'destroy'],
+]);
+
 // Facebook Continue
 Route::get('facebook/continue', 'FacebookController@redirectToProvider');
 Route::get('facebook/verify', 'FacebookController@handleProviderCallback');

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\Club;
+
+class ClubTest extends TestCase
+{
+    /**
+     * Test that a GET request to /api/v3/clubs returns an index of all clubs.
+     *
+     * @return void
+     */
+    public function testClubIndex()
+    {
+        factory(Club::class, 5)->create();
+
+        $response = $this->getJson('/api/v3/clubs');
+
+        $response->assertOk();
+        $response->assertJsonPath('meta.pagination.count', 5);
+    }
+
+    /**
+     * Test that we can filter clubs by name.
+     * GET /api/v3/campaigns.
+     * @return void
+     */
+    public function testClubIndexNameFilter()
+    {
+        $clubNames = [
+            'Batman Begins',
+            'Bipartisan',
+            'Brave New World',
+            'If I Never Knew You',
+            'San Dimas High School',
+            'Santa Claus',
+        ];
+
+        foreach ($clubNames as $clubName) {
+            factory(Club::class)->create([
+                'name' => $clubName,
+            ]);
+        }
+
+        $responseOne = $this->getJson('/api/v3/clubs?filter[name]=new');
+
+        $responseOne->assertOk();
+        $responseOne->assertJsonPath('meta.pagination.count', 2);
+
+        $responseTwo = $this->getJson('/api/v3/clubs?filter[name]=san');
+
+        $responseTwo->assertOk();
+        $responseTwo->assertJsonPath('meta.pagination.count', 3);
+    }
+
+    /**
+     * Test that we can paginate clubs using 'after' cursor.
+     * GET /api/v3/campaigns.
+     * @return void
+     */
+    public function testClubIndexAfterCursor()
+    {
+        $clubOne = factory(Club::class)->create();
+        $clubTwo = factory(Club::class)->create();
+
+        $response = $this->getJson(
+            '/api/v3/clubs?cursor[after]=' . $clubOne->getCursor(),
+        );
+
+        $response->assertOk();
+        $response->assertJsonPath('meta.cursor.count', 1);
+        $response->assertJsonPath('data.0.id', $clubTwo->id);
+    }
+
+    /**
+     * Test that a GET request to /api/v3/clubs/:id returns the intended club.
+     *
+     * @return void
+     */
+    public function testClubShow()
+    {
+        factory(Club::class, 5)->create();
+
+        // Create a specific club to search for.
+        $club = factory(Club::class)->create();
+
+        $response = $this->getJson('api/v3/clubs/' . $club->id);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $club->id);
+    }
+}

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -62,9 +62,9 @@ class ClubTest extends TestCase
         $clubOne = factory(Club::class)->create();
         $clubTwo = factory(Club::class)->create();
 
-        $response = $this->getJson(
-            '/api/v3/clubs?cursor[after]=' . $clubOne->getCursor(),
-        );
+        $cursor = $clubOne->getCursor();
+
+        $response = $this->getJson("/api/v3/clubs?cursor[after]=$cursor");
 
         $response->assertOk();
         $response->assertJsonPath('meta.cursor.count', 1);
@@ -83,7 +83,7 @@ class ClubTest extends TestCase
         // Create a specific club to search for.
         $club = factory(Club::class)->create();
 
-        $response = $this->getJson('/api/v3/clubs/' . $club->id);
+        $response = $this->getJson("/api/v3/clubs/$club->id");
 
         $response->assertOk();
         $response->assertJsonPath('data.id', $club->id);

--- a/tests/Http/ClubTest.php
+++ b/tests/Http/ClubTest.php
@@ -83,7 +83,7 @@ class ClubTest extends TestCase
         // Create a specific club to search for.
         $club = factory(Club::class)->create();
 
-        $response = $this->getJson('api/v3/clubs/' . $club->id);
+        $response = $this->getJson('/api/v3/clubs/' . $club->id);
 
         $response->assertOk();
         $response->assertJsonPath('data.id', $club->id);

--- a/tests/Http/Web/WebClubTest.php
+++ b/tests/Http/Web/WebClubTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use App\Models\Club;
+use App\Models\User;
+
+class ClubTest extends TestCase
+{
+    /**
+     * Test that admin can create a new club.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testAdminCanCreateClub()
+    {
+        $admin = factory(User::class, 'admin')->create();
+
+        $name = $this->faker->sentence;
+
+        $leaderId = factory(User::class)->create()->id;
+
+        $response = $this->actingAs($admin, 'web')->post('/clubs', [
+            'name' => $name,
+            'leader_id' => $leaderId,
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertMysqlDatabaseHas('clubs', [
+            'name' => $name,
+            'leader_id' => $leaderId,
+        ]);
+    }
+
+    /**
+     * Test that staff can create a new club.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testStaffCanCreateClub()
+    {
+        $staff = factory(User::class, 'staff')->create();
+
+        $name = $this->faker->sentence;
+
+        $leaderId = factory(User::class)->create()->id;
+
+        $response = $this->actingAs($staff, 'web')->post('/clubs', [
+            'name' => $name,
+            'leader_id' => $leaderId,
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertMysqlDatabaseHas('clubs', [
+            'name' => $name,
+            'leader_id' => $leaderId,
+        ]);
+    }
+
+    /**
+     * Test validation for creating a club.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testCreatingAClubWithValidationErrors()
+    {
+        $admin = factory(User::class, 'admin')->create();
+
+        $response = $this->actingAs($admin, 'web')->post('/clubs', [
+            'city' => 789, // This should be a string.
+            'name' => 123, // This should be a string.
+            'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.
+            'location' => 'wakanda', // This should be an iso3166 string.
+            'school_id' => 101112, // This should be a string.
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors([
+            'city',
+            'name',
+            'leader_id',
+            'location',
+            'school_id',
+        ]);
+    }
+
+    /**
+     * Test validation for creating a club with a duplicate leader_id.
+     *
+     * POST /clubs
+     * @return void
+     */
+    public function testCreatingAClubWithDuplicateLeaderId()
+    {
+        $this->markTestSkipped();
+
+        $admin = factory(User::class, 'admin')->create();
+
+        $club = factory(Club::class)->create();
+
+        $response = $this->actingAs($admin, 'web')->post('/clubs', [
+            'name' => $this->faker->company,
+            'leader_id' => $club->leaderId,
+        ]);
+
+        $response->assertJsonValidationErrors(['leader_id']);
+    }
+
+    /**
+     * Test for updating a club successfully.
+     *
+     * PATCH /clubs/:id
+     * @return void
+     */
+    public function testUpdatingAClub()
+    {
+        $this->faker->addProvider(new FakerNorthstarId($this->faker));
+        $this->faker->addProvider(new FakerSchoolId($this->faker));
+
+        $admin = factory(User::class, 'admin')->create();
+
+        $club = factory(Club::class)->create();
+
+        $name = $this->faker->company;
+
+        $leaderId = $this->faker->unique()->northstar_id;
+        // $leaderId = factory(User::class)->create()->id; // @TODO: which is better?
+
+        $location = 'US-' . $this->faker->stateAbbr;
+
+        $city = $this->faker->city;
+
+        $schooolId = $this->faker->school->school_id;
+
+        $response = $this->actingAs($admin, 'web')->patch(
+            '/clubs' . '/' . $club->id,
+            [
+                'name' => $name,
+                'leader_id' => $leaderId,
+                'location' => $location,
+                'city' => $city,
+                'school_id' => $schooolId,
+            ],
+        );
+
+        $response->assertRedirect();
+
+        // Make sure that the club's updated attributes are persisted in the database.
+        $this->assertEquals($club->fresh()->name, $name);
+        $this->assertEquals($club->fresh()->leader_id, $leaderId);
+        $this->assertEquals($club->fresh()->location, $location);
+        $this->assertEquals($club->fresh()->city, $city);
+        $this->assertEquals($club->fresh()->school_id, $schooolId);
+    }
+
+    /**
+     * Test for updating a club without changing the leader_id successfully.
+     *
+     * PATCH /clubs/:id
+     * @return void
+     */
+    public function testUpdatingAClubWithoutChangingTheLeaderId()
+    {
+        $this->markTestSkipped();
+
+        $admin = factory(User::class, 'admin')->create();
+
+        $club = factory(Club::class)->create();
+
+        $name = $this->faker->company;
+
+        $response = $this->actingAs($admin, 'web')->patchJson(
+            'clubs/' . $club->id,
+            [
+                'name' => $name,
+                'leader_id' => $club->leader_id,
+            ],
+        );
+
+        $response->assertStatus(302);
+
+        // Make sure that the club's updated attributes are persisted in the database.
+        $this->assertEquals($club->fresh()->name, $name);
+        $this->assertEquals($club->fresh()->leader_id, $club->leader_id);
+    }
+
+    /**
+     * test validation for updating a club.
+     *
+     * PATCH /clubs/:id
+     * @return void
+     */
+    public function testUpdatingAClubWithValidationErrors()
+    {
+        $this->markTestSkipped();
+
+        $admin = factory(User::class, 'admin')->create();
+
+        $club = factory(Club::class)->create();
+
+        $this->actingAs($admin, 'web')
+            ->patchJson('clubs/' . $club->id, [
+                'name' => 123, // This should be a string.
+                'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.
+                'location' => 'wakanda', // This should be an iso3166 string.
+                'city' => 789, // This should be a string.
+                'school_id' => 101112, // This should be a string.
+            ])
+            ->assertJsonValidationErrors([
+                'name',
+                'leader_id',
+                'location',
+                'city',
+                'school_id',
+            ]);
+    }
+}

--- a/tests/Http/Web/WebClubTest.php
+++ b/tests/Http/Web/WebClubTest.php
@@ -167,7 +167,7 @@ class ClubTest extends TestCase
         $name = $this->faker->company;
 
         $response = $this->actingAs($admin, 'web')->patch(
-            'clubs/' . $club->id,
+            '/clubs' . '/' . $club->id,
             [
                 'name' => $name,
                 'leader_id' => $club->leader_id,
@@ -195,7 +195,7 @@ class ClubTest extends TestCase
         $club = factory(Club::class)->create();
 
         $response = $this->actingAs($admin, 'web')->patch(
-            'clubs/' . $club->id,
+            '/clubs' . '/' . $club->id,
             [
                 'name' => 123, // This should be a string.
                 'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.

--- a/tests/Http/Web/WebClubTest.php
+++ b/tests/Http/Web/WebClubTest.php
@@ -3,7 +3,7 @@
 use App\Models\Club;
 use App\Models\User;
 
-class ClubTest extends TestCase
+class WebClubTest extends TestCase
 {
     /**
      * Test that admin can create a new club.

--- a/tests/Http/Web/WebClubTest.php
+++ b/tests/Http/Web/WebClubTest.php
@@ -130,16 +130,13 @@ class WebClubTest extends TestCase
 
         $schooolId = $this->faker->school->school_id;
 
-        $response = $this->actingAs($admin, 'web')->patch(
-            '/clubs' . '/' . $club->id,
-            [
-                'name' => $name,
-                'leader_id' => $leaderId,
-                'location' => $location,
-                'city' => $city,
-                'school_id' => $schooolId,
-            ],
-        );
+        $response = $this->actingAs($admin, 'web')->patch("/clubs/$club->id", [
+            'name' => $name,
+            'leader_id' => $leaderId,
+            'location' => $location,
+            'city' => $city,
+            'school_id' => $schooolId,
+        ]);
 
         $response->assertRedirect();
 
@@ -166,13 +163,10 @@ class WebClubTest extends TestCase
 
         $name = $this->faker->company;
 
-        $response = $this->actingAs($admin, 'web')->patch(
-            '/clubs' . '/' . $club->id,
-            [
-                'name' => $name,
-                'leader_id' => $club->leader_id,
-            ],
-        );
+        $response = $this->actingAs($admin, 'web')->patch("/clubs/$club->id", [
+            'name' => $name,
+            'leader_id' => $club->leader_id,
+        ]);
 
         $response->assertRedirect();
 
@@ -194,16 +188,13 @@ class WebClubTest extends TestCase
 
         $club = factory(Club::class)->create();
 
-        $response = $this->actingAs($admin, 'web')->patch(
-            '/clubs' . '/' . $club->id,
-            [
-                'name' => 123, // This should be a string.
-                'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.
-                'location' => 'wakanda', // This should be an iso3166 string.
-                'city' => 789, // This should be a string.
-                'school_id' => 101112, // This should be a string.
-            ],
-        );
+        $response = $this->actingAs($admin, 'web')->patch("/clubs/$club->id", [
+            'name' => 123, // This should be a string.
+            'leader_id' => 'Maddy is the leader!', // This should be a MongoDB ObjectID.
+            'location' => 'wakanda', // This should be an iso3166 string.
+            'city' => 789, // This should be a string.
+            'school_id' => 101112, // This should be a string.
+        ]);
 
         $response->assertRedirect();
         $response->assertSessionHasErrors([


### PR DESCRIPTION
### What's this PR do?

This pull request enables `v3/clubs` API routes and `/clubs` Web routes in Northstar 🎉

All the business logic was already copied over from Rogue, so this pull request just worked on getting the tests for these routes working again! ✅ 


### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #176851324](https://www.pivotaltracker.com/story/show/176851324).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
