### PR TITLE
Properly load user relationship for Customer.io activity events.

### DIFF
--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -43,7 +43,7 @@ class SendPostToCustomerIo extends Job
     public function handle(CustomerIo $customerIo)
     {
         $customerIo->trackEvent(
-            $this->post->user(),
+            $this->post->user,
             'campaign_signup_post',
             $this->post->toCustomerIoPayload(),
         );

--- a/app/Jobs/SendReviewedPostToCustomerIo.php
+++ b/app/Jobs/SendReviewedPostToCustomerIo.php
@@ -43,7 +43,7 @@ class SendReviewedPostToCustomerIo extends Job
     public function handle(CustomerIo $customerIo)
     {
         $customerIo->trackEvent(
-            $this->post->user(),
+            $this->post->user,
             'campaign_review',
             $this->post->toCustomerIoPayload(),
         );

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -43,7 +43,7 @@ class SendSignupToCustomerIo extends Job
     public function handle(CustomerIo $customerIo)
     {
         $customerIo->trackEvent(
-            $this->signup->user(),
+            $this->signup->user,
             'campaign_signup',
             $this->signup->toCustomerIoPayload(),
         );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -103,12 +103,6 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function assertCustomerIoEvent(User $user, string $eventName)
     {
         $userMatcher = Mockery::on(function ($argument) use ($user) {
-            // If this is an as-yet unresolved Eloquent relationship, figure out where
-            // it will go so we can make a comparison against the expected user:
-            if ($argument instanceof Relation) {
-                $argument = $argument->getResults();
-            }
-
             return $user->is($argument);
         });
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue passing a user along to Customer.io when sending post, signup, or review events.

### How should this be reviewed?

Gah, I should've caught this the first time around!! The reason that these mocks had been failing to register is because these jobs were loading the associated user via `->user()` (the method that configures the relationship), and not `->user` (the property that uses a magic method to load the related model).

### Any background context you want to provide?

With this fix, tests now pass properly without the hack! 😌

### Relevant tickets

References [Pivotal #176851319](https://www.pivotaltracker.com/story/show/176851319).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
