### PR TITLE
Adds documentation for muting promotions

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,7 +78,7 @@ use libphonenumber\PhoneNumberFormat;
  * @property Carbon $last_accessed_at - The timestamp of the user's last token refresh
  * @property Carbon $last_authenticated_at - The timestamp of the user's last successful login
  * @property Carbon $last_messaged_at - The timestamp of the last message this user sent
- * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been musted for this user
+ * @property Carbon $promotions_muted_at - The timestamp of the last time promotions have been muted for this user
  * @property Carbon $created_at
  * @property Carbon $updated_at
  *

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -4,12 +4,17 @@ We integrate with Customer.io to send transactional and promotional messaging to
 
 We maintain Customer.io profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
 
-## Subscription updates
+### Subscription updates
+
+* When a new account is created (via web or SMS), the member is subscribed for promotions by default, and a Customer.io profile is created for them.
 
 * If a member unsubscribes from both SMS and email promotions, their `promotions_muted_at` field will be set to the datetime they've unsubscribed. This will trigger their Customer.io profile deletion.
 
 * If a member whose promotions have been muted resubscribes to either email and/or SMS, their `promotions_muted_at` field will be set to null. This will trigger their Customer.io profile to be re-created, and additionally track a `promotions_resubscribe` Customer.io event.
 
+### Mute Promotions import
+
+Admins can run a Mute Promotions import from [Chompy](https://github.com/DoSomething/chompy/tree/master/docs/imports#mute-promotions) to manually set a user's `promotions_muted_at` field and delete their Customer.io profile.
 
 ## Integration
 
@@ -25,4 +30,4 @@ We use the [send email](https://customer.io/docs/api/#operation/sendEmail) endpo
 
 ## History
 
-When we first launched our Customer.io integration in 2016, we maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We changed this in 2021 to only maintain profiles for [active members who are subscribed](https://www.pivotaltracker.com/epic/show/4721712), running the first Mute Promotions import at the end of February 2021.
+When we first launched our Customer.io integration in 2016, we maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We changed this in 2021 to only maintain profiles for [active members who are subscribed](https://www.pivotaltracker.com/epic/show/4721712), running the first [Mute Promotions import](#mute-promotions-import) at the end of February 2021.

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -1,6 +1,6 @@
 # Customer.io
 
-We integrate with Customer.io to send transactional and promotional messaging to DoSomething members.
+We integrate with [Customer.io](https://customer.io/) to send transactional and promotional messaging to DoSomething members.
 
 We maintain Customer.io profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
 
@@ -18,9 +18,11 @@ Admins can run a Mute Promotions import from [Chompy](https://github.com/DoSomet
 
 ## Integration
 
+Northstar uses [queued jobs](https://laravel.com/docs/6.x/queues) to execute Customer.io API requests.
+
 ### Track API
 
-We use the [Track API](https://customer.io/docs/api/#tag/trackOverview) to track member activity in Customer.io, and send both promotional and transactional emails to subscribers. The documentation [here](http://docs.dosomething.org/customer-io) and [here](http://docs.dosomething.org/non-traditional-member-activation) provide more detail, and will soon be moved into this repo.
+We use the [Track API](https://customer.io/docs/api/#tag/trackOverview) to upsert a profile for each active, subscribed member, and to track their [events](https://customer.io/docs/events). The documentation [here](http://docs.dosomething.org/customer-io) and [here](http://docs.dosomething.org/non-traditional-member-activation) provide more detail, and will soon be moved into this repo.
 
 ### App API
 

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -2,14 +2,27 @@
 
 We integrate with Customer.io to send transactional and promotional messaging to DoSomething members.
 
-Historically, we've maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We're [currently working on changing this](https://www.pivotaltracker.com/epic/show/4721712) so that we only maintain profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
+We maintain Customer.io profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
 
-## Track API
+## Subscription updates
+
+* If a member unsubscribes from both SMS and email promotions, their `promotions_muted_at` field will be set to the datetime they've unsubscribed. This will trigger their Customer.io profile deletion.
+
+* If a member whose promotions have been muted resubscribes to either email and/or SMS, their `promotions_muted_at` field will be set to null. This will trigger their Customer.io profile to be re-created, and additionally track a `promotions_resubscribe` Customer.io event.
+
+
+## Integration
+
+### Track API
 
 We use the [Track API](https://customer.io/docs/api/#tag/trackOverview) to track member activity in Customer.io, and send both promotional and transactional emails to subscribers. The documentation [here](http://docs.dosomething.org/customer-io) and [here](http://docs.dosomething.org/non-traditional-member-activation) provide more detail, and will soon be moved into this repo.
 
-## App API
+### App API
 
 We use the [App API](https://customer.io/docs/api/#tag/appOverview) to send transactional emails for forgot password requests, and password updated events.
 
 We use the [send email](https://customer.io/docs/api/#operation/sendEmail) endpoint to send emails to members without requiring a Customer.io profile to exist. This is done by executing all send email requests for a specific ID of a placeholder Customer.io profile we've set up, set via the `CUSTOMER_IO_APP_IDENTIFIER_ID` config variable.
+
+## History
+
+When we first launched our Customer.io integration in 2016, we maintained a Customer.io profile for every DoSomething member (a.k.a. Northstar user). We changed this in 2021 to only maintain profiles for [active members who are subscribed](https://www.pivotaltracker.com/epic/show/4721712), running the first Mute Promotions import at the end of February 2021.


### PR DESCRIPTION
### What's this PR do?

This pull request adds more documentation for the `promotions_muted_at` User field, and describes:

* Deleting or re-creating of Customer.io profiles per member's subscription status changes, added in #1125.
* The Mute Promotions import,  added in https://github.com/DoSomething/chompy/pull/202 and ran at the end of Feb 2021.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This kind of documentation is the kind that gets me wondering about where a more product/staff friendly place could be for docs -- but for now, it's here!  

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
