### PR TITLE
Adds support to mute promotions for soft deleted users

### DIFF
--- a/app/Http/Controllers/PromotionsController.php
+++ b/app/Http/Controllers/PromotionsController.php
@@ -29,11 +29,14 @@ class PromotionsController extends Controller
     /**
      * Mute promotions for the specified resource.
      *
-     * @param  User $user
+     * @param  string $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy(User $user)
+    public function destroy(string $id)
     {
+        // Allow muting promotions for soft deleted users.
+        $user = User::withTrashed()->find($id);
+
         $user->promotions_muted_at = now();
         $user->save();
 

--- a/app/Http/Controllers/PromotionsController.php
+++ b/app/Http/Controllers/PromotionsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Transformers\UserTransformer;
 use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 
 class PromotionsController extends Controller
@@ -36,6 +37,10 @@ class PromotionsController extends Controller
     {
         // Allow muting promotions for soft deleted users.
         $user = User::withTrashed()->find($id);
+
+        if (!$user) {
+            throw new ModelNotFoundException();
+        }
 
         $user->promotions_muted_at = now();
         $user->save();

--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -635,6 +635,8 @@ curl -X DELETE \
 
 Mute promotions for a user resource. The `user_id` property of the user to mute promotions for must be provided in the URL path, and refers to the user's Northstar ID. This requires either the `admin` scope, or "admin" or "staff" role with the appropriate scope.
 
+The ID of a user who has been [soft deleted](https://laravel.com/docs/6.x/eloquent#soft-deleting) may be passed to this endpoint, and will not result in a 404 Not Found response.
+
 ```
 DELETE /v2/users/:user_id/promotions
 ```

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,13 +99,13 @@ Route::group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     );
 
     // Promotions
-    Route::delete('users/{user}/promotions', 'PromotionsController@destroy');
+    Route::delete('users/{id}/promotions', 'PromotionsController@destroy');
     /*
      * HACK: Gateway PHP does not correctly parse our delete request response, so expose a POST
      * route to mute promotions and inspect the response.
      * @see https://github.com/DoSomething/chompy/pull/202
      */
-    Route::post('users/{user}/promotions', 'PromotionsController@destroy');
+    Route::post('users/{id}/promotions', 'PromotionsController@destroy');
 
     // Cause Preferences
     Route::post('users/{user}/causes/{cause}', 'CauseUpdateController@store');

--- a/tests/Http/PromotionsTest.php
+++ b/tests/Http/PromotionsTest.php
@@ -56,4 +56,18 @@ class PromotionsTest extends BrowserKitTestCase
         $this->assertResponseStatus(200);
         $this->assertNotNull($user->fresh()->promotions_muted_at);
     }
+
+    /**
+     * Test status when user not found.
+     *
+     * @return void
+     */
+    public function testStatusWhenMutePromotionsForNotFoundUser()
+    {
+        $this->asAdminUser()->delete(
+            'v2/users/600201a023a8223a1e4575a3/promotions',
+        );
+
+        $this->assertResponseStatus(404);
+    }
 }

--- a/tests/Http/PromotionsTest.php
+++ b/tests/Http/PromotionsTest.php
@@ -37,4 +37,23 @@ class PromotionsTest extends BrowserKitTestCase
 
         $this->assertResponseStatus(401);
     }
+
+    /**
+     * Test muting promotions on a deleted user.
+     *
+     * @return void
+     */
+    public function testCanMutePromotionsForDeletedUser()
+    {
+        $user = factory(User::class)->create();
+
+        $user->delete();
+
+        $this->asAdminUser()->delete(
+            'v2/users/' . $user->id . '/promotions',
+        );
+
+        $this->assertResponseStatus(200);
+        $this->assertNotNull($user->fresh()->promotions_muted_at);
+    }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the API `PromotionsController` to allow muting promotions for user models that have been [soft deleted](https://laravel.com/docs/6.x/eloquent#soft-deleting).

### How should this be reviewed?

👀 

### Any background context you want to provide?

There are [currently 1471 failed jobs in Chompy](https://importer.dosomething.org/failed-jobs) where API requests to mute promotions failed. Our hunch is that the requests have failed because the users have been soft deleted, and Northstar returns a 404. This should hopefully fix those API errors and clear out the Chompy failed job queue upon next retry.

### Relevant tickets

References [Pivotal #177170418](https://www.pivotaltracker.com/story/show/177170418).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
