### PR TITLE
Adds promotions_muted_at User field

### DIFF
--- a/app/Http/Controllers/Web/Admin/PromotionsController.php
+++ b/app/Http/Controllers/Web/Admin/PromotionsController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Web\Admin;
+
+use App\Auth\Registrar;
+use App\Auth\Role;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class PromotionsController extends Controller
+{
+    /**
+     * Northstar's user registrar.
+     *
+     * @var Registrar
+     */
+    protected $registrar;
+
+    public function __construct(Registrar $registrar)
+    {
+        $this->registrar = $registrar;
+
+        $this->middleware('auth:web');
+        $this->middleware('role:admin,staff,intern');
+
+        $this->middleware('role:admin', ['only' => ['edit', 'update']]);
+    }
+
+    /**
+     * Mutes promotions for user.
+     *
+     * @param User $user
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(User $user)
+    {
+        $this->authorize('delete', $user);
+
+        logger('Muting promotions', ['user' => $user->id]);
+
+        $user->promotions_muted_at = Carbon::now();
+        $user->save();
+
+        return redirect()
+            ->route('admin.users.show', $user->id)
+            ->with('flash', 'Promotions muted for user. Shhh....');
+    }
+}

--- a/app/Http/Controllers/Web/Admin/PromotionsController.php
+++ b/app/Http/Controllers/Web/Admin/PromotionsController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Web\Admin;
 
-use App\Auth\Registrar;
 use App\Auth\Role;
 use App\Http\Controllers\Controller;
 use App\Models\User;
@@ -11,17 +10,8 @@ use Illuminate\Http\Request;
 
 class PromotionsController extends Controller
 {
-    /**
-     * Northstar's user registrar.
-     *
-     * @var Registrar
-     */
-    protected $registrar;
-
-    public function __construct(Registrar $registrar)
+    public function __construct()
     {
-        $this->registrar = $registrar;
-
         $this->middleware('auth:web');
         $this->middleware('role:admin,staff,intern');
 

--- a/app/Http/Controllers/Web/Admin/UserController.php
+++ b/app/Http/Controllers/Web/Admin/UserController.php
@@ -157,7 +157,7 @@ class UserController extends Controller
     }
 
     /**
-     * Mutes promotions for user
+     * Mutes promotions for user.
      *
      * @param User $user
      * @return \Illuminate\Http\Response

--- a/app/Http/Controllers/Web/Admin/UserController.php
+++ b/app/Http/Controllers/Web/Admin/UserController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Types\CauseInterestType;
 use App\Types\PasswordResetType;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 
 class UserController extends Controller
@@ -153,5 +154,25 @@ class UserController extends Controller
         return redirect()
             ->route('admin.users.show', $user->id)
             ->with('flash', 'Sent ' . $type . ' email to user.');
+    }
+
+    /**
+     * Mutes promotions for user
+     *
+     * @param User $user
+     * @return \Illuminate\Http\Response
+     */
+    public function mutePromotions(User $user)
+    {
+        $this->authorize('delete', $user);
+
+        logger('Muting promotions', ['user' => $user->id]);
+
+        $user->promotions_muted_at = Carbon::now();
+        $user->save();
+
+        return redirect()
+            ->route('admin.users.show', $user->id)
+            ->with('flash', 'Promotions muted for user. Shhh....');
     }
 }

--- a/app/Http/Controllers/Web/Admin/UserController.php
+++ b/app/Http/Controllers/Web/Admin/UserController.php
@@ -155,24 +155,4 @@ class UserController extends Controller
             ->route('admin.users.show', $user->id)
             ->with('flash', 'Sent ' . $type . ' email to user.');
     }
-
-    /**
-     * Mutes promotions for user.
-     *
-     * @param User $user
-     * @return \Illuminate\Http\Response
-     */
-    public function mutePromotions(User $user)
-    {
-        $this->authorize('delete', $user);
-
-        logger('Muting promotions', ['user' => $user->id]);
-
-        $user->promotions_muted_at = Carbon::now();
-        $user->save();
-
-        return redirect()
-            ->route('admin.users.show', $user->id)
-            ->with('flash', 'Promotions muted for user. Shhh....');
-    }
 }

--- a/app/Http/Transformers/UserTransformer.php
+++ b/app/Http/Transformers/UserTransformer.php
@@ -136,6 +136,9 @@ class UserTransformer extends BaseTransformer
                 $user->last_authenticated_at,
             );
             $response['last_messaged_at'] = iso8601($user->last_messaged_at);
+            $response['promotions_muted_at'] = iso8601(
+                $user->promotions_muted_at,
+            );
         }
 
         $response['updated_at'] = iso8601($user->updated_at);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,6 +78,7 @@ use libphonenumber\PhoneNumberFormat;
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
  * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
+  * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been musted for this user
  * @property Carbon $created_at
  * @property Carbon $updated_at
  *
@@ -179,6 +180,7 @@ class User extends MongoModel implements
         'sms_status',
         'sms_paused',
         'last_messaged_at',
+        'promotions_muted_at',
         'feature_flags',
         'totp',
         'referrer_user_id',
@@ -255,6 +257,7 @@ class User extends MongoModel implements
         'last_accessed_at',
         'last_authenticated_at',
         'last_messaged_at',
+        'promotions_muted_at',
         self::UPDATED_AT,
         self::CREATED_AT,
     ];
@@ -429,6 +432,16 @@ class User extends MongoModel implements
     public function setLastMessagedAtAttribute($value)
     {
         $this->setArbitraryDateString('last_messaged_at', $value);
+    }
+
+    /**
+     * Mutator for setting the promotions_muted_at field.
+     *
+     * @param string|Carbon $value
+     */
+    public function setPromotionsMutedAtAttribute($value)
+    {
+        $this->setArbitraryDateString('promotions_muted_at', $value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,7 +78,7 @@ use libphonenumber\PhoneNumberFormat;
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
  * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
-  * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been musted for this user
+ * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been musted for this user
  * @property Carbon $created_at
  * @property Carbon $updated_at
  *

--- a/resources/views/admin/users/partials/danger-zone.blade.php
+++ b/resources/views/admin/users/partials/danger-zone.blade.php
@@ -27,8 +27,8 @@
     </div>
 
     <div class="danger-zone__block">
-        <form method="POST" action="{{ route('admin.users.mute-promotions', ['user' => $user->id]) }}">
-            {{ method_field('POST')}}
+        <form method="POST" action="{{ route('admin.users.promotions.destroy', ['user' => $user->id]) }}">
+            {{ method_field('DELETE')}}
             {{ csrf_field() }}
 
             <div class="form-item">  

--- a/resources/views/admin/users/partials/danger-zone.blade.php
+++ b/resources/views/admin/users/partials/danger-zone.blade.php
@@ -27,6 +27,25 @@
     </div>
 
     <div class="danger-zone__block">
+        <form method="POST" action="{{ route('admin.users.mute-promotions', ['user' => $user->id]) }}">
+            {{ method_field('POST')}}
+            {{ csrf_field() }}
+
+            <div class="form-item">  
+                <label for="mute-promotions" class="field-label">Mute Promotions</label>
+
+                <p class="footnote">This will delete the user's Customer.io profile.</p>
+            </div>
+
+            <div class="form-actions">
+                <button type="submit" class="button -secondary">
+                    Mute promotions
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <div class="danger-zone__block">
         <form method="POST" action="{{ route('admin.users.destroy', ['user' => $user->id]) }}">
             {{ method_field('DELETE')}}
             <div class="form-item">

--- a/resources/views/admin/users/partials/subscriptions.blade.php
+++ b/resources/views/admin/users/partials/subscriptions.blade.php
@@ -3,3 +3,4 @@
 <dt>SMS Subscription Topics:</dt><dd>{{ $user->sms_subscription_topics ? implode(",  ",$user->sms_subscription_topics) : '—'}}</dd>
 <dt>Email Subscription Status:</dt><dd>{{ $user->email_subscription_status ? '✔' : '✘' }}</dd>
 <dt>Email Subscription Topics:</dt><dd>{{ $user->email_subscription_topics ? implode(",  ",$user->email_subscription_topics) : '—'}}</dd>
+<dt>Promotions Muted At:</dt><dd>{{ $user->promotions_muted_at ? $user->promotions_muted_at->format('F d, Y g:ia') : '—'}}</dd>

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,6 +102,10 @@ if (config('features.admin')) {
                 'as' => 'users.resets.create',
                 'uses' => 'Admin\UserController@sendPasswordReset',
             ]);
+            Route::post('users/{user}/mute-promotions', [
+                'as' => 'users.mute-promotions',
+                'uses' => 'Admin\UserController@mutePromotions',
+            ]);
 
             // Fastly Redirects
             Route::resource('redirects', 'Admin\RedirectsController');

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,9 +102,9 @@ if (config('features.admin')) {
                 'as' => 'users.resets.create',
                 'uses' => 'Admin\UserController@sendPasswordReset',
             ]);
-            Route::post('users/{user}/mute-promotions', [
-                'as' => 'users.mute-promotions',
-                'uses' => 'Admin\UserController@mutePromotions',
+            Route::delete('users/{user}/promotions', [
+                'as' => 'users.promotions.destroy',
+                'uses' => 'Admin\PromotionsController@destroy',
             ]);
 
             // Fastly Redirects


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `promotions_muted_at` field to our User model and adds an admin form to set it to the current time (for testing). The next PR (#1124) will modify our User observer to delete the user's Customer.io profile if this field is set, but holding off that, for now, to hopefully keep this easy to review.

<img src="https://user-images.githubusercontent.com/1236811/107711198-1a6c9400-6c7c-11eb-8eaa-c9480fdc1545.png" width="500">

### How should this be reviewed?

👀 

### Any background context you want to provide?

It'd be sweet to get the `data-confirm` code from Aurora working in this app to ask the staff member to confirm before muting (or sending a password reset), but out of scope for this PR.

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
