### PR TITLE
Revert "Makes User.promotions_muted_at property fillable"

### DIFF
--- a/app/Auth/Registrar.php
+++ b/app/Auth/Registrar.php
@@ -79,7 +79,6 @@ class Registrar
             'sms_paused' => 'boolean',
             'sms_subscription_topics.*' => 'in:general,voting',
             'last_messaged_at' => 'date',
-            'promotions_muted_at' => 'date',
             'email_subscription_status' => 'boolean',
             'email_subscription_topics.*' => Rule::in(
                 EmailSubscriptionTopicType::all(),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,7 +78,7 @@ use libphonenumber\PhoneNumberFormat;
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
  * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
- * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been muted for this user
+ * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been musted for this user
  * @property Carbon $created_at
  * @property Carbon $updated_at
  *
@@ -152,9 +152,6 @@ class User extends MongoModel implements
         // Email Subscription:
         'email_subscription_status',
         'email_subscription_topics',
-
-        // Promotions:
-        'promotions_muted_at',
 
         // Voting Method/Plan fields:
         'voting_method',

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -2,7 +2,7 @@
 
 We integrate with Customer.io to send transactional and promotional messaging to DoSomething members.
 
-Historically, we've maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We're [currently working on changing this](https://www.pivotaltracker.com/epic/show/4721712) so that we only maintain profiles for active members who are subscribed to receive email and/or SMS promotional messaging. If a member's `promotions_muted_at` field is updated via API request, their corresponding Customer.io profile will be deleted. 
+Historically, we've maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We're [currently working on changing this](https://www.pivotaltracker.com/epic/show/4721712) so that we only maintain profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
 
 ## Track API
 

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -403,7 +403,6 @@ PUT /v2/users/:user_id
   role: String; // Can only be modified by admins. Either 'user' (default), 'staff', or 'admin'.
   sms_status: String; // Either 'active', 'stop', less', 'undeliverable', 'pending', or 'unknown'
   sms_paused: Boolean; // Whether a user is in a support conversation.
-  promotions_muted_at: Date; // Used to delete the user's Customer.io profile.
 
   // Hidden fields (optional):
   race: String;

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1214,27 +1214,4 @@ class UserTest extends TestCase
             'sms_subscription_topics' => null,
         ]);
     }
-
-    /**
-     * Test that the promotions_muted_at field is editable for admins.
-     *
-     * @return void
-     */
-    public function testSettingPromotionsMutedAt()
-    {
-        $user = factory(User::class)->states('email-subscribed')->create();
-
-        $newTimestamp = '2021-11-02T18:42:00.000Z';
-
-        $response = $this->asAdminUser()->putJson('v2/users/' . $user->id, [
-            'promotions_muted_at' => $newTimestamp,
-        ]);
-
-        $response->assertStatus(200);
-
-        $this->assertEquals(
-            '2021-11-02T18:42:00+00:00',
-            $user->fresh()->promotions_muted_at->toIso8601String(),
-        );
-    }
 }


### PR DESCRIPTION
Reverts DoSomething/northstar#1130: When trying to make a `PUT /users/:id` request for users to mute promotions for users have been removed for GDPR, the [request fails with validation errors](https://dosomething.slack.com/archives/CJ340DEEL/p1614115585008100?thread_ts=1614106925.003200&cid=CJ340DEEL) because these users have had email and mobile fields cleared (e.g. the request fails with error - `The mobile field is required when email is not present.`).

To workaround this, we'll create a new `DELETE users/{user}/promotions` endpoint that the Mute Promotions import (https://github.com/DoSomething/chompy/pull/200) can call. It'll mock our admin PromotionsController added in https://github.com/DoSomething/northstar/pull/1121, which will allow us to set the `promotions_muted_at`  field to the current time the request is made without worrying about validating any existing fields on the user.