### PR TITLE
Update potentially conflicting method name.

### DIFF
--- a/tests/Http/GroupTest.php
+++ b/tests/Http/GroupTest.php
@@ -10,7 +10,7 @@ class GroupTest extends TestCase
      *
      * @return void
      */
-    public function testGroupTypeIndex()
+    public function testGroupIndex()
     {
         $groupType = factory(GroupType::class)->create();
 
@@ -30,23 +30,23 @@ class GroupTest extends TestCase
             ]);
         }
 
-        $responseOne = $this->getJson('api/v3/groups');
+        $responseOne = $this->getJson('/api/v3/groups');
 
         $responseOne->assertOk();
         $responseOne->assertJsonPath('meta.pagination.count', 6);
 
-        $responseTwo = $this->getJson('api/v3/groups?filter[name]=new');
+        $responseTwo = $this->getJson('/api/v3/groups?filter[name]=new');
 
         $responseTwo->assertOk();
         $responseTwo->assertJsonPath('meta.pagination.count', 2);
 
-        $responseThree = $this->getJson('api/v3/groups?filter[name]=san');
+        $responseThree = $this->getJson('/api/v3/groups?filter[name]=san');
 
         $responseThree->assertOk();
         $responseThree->assertJsonPath('meta.pagination.count', 3);
 
         // Test for encoded special characters.
-        $response = $this->getJson('api/v3/groups?filter[name]=g%5C');
+        $response = $this->getJson('/api/v3/groups?filter[name]=g%5C');
 
         $response->assertOk();
         $response->assertJsonPath('meta.pagination.count', 0);
@@ -64,7 +64,7 @@ class GroupTest extends TestCase
         // Create a specific group type to search for.
         $group = factory(Group::class)->create();
 
-        $response = $this->getJson('api/v3/groups/' . $group->id);
+        $response = $this->getJson("/api/v3/groups/$group->id");
 
         $response->assertOk();
         $response->assertJsonPath('data.id', $group->id);


### PR DESCRIPTION
### What's this PR do?

This pull request does some path clean up but more importantly updates a potentially conflicting (but also incorrect) test method name called `testGroupTypeIndex()` to correct it to `testGroupIndex()` since it's part of the `GroupTest.php` class. 

There is a separate `GroupTypeTest.php` which has its correctly named `testGroupTypeIndex()`.

### How should this be reviewed?

👀 

### Any background context you want to provide?

[Pivotal ticket](https://www.pivotaltracker.com/story/show/176914617) has additional details regarding how this method name might conflict but not 100% sure. Hoping it resolves the "lock wait timeout exceeded" general error.

### Relevant tickets

References [Pivotal #176914617](https://www.pivotaltracker.com/story/show/176914617).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
