### PR TITLE
Adds API endpoint to mute user promotions

### DIFF
--- a/app/Http/Controllers/PromotionsController.php
+++ b/app/Http/Controllers/PromotionsController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Transformers\UserTransformer;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class PromotionsController extends Controller
+{
+    /**
+     * @var UserTransformer
+     */
+    protected $transformer;
+
+    /**
+     * Make a new PromotionsController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param UserTransformer $transformer
+     */
+    public function __construct(UserTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+
+        $this->middleware('role:admin,staff');
+    }
+
+    /**
+     * Mute promotions for the specified resource.
+     *
+     * @param  User $user
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(User $user)
+    {
+        $user->promotions_muted_at = now();
+        $user->save();
+
+        info('mute_promotions_request', ['id' => $user->id]);
+
+        return $this->item($user);
+    }
+}

--- a/app/Jobs/GetEmailSubStatusFromCustomerIo.php
+++ b/app/Jobs/GetEmailSubStatusFromCustomerIo.php
@@ -31,6 +31,10 @@ class GetEmailSubStatusFromCustomerIo extends Job
      */
     public function handle()
     {
+        /*
+         * Rate limit to 10 requests/second for Beta API requests.
+         * @see https://customer.io/docs/api/#tag/betaLimit
+         */
         Redis::throttle('customerioemailsubstatus')
             ->allow(10)
             ->every(1)

--- a/app/Jobs/Middleware/CustomerIoRateLimit.php
+++ b/app/Jobs/Middleware/CustomerIoRateLimit.php
@@ -15,9 +15,13 @@ class CustomerIoRateLimit
      */
     public function handle($job, $next)
     {
-        // Rate limit to 10 requests/second.
+        /*
+         * Rate limit to 100 requests/second for App and Track API requests.
+         * @see https://customer.io/docs/api/#tag/trackLimit
+         * @see https://customer.io/docs/api/#tag/appLimit
+         */
         $throttler = Redis::throttle('customerio')
-            ->allow(10)
+            ->allow(100)
             ->every(1);
 
         $throttler->then(

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -34,6 +34,7 @@ See [Authentication](authentication.md) for details on authorizing your requests
 | `POST v1/users/:id/merge` | [Merge User Accounts](endpoints/users.md#merge-user-accounts)      | `role:admin,staff` or `admin` |
 | `GET v2/mobile/:id`       | [Retrieve A User](endpoints/v2/users.md#retrieve-a-user-by-mobile) | `role:admin` or `admin`       |
 | `GET v2/email/:id`        | [Retrieve A User](endpoints/v2/users.md#retrieve-a-user-by-email)  | `role:admin` or `admin`       |
+| `DELETE v2/users/:id/promotions` | [Mute User Promotions](endpoints/v2/users.md#mute-promotions)      | `role:admin,staff` or `admin` |
 
 <details>
   <summary>view deprecated endpoints</summary>

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -623,8 +623,44 @@ curl -X DELETE \
 
 </details>
 
-## Notes
+### Notes
 
 - Northstar will automatically set the `email_subscription_status` field to `true` if a user is created or updated with one or more `email_subscription_topics`.
 
 - Northstar will automatically set the `email_subscription_topics` field to an empty array if a user is updated with a `email_subscription_status` value of `false`.
+
+## Mute Promotions
+
+Mute promotions for a user resource. The `user_id` property of the user to mute promotions for must be provided in the URL path, and refers to the user's Northstar ID. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
+
+```
+DELETE /v2/users/:user_id/promotions
+```
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```sh
+curl -X DELETE \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  https://northstar.dosomething.org/v2/users/555b9ca8bffebc30068b456e/promotions
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```js
+// 200 OK
+
+{
+    "data": {
+        "id": "555b9ca8bffebc30068b456e",
+        "promotions_muted_at": "2021-02-25T19:33:24+0000",
+        // the rest of the profile...
+    }
+}
+```
+
+</details>

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -268,6 +268,7 @@ curl -X GET \
     }
 }
 ```
+</details>
 
 ## Retrieve a User By Mobile
 
@@ -316,6 +317,7 @@ curl -X GET \
     }
 }
 ```
+</details>
 
 ## Retrieve a User By Email
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -98,6 +98,9 @@ Route::group(['prefix' => 'v2', 'as' => 'v2.'], function () {
         'SubscriptionUpdateController@destroy',
     );
 
+    // Promotions
+    Route::delete('users/{user}/promotions', 'PromotionsController@destroy');
+
     // Cause Preferences
     Route::post('users/{user}/causes/{cause}', 'CauseUpdateController@store');
     Route::delete(

--- a/routes/api.php
+++ b/routes/api.php
@@ -100,6 +100,12 @@ Route::group(['prefix' => 'v2', 'as' => 'v2.'], function () {
 
     // Promotions
     Route::delete('users/{user}/promotions', 'PromotionsController@destroy');
+    /*
+     * HACK: Gateway PHP does not correctly parse our delete request response, so expose a POST
+     * route to mute promotions and inspect the response.
+     * @see https://github.com/DoSomething/chompy/pull/202
+     */
+    Route::post('users/{user}/promotions', 'PromotionsController@destroy');
 
     // Cause Preferences
     Route::post('users/{user}/causes/{cause}', 'CauseUpdateController@store');

--- a/tests/Http/PromotionsTest.php
+++ b/tests/Http/PromotionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+
+class PromotionsTest extends BrowserKitTestCase
+{
+    /**
+     * Test that an admin can mute promotions.
+     *
+     * @return void
+     */
+    public function testAdminCanMutePromotions()
+    {
+        $user = factory(User::class)->create();
+
+        $this->asAdminUser()->delete(
+            'v2/users/' . $user->id . '/promotions',
+        );
+
+        $this->assertResponseStatus(200);
+        $this->assertNotNull($user->fresh()->promotions_muted_at);
+    }
+
+    /**
+     * Test that a non-staff user can't mute promotions.
+     *
+     * @return void
+     */
+    public function testNormalUserCannotMutePromotions()
+    {
+        $villain = factory(User::class)->create();
+        $user = factory(User::class)->create();
+
+        $this->asUser($villain, ['user', 'write'])->delete(
+            'v2/users/' . $user->id . '/promotions',
+        );
+
+        $this->assertResponseStatus(401);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #1131 to add a new `DELETE /user/{user}/promotions` API endpoint for setting a user's `promotions_muted_at` field, which triggers their Customer.io profile deletion (#1127). 

We ran into issues trying to make a `PUT /users/:id` request to set the field for users who have had their mobile and email fields cleared (per GDPR). This new endpoint allows us to avoid validation errors on any existing field values for users we may want to mute promotions for.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Next up is updating the Chompy import to post to this endpoint instead of making a `PUT /users/:id` request.

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
