### PR TITLE
Increase nginx request size limit.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,9 @@ location ^~ /.well-known/ {
     try_files $uri $uri/ /index.php?$query_string;
 }
 
+# Increase request size limit.
+client_max_body_size 10M;
+
 # Disable nginx's access log since we get the same information
 # from Heroku's router (and can more easily filter that).
 access_log off;


### PR DESCRIPTION
### What's this PR do?

This pull request sets the `client_max_body_size` Nginx setting to 10MB. This should fix an issue where we were unable to upload files larger than 1MB to Northstar's `api/v3/posts` endpoint when running on Heroku.

### How should this be reviewed?

This simply copy-pastes the [setting we used in Rogue](https://github.com/DoSomething/rogue/blob/4d43ca518ab629af0dd0297a772615f8a824350a/nginx.conf#L8-L9).

### Any background context you want to provide?

We can consider upping this (say, to 15MB) in the future, but want to limit the scope of changes for now!

### Relevant tickets

References [Pivotal #176851319](https://www.pivotaltracker.com/story/show/176851319).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
