### PR TITLE
Add rotation, image, and original routes.

### DIFF
--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -40,13 +40,14 @@ class ReviewsController extends ActivityApiController
     }
 
     /**
-     * Update a post(s)'s status when reviewed.
+     * Create a new review.
      *
+     * @param Post $post
      * @param Request $request
      *
      * @return \Illuminate\Http\Response
      */
-    public function reviews(Request $request, Post $post)
+    public function store(Post $post, Request $request)
     {
         $request->validate([
             'status' => 'in:pending,accepted,rejected',

--- a/app/Http/Controllers/RotationController.php
+++ b/app/Http/Controllers/RotationController.php
@@ -7,7 +7,6 @@ use App\Models\Post;
 use App\Services\Fastly;
 use App\Services\ImageStorage;
 use Illuminate\Http\Request;
-use Storage;
 
 class RotationController extends Controller
 {
@@ -35,17 +34,14 @@ class RotationController extends Controller
      *
      * @param Filesystem $filesystem
      */
-    public function __construct(
-        Fastly $fastly,
-        ImageStorage $storage,
-        PostTransformer $transformer
-    ) {
+    public function __construct(Fastly $fastly, ImageStorage $storage)
+    {
         $this->fastly = $fastly;
         $this->storage = $storage;
-        $this->transformer = $transformer;
+        $this->transformer = new PostTransformer();
 
-        $this->middleware('auth', ['only' => 'update']);
-        $this->middleware('role:staff,admin', ['only' => 'update']);
+        $this->middleware('auth:api');
+        $this->middleware('role:staff,admin');
     }
 
     /**

--- a/app/Http/Controllers/Web/OriginalsController.php
+++ b/app/Http/Controllers/Web/OriginalsController.php
@@ -4,9 +4,8 @@ namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
 use App\Models\Post;
-use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Facades\Image;
-use Storage;
 
 class OriginalsController extends Controller
 {
@@ -15,17 +14,16 @@ class OriginalsController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth:web');
     }
 
     /**
      * Display the specified resource.
      *
      * @param  Post $post
-     * @param  Request $request
      * @return \Illuminate\Http\Response
      */
-    public function show(Post $post, Request $request)
+    public function show(Post $post)
     {
         $this->authorize('viewAll', $post);
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -336,7 +336,7 @@ class Post extends Model
     {
         $path = parse_url($this->url, PHP_URL_PATH);
 
-        // We store local URLs prefixed with `/storage` when using the "public" adapter.
+        // We store local URLs prefixed with `/storage` when using the "local" adapter.
         if (config('filesystems.default') == 'local') {
             return str_replace('/storage/', '', $path);
         }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -337,7 +337,7 @@ class Post extends Model
         $path = parse_url($this->url, PHP_URL_PATH);
 
         // We store local URLs prefixed with `/storage` when using the "public" adapter.
-        if (config('filesystems.default') == 'public') {
+        if (config('filesystems.default') == 'local') {
             return str_replace('/storage/', '', $path);
         }
 

--- a/app/Services/Fastly.php
+++ b/app/Services/Fastly.php
@@ -137,7 +137,7 @@ class Fastly extends RestApiClient
      */
     protected function purgeKey($cacheKey): void
     {
-        if (!$this->service) {
+        if (!$this->backendServiceId) {
             return;
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -129,6 +129,9 @@ Route::group(['prefix' => 'v1', 'as' => 'v1.'], function () {
     Route::post('profile', 'Legacy\ProfileController@update');
 });
 
+// Assets
+Route::get('images/{hash}', 'Web\ImagesController@show');
+
 // Discovery
 Route::group(['prefix' => '.well-known'], function () {
     Route::get('openid-configuration', 'DiscoveryController@index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,7 +47,7 @@ Route::group(
         Route::get('posts/{post}/reactions', 'ReactionController@index');
 
         // Posts: Reviews
-        Route::post('posts/{post}/reviews', 'ReviewsController@reviews');
+        Route::post('posts/{post}/reviews', 'ReviewsController@store');
 
         // Signups
         Route::post('signups', 'SignupsController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -49,6 +49,9 @@ Route::group(
         // Posts: Reviews
         Route::post('posts/{post}/reviews', 'ReviewsController@store');
 
+        // Posts: Rotate
+        Route::post('posts/{post}/rotate', 'RotationController@update');
+
         // Signups
         Route::post('signups', 'SignupsController@store');
         Route::get('signups', 'SignupsController@index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,6 +86,9 @@ Route::get('password/reset/{type}/{token}', [
 ]);
 Route::post('password/reset/{type}', 'ResetPasswordController@reset');
 
+// Originals
+Route::get('originals/{post}', 'OriginalsController@show');
+
 // Administration
 if (config('features.admin')) {
     Route::prefix('admin')

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -47,6 +47,9 @@ trait CreatesApplication
         $this->customerIoMock->shouldReceive('trackEvent');
         $this->customerIoMock->shouldReceive('sendEmail');
 
+        $this->fastlyMock = $this->mock(\App\Services\Fastly::class);
+        $this->fastlyMock->shouldReceive('purge');
+
         // Configure a mock for GraphQL calls.
         $this->graphqlMock = $this->mock(\App\Services\GraphQL::class);
         $this->graphqlMock->shouldReceive('getSchoolById')->andReturn([

--- a/tests/Http/RotationTest.php
+++ b/tests/Http/RotationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\Post;
+use App\Models\User;
+
+class RotationTest extends TestCase
+{
+    /**
+     * Test that an admin can view originals.
+     *
+     * @return void
+     */
+    public function testRotateImage()
+    {
+        $post = factory(Post::class)
+            ->states('photo')
+            ->create();
+
+        $response = $this->asAdminUser()->postJson(
+            '/api/v3/posts/' . $post->id . '/rotate',
+            ['degrees' => 90],
+        );
+
+        $response->assertSuccessful();
+
+        $this->fastlyMock->shouldHaveReceived('purge');
+    }
+
+    /**
+     * Test that normal users can't view others' originals.
+     *
+     * @return void
+     */
+    public function testRotateImageAsNonOwner()
+    {
+        $somebodyElse = factory(User::class)->create();
+
+        $post = factory(Post::class)
+            ->states('photo')
+            ->create();
+
+        $response = $this->asUser($somebodyElse)->postJson(
+            '/api/v3/posts/' . $post->id . '/rotate',
+            ['degrees' => 90],
+        );
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test that normal users can't view others' originals.
+     *
+     * @return void
+     */
+    public function testRotateImageAsAnonymousUser()
+    {
+        $post = factory(Post::class)
+            ->states('photo')
+            ->create();
+
+        $response = $this->postJson('/api/v3/posts/' . $post->id . '/rotate', [
+            'degrees' => 90,
+        ]);
+
+        $response->assertUnauthorized();
+    }
+}

--- a/tests/Http/Web/ImagesTest.php
+++ b/tests/Http/Web/ImagesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Post;
+
+class ImagesTest extends TestCase
+{
+    /**
+     * Test for endpoint throttling.
+     *
+     * @return void
+     */
+    public function testImagesThrottle()
+    {
+        $posts = factory(Post::class, 3)
+            ->states('photo', 'accepted')
+            ->create();
+
+        for ($i = 0; $i < 60; $i++) {
+            $response = $this->getJson('images/' . $posts->random()->hash);
+            $response->assertStatus(200);
+        }
+
+        // Get a "Too Many Attempts" response when asking to render a 61st image. Since
+        // rendered images are cached in Fastly, this should be unlikely for real users!
+        $response = $this->getJson('images/' . $posts->random()->id);
+        $response->assertStatus(429);
+    }
+
+    /**
+     * Test that we allow cross-origin requests for images.
+     *
+     * @return void
+     */
+    public function testCorsWhitelist()
+    {
+        $post = factory(Post::class)
+            ->states('photo', 'accepted')
+            ->create();
+
+        $response = $this->getJson('images/' . $post->hash, [
+            'Origin' => 'www.dosomething.org',
+        ]);
+
+        $response->assertHeader(
+            'Access-Control-Allow-Origin',
+            'www.dosomething.org',
+        );
+    }
+}

--- a/tests/Http/Web/OriginalsTest.php
+++ b/tests/Http/Web/OriginalsTest.php
@@ -18,9 +18,10 @@ class OriginalsTest extends TestCase
             ->states('photo', 'accepted')
             ->create();
 
-        $this->be($admin, 'web');
+        $response = $this->actingAs($admin, 'web')->get(
+            'originals/' . $post->id,
+        );
 
-        $response = $this->get('originals/' . $post->id);
         $response->assertSuccessful();
     }
 
@@ -37,9 +38,10 @@ class OriginalsTest extends TestCase
             ->states('photo', 'accepted')
             ->create();
 
-        $this->be($somebodyElse, 'web');
+        $response = $this->actingAs($somebodyElse, 'web')->get(
+            'originals/' . $post->id,
+        );
 
-        $response = $this->get('originals/' . $post->id);
-        $response->assertStatus(302); // Redirect to 'register'.
+        $response->assertStatus(302); // TODO: This should show an error page rather than double-redirect.
     }
 }

--- a/tests/Http/Web/OriginalsTest.php
+++ b/tests/Http/Web/OriginalsTest.php
@@ -29,7 +29,7 @@ class OriginalsTest extends TestCase
      *
      * @return void
      */
-    public function test()
+    public function testGetOriginalImageAsNonOwner()
     {
         $somebodyElse = factory(User::class)->create();
 

--- a/tests/Http/Web/OriginalsTest.php
+++ b/tests/Http/Web/OriginalsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Post;
+use App\Models\User;
+
+class OriginalsTest extends TestCase
+{
+    /**
+     * Test that an admin can view originals.
+     *
+     * @return void
+     */
+    public function testGetOriginalImage()
+    {
+        $admin = factory(User::class, 'admin')->create();
+
+        $post = factory(Post::class)
+            ->states('photo', 'accepted')
+            ->create();
+
+        $this->be($admin, 'web');
+
+        $response = $this->get('originals/' . $post->id);
+        $response->assertSuccessful();
+    }
+
+    /**
+     * Test that normal users can't view others' originals.
+     *
+     * @return void
+     */
+    public function test()
+    {
+        $somebodyElse = factory(User::class)->create();
+
+        $post = factory(Post::class)
+            ->states('photo', 'accepted')
+            ->create();
+
+        $this->be($somebodyElse, 'web');
+
+        $response = $this->get('originals/' . $post->id);
+        $response->assertStatus(302); // Redirect to 'register'.
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `posts/{post}/rotate`, `images/{hash}` and `originals/{id}` routes.

### How should this be reviewed?

I made one fix to how we generate image paths in 4464b5d, since we use the `local` driver in this application (not `public`, as we used in Rogue). Since we don't actually expose this images via the public symlink, this better matches real usage.

Then, each route & associated tests are added in an individual commit: 21ce15a, 001b34b, 36e0ab3

Finally, I tweaked `ReviewsController` to be [resourceful](https://laravel.com/docs/8.x/controllers#actions-handled-by-resource-controller) in 2b7c832 (rather than using a non-standard method name).

### Any background context you want to provide?

We didn't have any tests for `originals/{id}` or `posts/{post}/rotate`, so I whipped up some simple coverage.

### Relevant tickets

References [Pivotal #176851335](https://www.pivotaltracker.com/story/show/176851335).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
