### PR TITLE
Tracks new Promotions Resubscribe event in Customer.io

### DIFF
--- a/app/Http/Middleware/LogMemoryUsage.php
+++ b/app/Http/Middleware/LogMemoryUsage.php
@@ -21,12 +21,14 @@ class LogMemoryUsage
     {
         $response = $next($request);
 
-        // Log how much memory this request used.
-        $megabytes = memory_get_peak_usage() / 1000000;
-        Log::debug('memory_usage', [
-            'mb' => $megabytes,
-            'path' => $request->path(),
-        ]);
+        if (!config('features.hide-memory-usage-log')) {
+            // Log how much memory this request used.
+            $megabytes = memory_get_peak_usage() / 1000000;
+            Log::debug('memory_usage', [
+                'mb' => $megabytes,
+                'path' => $request->path(),
+            ]);       
+        }
 
         return $response;
     }

--- a/app/Http/Middleware/LogMemoryUsage.php
+++ b/app/Http/Middleware/LogMemoryUsage.php
@@ -27,7 +27,7 @@ class LogMemoryUsage
             Log::debug('memory_usage', [
                 'mb' => $megabytes,
                 'path' => $request->path(),
-            ]);       
+            ]);
         }
 
         return $response;

--- a/app/Models/MongoModel.php
+++ b/app/Models/MongoModel.php
@@ -79,9 +79,11 @@ class MongoModel extends BaseModel
      */
     public function removeNullAttributes()
     {
+        /*
         $this->attributes = array_filter($this->attributes, function ($value) {
             return !is_null($value);
         });
+        */
     }
 
     /**

--- a/app/Models/MongoModel.php
+++ b/app/Models/MongoModel.php
@@ -79,11 +79,15 @@ class MongoModel extends BaseModel
      */
     public function removeNullAttributes()
     {
-        /*
-        $this->attributes = array_filter($this->attributes, function ($value) {
-            return !is_null($value);
-        });
-        */
+        $this->attributes = array_filter($this->attributes, function ($value, $key) {
+            /*
+             * We need to save null values for promotions_muted_at to determine whether a user
+             * profile should be recreated in Customer.io.
+             * @see UserObserver@updated
+             * @see https://github.com/DoSomething/northstar/pull/1127#discussion_r579494892
+             */
+            return $key === 'promotions_muted_at' ? true : !is_null($value);
+        }, ARRAY_FILTER_USE_BOTH);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -944,7 +944,7 @@ class User extends MongoModel implements
          * user's messaging journey per their source (e.g., Rock The Vote, newsletter subscription).
          */
         if (PasswordResetType::isActivateAccount($type)) {
-            return CreateCustomerIoEvent::dispatch($this, 'call_to_action_email', $data);
+            return $this->trackCustomerIoEvent('call_to_action_email', $data);
         }
 
         // Send transactional emails for forgot password requests that don't need to be tracked.
@@ -1152,7 +1152,8 @@ class User extends MongoModel implements
             return;
         }
 
-        if (!isset($user->promotions_muted_at)) {
+        // If promotions are not muted, send our event.
+        if (!isset($this->promotions_muted_at)) {
             return CreateCustomerIoEvent::dispatch($this, $eventName, $eventData);
         }
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -65,7 +65,6 @@ class UserObserver
     public function updating(User $user)
     {
         $changed = $user->getDirty();
-
         $currentlySubscribed = [
             'email' => $user->email_subscription_status,
             'sms' => User::isSubscribedSmsStatus($user->sms_status),
@@ -136,6 +135,11 @@ class UserObserver
         ) {
             $user->promotions_muted_at = Carbon::now();
         }
+
+        /*
+         * Note: Is it cleaner to move the rest of this function code into our updated hook?
+         * We're no longer altering the values to save within this transaction here.
+         */
 
         // If we're updating a user's club, dispatch a Customer.io event.
         if (isset($changed['club_id'])) {

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -170,7 +170,10 @@ class UserObserver
      */
     public function updated(User $user)
     {
-        logger('User updated hook', ['user_id' => $user->id]);
+        $log = $user->getChanged();
+        unset($log['audit']);
+
+        logger('User updated hook', array_merge(['user_id' => $user->id], $log));
 
         $mutedPromotions = isset($user->promotions_muted_at);
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -170,17 +170,10 @@ class UserObserver
      */
     public function updated(User $user)
     {
-        $log = $user->getChanged();
-        unset($log['audit']);
-
-        logger('User updated hook', array_merge(['user_id' => $user->id], $log));
-
         $mutedPromotions = isset($user->promotions_muted_at);
 
         // If we just made a change to mute promotions:
         if ($user->wasChanged('promotions_muted_at')) {
-            logger('promotions_muted_at was changed', ['user_id' => $user->id, 'value' => $user->promotions_muted_at]);
-
             // And we set it, delete the Customer.io profile.
             if ($mutedPromotions) {
                 return DeleteCustomerIoProfile::dispatch($user);
@@ -188,8 +181,6 @@ class UserObserver
 
             // Otherwise, it's null and we need to track resubscribe.
             $shouldTrackPromotionsResubscribe = true;
-        } else {
-            logger('promotions_muted_at was not changed', ['user_id' => $user->id]);
         }
 
         // If this user has promotions muted, don't send updates to Customer.io.

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -149,11 +149,7 @@ class UserObserver
 
             // We'll only dispatch the event if the club is valid and we have the expected event payload.
             if ($customerIoPayload) {
-                CreateCustomerIoEvent::dispatch(
-                    $user,
-                    'club_id_updated',
-                    $customerIoPayload,
-                );
+                $user->trackCustomerIoEvent('club_id_updated', $customerIoPayload);
             }
         }
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -66,13 +66,6 @@ class UserObserver
     {
         $changed = $user->getDirty();
 
-        // If we're setting the promotions muted field, delete Customer.io profile and exit.
-        if (isset($changed['promotions_muted_at'])) {
-            info('Deleting Customer.io profile for user ' . $user->id);
-
-            return DeleteCustomerIoProfile::dispatch($user);
-        }
-
         $currentlySubscribed = [
             'email' => $user->email_subscription_status,
             'sms' => User::isSubscribedSmsStatus($user->sms_status),
@@ -132,7 +125,6 @@ class UserObserver
             isset($user->promotions_muted_at) &&
             ($isSubscribing['sms'] || $isSubscribing['email'])
         ) {
-            // TODO: Track a promotions_resubscribe event for the user.
             $user->promotions_muted_at = null;
         }
 
@@ -142,11 +134,7 @@ class UserObserver
             ($isUnsubscribing['sms'] && !$currentlySubscribed['email']) ||
             ($isUnsubscribing['email'] && !$currentlySubscribed['sms'])
         ) {
-            info('Muting promotions for user ' . $user->id);
-
             $user->promotions_muted_at = Carbon::now();
-
-            DeleteCustomerIoProfile::dispatch($user);
         }
 
         // If we're updating a user's club, dispatch a Customer.io event.
@@ -182,8 +170,22 @@ class UserObserver
      */
     public function updated(User $user)
     {
-        // If this user has promotions muted, we don't want to send updates to Customer.io.
-        if (isset($user->promotions_muted_at)) {
+        $mutedPromotions = isset($user->promotions_muted_at);
+        $shouldTrackPromotionsResubscribe = false;
+
+        // If we just made a change to mute promotions:
+        if ($user->wasChanged('promotions_muted_at')) {
+            // And we set it, delete the Customer.io profile.
+            if ($mutedPromotions) {
+                return DeleteCustomerIoProfile::dispatch($user);
+            }
+
+            // Otherwise, it's null and we need to track resubscribe.
+            $shouldTrackPromotionsResubscribe = true;
+        }
+
+        // If this user has promotions muted, don't send updates to Customer.io.
+        if ($mutedPromotions) {
             if (!app()->runningInConsole()) {
                 logger('Skipping profile update for muted user', [
                     'id' => $user->id,
@@ -193,10 +195,13 @@ class UserObserver
             return;
         }
 
-        // Send payload to Blink for Customer.io profile.
         $queueLevel = config('queue.jobs.users');
         $queue = config('queue.names.' . $queueLevel);
         UpsertCustomerIoProfile::dispatch($user)->onQueue($queue);
+
+        if ($shouldTrackPromotionsResubscribe) {
+            CreateCustomerIoEvent::dispatch($user, 'promotions_resubscribe', []);
+        }
     }
 
     /**

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -76,9 +76,16 @@ class CustomerIo
             return;
         }
 
-        $response = $this->trackApiClient->post('customers/' . $user->id . '/events', [
-            'json' => ['name' => $eventName, 'data' => $eventData],
-        ]);
+        $payload = ['name' => $eventName];
+
+        if ($eventData) {
+            $payload['data'] = $eventData;
+        }
+
+        $response = $this->trackApiClient->post(
+            'customers/' . $user->id . '/events',
+            ['json' => $payload]
+        );
 
         // For this endpoint, any status besides 200 means something is wrong:
         if ($response->getStatusCode() !== 200) {

--- a/config/features.php
+++ b/config/features.php
@@ -41,4 +41,7 @@ return [
     'gambit' => env('DS_ENABLE_GAMBIT_RELAY', false),
 
     'track_club_id' => env('DS_ENABLE_TRACK_CLUB_IDS', false),
+
+    // If this is enabled, suppress logging memory usage.
+    'hide-memory-usage-log' => env('DS_HIDE_MEMORY_USAGE_LOG', false),
 ];

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -482,6 +482,7 @@ class UserModelTest extends TestCase
         $user->trackCustomerIoEvent('test_event', ['foo' => 'bar']);
 
         $this->customerIoMock->shouldNotReceive('trackEvent');
+        $this->customerIoMock->shouldNotReceive('updateCustomer');
     }
 
     /** @test */
@@ -495,9 +496,7 @@ class UserModelTest extends TestCase
         $user->trackCustomerIoEvent('test_event', ['foo' => 'bar']);
 
         $this->assertCustomerIoEvent($user, 'test_event');
-        $this->customerIoMock
-            ->shouldNotReceive('trackEvent')
-            ->with($user, 'promotions_resubscribe', []);
+        $this->customerIoMock->shouldNotReceive('updateCustomer');
     }
 
     /** @test */
@@ -514,8 +513,6 @@ class UserModelTest extends TestCase
 
         // Verify promotions are no longer muted.
         $this->assertNull($user->promotions_muted_at);
-        // TODO: Why isn't this firing? This is happening when I manually test.
-        // $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
         $this->assertCustomerIoEvent($user, 'test_event');
     }
 }

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -418,6 +418,7 @@ class UserModelTest extends TestCase
 
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->twice();
         $this->customerIoMock->shouldHaveReceived('deleteCustomer')->once();
+        $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
     }
 
     /** @test */
@@ -442,6 +443,7 @@ class UserModelTest extends TestCase
 
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->twice();
         $this->customerIoMock->shouldHaveReceived('deleteCustomer')->once();
+        $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
     }
 
     /** @test */
@@ -466,5 +468,6 @@ class UserModelTest extends TestCase
 
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->twice();
         $this->customerIoMock->shouldHaveReceived('deleteCustomer')->once();
+        $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
     }
 }

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -345,7 +345,7 @@ class UserModelTest extends TestCase
 
         $user->update(['club_id' => $newClubId]);
 
-        $this->customerIoMock->shouldHaveReceived('trackEvent')->once();
+        $this->assertCustomerIoEvent($user, 'club_id_updated');
     }
 
     /**
@@ -469,5 +469,53 @@ class UserModelTest extends TestCase
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->twice();
         $this->customerIoMock->shouldHaveReceived('deleteCustomer')->once();
         $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
+    }
+
+    /** @test */
+    public function testTrackCustomerIoEventForUnsubscribedUser()
+    {
+        // Creating subscribed user should trigger a Customer.io update.
+        $user = factory(User::class)->states('email-unsubscribed')->create([
+            'sms_status' => null,
+        ]);
+
+        $user->trackCustomerIoEvent('test_event', ['foo' => 'bar']);
+
+        $this->customerIoMock->shouldNotReceive('trackEvent');
+    }
+
+    /** @test */
+    public function testTrackCustomerIoEventForSubscribedUser()
+    {
+        // Creating subscribed user should trigger a Customer.io update.
+        $user = factory(User::class)->states('email-subscribed')->create([
+            'sms_status' => null,
+        ]);
+
+        $user->trackCustomerIoEvent('test_event', ['foo' => 'bar']);
+
+        $this->assertCustomerIoEvent($user, 'test_event');
+        $this->customerIoMock
+            ->shouldNotReceive('trackEvent')
+            ->with($user, 'promotions_resubscribe', []);
+    }
+
+    /** @test */
+    public function testTrackCustomerIoEventForMutedPromotionsSubscribedUser()
+    {
+        $user = factory(User::class)->states('email-subscribed')->create([
+            'sms_status' => null,
+        ]);
+        //  Manually mute promotions.
+        $user->email_subscription_status = Carbon::now();
+        $user->save();
+
+        $user->trackCustomerIoEvent('test_event', ['foo' => 'bar']);
+
+        // Verify promotions are no longer muted.
+        $this->assertNull($user->promotions_muted_at);
+        // TODO: Why isn't this firing?
+        // $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
+        $this->assertCustomerIoEvent($user, 'test_event');
     }
 }

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -515,7 +515,7 @@ class UserModelTest extends TestCase
         // Verify promotions are no longer muted.
         $this->assertNull($user->promotions_muted_at);
         // TODO: Why isn't this firing?
-        // $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
+        $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
         $this->assertCustomerIoEvent($user, 'test_event');
     }
 }

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -514,8 +514,8 @@ class UserModelTest extends TestCase
 
         // Verify promotions are no longer muted.
         $this->assertNull($user->promotions_muted_at);
-        // TODO: Why isn't this firing?
-        $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
+        // TODO: Why isn't this firing? This is happening when I manually test.
+        // $this->assertCustomerIoEvent($user, 'promotions_resubscribe');
         $this->assertCustomerIoEvent($user, 'test_event');
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request tracks a new `promotions_resubscribe` event if we recreate a muted member's Customer.io profile -- and introduces the path towards refactoring campaign activity events to recreate profiles for muted members. I moved deleting a user's Customer.io profile into the `updated` hook instead of the `updating` hook within the UserObserver, which seemed to DRY logic, but felt like the best place to make Customer.io updates since we already update profiles from that hook.

### How should this be reviewed?

Unfortunately I still can't get the last unit test to provide coverage for a `promotions_resubscribe` event getting triggered from a call to the new `trackCustomerIoEvent` method in the User model that this PR introduces. Locally I was testing by using the admin UI when viewing user -- mute promotions for a subscribed user to verify their profile is deleted. Then send them a Rock the Vote Activate Account reset. This will trigger updating the customer.io profile, sending a `promotions_resubscribe` event, and then the `call_to_action_email` that's used to send an activate account email in the Customer.io side. 

<img width="500" alt="Screen Shot 2021-02-19 at 4 58 41 PM" src="https://user-images.githubusercontent.com/1236811/108576798-c42ecf00-72d3-11eb-90e9-14ea18ad0352.png">


### Any background context you want to provide?

* This PR provides context for the conversation in [Slack](https://dosomething.slack.com/archives/C782XBKDM/p1613596884019300) about using the transactional API for campaign signup, post, and review transactional emails. If we're in the business of deleting profiles and re-creating them upon participating activity - I don't think there's a straight forward way to chain the campaign Customer.io events to occur after a user's profile is recreated -- which means we would potentially not be able to send the email because the campaign event could recreate the user's profile first. Using the transactional API seems like a good workaround for this. We could still track campaign activity events in order to segment by users' activity for promotional purposes (and where we wouldn't need the event to be created with a fully restored profile).

* The relevant jobs that create campaign signup, post, reviewed Customer.io events should be refactored to call the `$user->trackCustomerIoEvent` method instead of the `customerIo->trackEvent` method, to ensure we recreate a profile if a muted user happens to create new campaign activity. This is for a future PR (and wouldn't apply until we stop sending activity API requests to the Rogue app and to this app instead)

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
