### PR TITLE
Use 'flash' to send reset messaging.

### DIFF
--- a/app/Http/Controllers/Web/ForgotPasswordController.php
+++ b/app/Http/Controllers/Web/ForgotPasswordController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+use Illuminate\Http\Request;
 
 class ForgotPasswordController extends Controller
 {
@@ -27,5 +28,17 @@ class ForgotPasswordController extends Controller
     {
         $this->middleware('guest');
         $this->middleware('throttle', ['only' => ['sendResetLinkEmail']]);
+    }
+
+    /**
+     * Get the response for a successful password reset link.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $response
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    protected function sendResetLinkResponse(Request $request, $response)
+    {
+        return back()->with('flash', trans($response));
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request fixes confirmation messaging on our password reset flow:

![Screen Shot 2021-02-22 at 11 18 13 AM](https://user-images.githubusercontent.com/583202/108736874-02103b00-7500-11eb-95c9-7455520cc9c5.png)

### How should this be reviewed?

👀

### Any background context you want to provide?

We updated the [template](https://github.com/DoSomething/northstar/blob/aa579060ba360e64e0595a0f18d298a9e0952066/resources/views/layouts/app.blade.php#L30-L32) where this is displayed to `flash` in #1126 for consistency with incoming Rogue admin views, but this usage was hidden away in a [trait](https://github.com/laravel/framework/blob/d5ffd8efdd04b11a2b1199cc7f2148337418191f/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php#L64-L74) bundled with the framework!

### Relevant tickets

References [Pivotal #177043554](https://www.pivotaltracker.com/story/show/177043554).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
