### PR TITLE
Treat machine requests as authenticated.

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Auth\Scope;
 use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\Factory as Auth;
@@ -55,6 +56,12 @@ class Authenticate
     {
         if (empty($guards)) {
             $guards = ['api'];
+        }
+
+        // If we're using the API guard and a request comes in with the 'admin'
+        // scope, then treat it as authenticated (as a machine client):
+        if (in_array('api', $guards) && Scope::allows('admin')) {
+            return;
         }
 
         // Check if any of the guards let the user in.


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue where the `auth:api` middleware would treat a request made by a "machine" client (like Gambit or a Chompy queue worker) as unauthenticated. This was causing incoming posts from Gambit to fail.

### How should this be reviewed?

🔒 👀

### Any background context you want to provide?

We attach the `admin` scope to internal "machine" clients that should be able to act on behalf of other users. I'm not a huge fan of how this works anymore, but we haven't had time to rethink this implementation in ages. Hoping we will soon!

### Relevant tickets

References [Pivotal #176851319](https://www.pivotaltracker.com/story/show/176851319).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
