### PR TITLE
Only set phone on Customer.io profile when member is SMS subscriber

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -651,7 +651,7 @@ class User extends MongoModel implements
         $payload = [
             'id' => $this->id,
             'email' => $this->email,
-            'phone' => $this->mobile,
+            'phone' => $this->isSmsSubscribed() ? $this->mobile : null,
             'sms_status' => $this->sms_status,
             'sms_status_source' => data_get($this->audit, 'sms_status.source'),
             'sms_paused' => (bool) $this->sms_paused,
@@ -1057,13 +1057,15 @@ class User extends MongoModel implements
     }
 
     /**
-     * Whether user has a subscribed SMS status.
+     * Whether user is a SMS subscriber.
      *
      * @return bool
      */
     public function isSmsSubscribed()
     {
-        return isset($this->sms_status) &&
+        return
+            isset($this->mobile) &&
+            isset($this->sms_status) &&
             self::isSubscribedSmsStatus($this->sms_status);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1057,7 +1057,7 @@ class User extends MongoModel implements
     }
 
     /**
-     * Whether user is a SMS subscriber.
+     * Whether user is an SMS subscriber.
      *
      * @return bool
      */

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -8,7 +8,7 @@ class UserModelTest extends TestCase
     /** @test */
     public function it_should_send_new_users_to_customer_io()
     {
-        config(['features.blink' => true]);
+        config(['features.customer_io' => true]);
 
         /** @var User $user */
         $user = factory(User::class)->create([
@@ -97,7 +97,7 @@ class UserModelTest extends TestCase
     /** @test */
     public function it_should_send_updated_users_to_customer_io()
     {
-        config(['features.blink' => true]);
+        config(['features.customer_io' => true]);
 
         /** @var User $user */
         $user = factory(User::class)->create();
@@ -187,6 +187,18 @@ class UserModelTest extends TestCase
     }
 
     /** @test */
+    public function testCustomerIoPhoneIsNotSetIfNotSubscribedToSms()
+    {
+        $user = factory(User::class)
+            ->states('sms-unsubscribed')
+            ->create();
+
+        $result = $user->toCustomerIoPayload();
+
+        $this->assertNull($result['phone']);
+    }
+
+    /** @test */
     public function testIsSmsSubscribedisTrueIfSmsStatusIsActive()
     {
         $user = factory(User::class)->create([
@@ -221,6 +233,17 @@ class UserModelTest extends TestCase
     {
         $user = factory(User::class)->create([
             'sms_status' => 'stop',
+        ]);
+
+        $this->assertFalse($user->isSmsSubscribed());
+    }
+
+    /** @test */
+    public function testIsSmsSubscribedisFalseIfMobileIsNull()
+    {
+        $user = factory(User::class)->create([
+            'mobile' => null,
+            'sms_status' => 'active',
         ]);
 
         $this->assertFalse($user->isSmsSubscribed());


### PR DESCRIPTION
### What's this PR do?

This pull request modifies our upsert of a member's Customer.io profile to only set their `phone` attribute when they are subscribed to SMS promotions.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This work is the first step towards only storing mobile numbers in Customer.io for members that are subscribed to SMS promotions -- that way we don't need to lookup each Northstar user when sending a Gambit broadcast to safety check that we're not accidentally sending a broadcast to a member who's unsubscribed.

The next step is removing phone numbers from all existing Customer.io profiles that are not subscribed to SMS promotions. This will likely be handled by running a Chompy import or by modifying the [BackfillCustomerIo]( https://github.com/DoSomething/northstar/blob/master/app/Console/Commands/BackfillCustomerIo.php) command to optionally accept a CSV of user ids (there's no need to backfill all users -- just ones who have a mobile set, are unsubscribed, and haven't had their promotions muted per our February Customer.io retirement import)

### Relevant tickets

References [Pivotal #177168236](https://www.pivotaltracker.com/story/show/177168236).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
