### PR TITLE
Unmute promotions before tracking activity events

### DIFF
--- a/app/Jobs/SendPostToCustomerIo.php
+++ b/app/Jobs/SendPostToCustomerIo.php
@@ -42,8 +42,7 @@ class SendPostToCustomerIo extends Job
      */
     public function handle(CustomerIo $customerIo)
     {
-        $customerIo->trackEvent(
-            $this->post->user,
+        $this->post->user->trackCustomerIoEvent(
             'campaign_signup_post',
             $this->post->toCustomerIoPayload(),
         );

--- a/app/Jobs/SendReviewedPostToCustomerIo.php
+++ b/app/Jobs/SendReviewedPostToCustomerIo.php
@@ -42,8 +42,7 @@ class SendReviewedPostToCustomerIo extends Job
      */
     public function handle(CustomerIo $customerIo)
     {
-        $customerIo->trackEvent(
-            $this->post->user,
+        $this->post->user->trackCustomerIoEvent(
             'campaign_review',
             $this->post->toCustomerIoPayload(),
         );

--- a/app/Jobs/SendSignupToCustomerIo.php
+++ b/app/Jobs/SendSignupToCustomerIo.php
@@ -42,8 +42,7 @@ class SendSignupToCustomerIo extends Job
      */
     public function handle(CustomerIo $customerIo)
     {
-        $customerIo->trackEvent(
-            $this->signup->user,
+        $this->signup->user->trackCustomerIoEvent(
             'campaign_signup',
             $this->signup->toCustomerIoPayload(),
         );


### PR DESCRIPTION
### What's this PR do?

This pull request refactors the jobs that track Customer.io events for signups and posts to use the `trackCustomerIoEvent` method on the User model (added in https://github.com/DoSomething/northstar/pull/1127), to ensure a profile is re-created if an event is tracked for a user whose promotions have been muted (saw one of these in the wild [today](https://dosomething.slack.com/archives/CJ340DEEL/p1614637305012600?thread_ts=1614440901.002300&cid=CJ340DEEL), after our first Mute Promotions import wrapped up over the weekend) 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐯 

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/story/show/176771234).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
