### PR TITLE
Makes User.promotions_muted_at property fillable

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -79,6 +79,7 @@ class Registrar
             'sms_paused' => 'boolean',
             'sms_subscription_topics.*' => 'in:general,voting',
             'last_messaged_at' => 'date',
+            'promotions_muted_at' => 'date',
             'email_subscription_status' => 'boolean',
             'email_subscription_topics.*' => Rule::in(
                 EmailSubscriptionTopicType::all(),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,7 +78,7 @@ use libphonenumber\PhoneNumberFormat;
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
  * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
- * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been musted for this user
+ * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been muted for this user
  * @property Carbon $created_at
  * @property Carbon $updated_at
  *

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -153,6 +153,9 @@ class User extends MongoModel implements
         'email_subscription_status',
         'email_subscription_topics',
 
+        // Promotions:
+        'promotions_muted_at',
+
         // Voting Method/Plan fields:
         'voting_method',
         'voting_plan_attending_with',

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -2,7 +2,7 @@
 
 We integrate with Customer.io to send transactional and promotional messaging to DoSomething members.
 
-Historically, we've maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We're [currently working on changing this](https://www.pivotaltracker.com/epic/show/4721712) so that we only maintain profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
+Historically, we've maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We're [currently working on changing this](https://www.pivotaltracker.com/epic/show/4721712) so that we only maintain profiles for active members who are subscribed to receive email and/or SMS promotional messaging. If a member's `promotions_muted_at` field is updated via API request, their corresponding Customer.io profile will be deleted. 
 
 ## Track API
 

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -403,6 +403,7 @@ PUT /v2/users/:user_id
   role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
+  promotions_muted_at: Date; // Used to delete the user's Customer.io profile.
 
   // Hidden fields (optional):
   race: String;

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1214,4 +1214,27 @@ class UserTest extends TestCase
             'sms_subscription_topics' => null,
         ]);
     }
+
+    /**
+     * Test that the promotions_muted_at field is editable for admins.
+     *
+     * @return void
+     */
+    public function testSettingPromotionsMutedAt()
+    {
+        $user = factory(User::class)->states('email-subscribed')->create();
+
+        $newTimestamp = '2021-11-02T18:42:00.000Z';
+
+        $response = $this->asAdminUser()->putJson('v2/users/' . $user->id, [
+            'promotions_muted_at' => $newTimestamp,
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertEquals(
+            '2021-11-02T18:42:00+00:00',
+            $user->fresh()->promotions_muted_at->toIso8601String(),
+        );
+    }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug in #1121 -- when I added the `promotions_muted_at` field, it wasn't editable via API request.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I wondered whether the additional test is kind of repetitive alongside a lot of the other tests, but at the same time -- I didn't catch this bug until trying to edit the field over in a new Chompy import.

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
