### PR TITLE
Mute/unmute promotions per subscription status changes

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -77,9 +77,11 @@ class UserObserver
             'email' => $user->email_subscription_status,
             'sms' => User::isSubscribedSmsStatus($user->sms_status),
         ];
-        // Initialize variables for tracking any subscription changes.
+        // Initialize variables to track any subscription changes.
         $isSubscribing = [
-            'email' => false,
+            // If topics have been updated with a non-zero count, user is subscribed.
+            'email' => isset($changed['email_subscription_topics']) &&
+            count($changed['email_subscription_topics']),
             'sms' => false,
         ];
         $isUnsubscribing = [
@@ -102,12 +104,8 @@ class UserObserver
              * Note: We intentionally do not auto-unsubscribe if we're updating topics with an empty array.
              * @see https://www.pivotaltracker.com/n/projects/2401401/stories/170599403/comments/211127349.
              */
-            isset($changed['email_subscription_topics']) &&
-            count($changed['email_subscription_topics']) &&
-            !$user->email_subscription_status
+            $isSubscribing['email'] && !$user->email_subscription_status
         ) {
-            $isSubscribing['email'] = true;
-
             $user->email_subscription_status = true;
         }
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -77,25 +77,22 @@ class UserObserver
             'email' => $user->email_subscription_status,
             'sms' => User::isSubscribedSmsStatus($user->sms_status),
         ];
-        // Initialize variables to track any subscription changes.
         $isSubscribing = [
-            // If topics have been updated with a non-zero count, user is subscribed.
+            // Users subscribe to email by selecting topics from their Subscriptions profile page.
             'email' => isset($changed['email_subscription_topics']) &&
             count($changed['email_subscription_topics']),
+            // Initialize as false for now (will get set later if subscribing to SMS).
             'sms' => false,
         ];
         $isUnsubscribing = [
-            'email' => false,
+            'email' => isset($changed['email_subscription_status']) &&
+            !$changed['email_subscription_status'],
+            // Initialize as false for now (will get set later if unsubscribing to SMS).
             'sms' => false,
         ];
 
         // If we're unsubscribing from email, clear all topics.
-        if (
-            isset($changed['email_subscription_status']) &&
-            !$changed['email_subscription_status']
-        ) {
-            $isUnsubscribing['email'] = true;
-
+        if ($isUnsubscribing['email']) {
             $user->email_subscription_topics = [];
         } elseif (
             /*

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -137,7 +137,7 @@ class UserObserver
             isset($user->promotions_muted_at) &&
             ($isSubscribing['sms'] || $isSubscribing['email'])
         ) {
-            // TODO: Send promotions_resubscribe event.
+            // TODO: Track a promotions_resubscribe event for the user.
             $user->promotions_muted_at = null;
         }
 

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -76,16 +76,6 @@ class CustomerIo
             return;
         }
 
-        // If this user had their profile deleted, unmute promotions to recreate it.
-        // TODO: Let's move this logic out of the Customer.io service and into the User model, or
-        // a job that handles the logic.
-        if (isset($user->promotions_muted_at)) {
-            // TODO: Addtionally, track a promotions_resubscribe event.
-            $user->promotions_muted_at = null;
-            // @see UserObserver@updating
-            $user->save();
-        }
-
         $response = $this->trackApiClient->post('customers/' . $user->id . '/events', [
             'json' => ['name' => $eventName, 'data' => $eventData],
         ]);

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -76,6 +76,16 @@ class CustomerIo
             return;
         }
 
+        // If this user had their profile deleted, unmute promotions to recreate it.
+        // TODO: Let's move this logic out of the Customer.io service and into the User model, or
+        // a job that handles the logic.
+        if (isset($user->promotions_muted_at)) {
+            // TODO: Addtionally, track a promotions_resubscribe event.
+            $user->promotions_muted_at = null;
+            // @see UserObserver@updating
+            $user->save();
+        }
+
         $response = $this->trackApiClient->post('customers/' . $user->id . '/events', [
             'json' => ['name' => $eventName, 'data' => $eventData],
         ]);

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -1,6 +1,8 @@
 # Customer.io
 
-We integrate with Customer.io to send transactional and promotional messaging to members.
+We integrate with Customer.io to send transactional and promotional messaging to DoSomething members.
+
+Historically, we've maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We're [currently working on changing this](https://www.pivotaltracker.com/epic/show/4721712) so that we only maintain profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
 
 ## Track API
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds logic to the `UserObserver` to delete a user's Customer.io profile if they've unsubscribed from all platforms (email and SMS), or recreates their profile if they've resubscribed to either platform. Fixes TODO from #1124. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

Luckily, there was already existing code in this observer that checks for subscribing or unsubscribing to each platform, which is used for updating the relevant subscription topics for each platform -- so this was fairly straightforward to add.

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
