### PR TITLE
Send tags to Customer.io and delay job from sending after review is completed

### DIFF
--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -129,7 +129,8 @@ class PostManager
     {
         $post = $this->repository->reviews($post, $data, $comment, $admin);
 
-        // sending review to customerIo is delayed to ensure tags have been added to the post before it triggers an email to users
+        // sending review to customerIo is delayed to ensure users can optionally add tags to rejected or accepted posts
+        // if they're added, we want them to be sent along in the payload!
         SendReviewedPostToCustomerIo::dispatch($post)->delay(
             now()->addMinutes(5),
         );

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -129,7 +129,10 @@ class PostManager
     {
         $post = $this->repository->reviews($post, $data, $comment, $admin);
 
-        SendReviewedPostToCustomerIo::dispatch($post);
+        // sending review to customerIo is delayed to ensure tags have been added to the post before it triggers an email to users
+        SendReviewedPostToCustomerIo::dispatch($post)->delay(
+            now()->addMinutes(5),
+        );
 
         // Log that a post was reviewed.
         info('post_reviewed', [

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -381,6 +381,7 @@ class Post extends Model
         $action = $this->actionModel;
         $signup = optional($this->signup);
         $campaign = optional($signup->campaign);
+        $tags = $this->tagSlugs()->toArray();
 
         return array_merge(
             [
@@ -423,7 +424,7 @@ class Post extends Model
                 'created_at' => $this->created_at->timestamp,
                 'updated_at' => $this->updated_at->timestamp,
                 'deleted_at' => optional($this->deleted_at)->timestamp,
-                'tags' => implode(',', $this->tagSlugs() ?: []),
+                'tags' => implode(',', $tags ?: []),
             ],
             optional($this->group)->toCustomerIoPayload() ?: [],
         );

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -423,6 +423,7 @@ class Post extends Model
                 'created_at' => $this->created_at->timestamp,
                 'updated_at' => $this->updated_at->timestamp,
                 'deleted_at' => optional($this->deleted_at)->timestamp,
+                'tags' => implode(',', $this->tagSlugs() ?: []),
             ],
             optional($this->group)->toCustomerIoPayload() ?: [],
         );

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -14,6 +14,8 @@ class ReviewsTest extends TestCase
      */
     public function testPostingReview()
     {
+        $this->withoutExceptionHandling();
+
         $admin = factory(User::class, 'admin')->create();
 
         $schoolId = $this->faker->school_id;

--- a/tests/Http/ReviewsTest.php
+++ b/tests/Http/ReviewsTest.php
@@ -14,8 +14,6 @@ class ReviewsTest extends TestCase
      */
     public function testPostingReview()
     {
-        $this->withoutExceptionHandling();
-
         $admin = factory(User::class, 'admin')->create();
 
         $schoolId = $this->faker->school_id;


### PR DESCRIPTION
### What's this PR do?

This pull request adds `tags` as a field in the payload we send to Customer.Io. The field is set based on what tags have been added when the posts are reviewed, and we are sending it as a single comma separated string vs an array.

The PR also adds a 5 minute delay to when the payload is sent upon review of a post. This delay is to ensure that when a review is completed, it is not sent over unintentionally without tags. Anthony plans on utilizing the tags as liquid tags in c.io and we want to give campaign managers enough time to add them after choosing `accept` or `reject` on a particular post.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We are hoping that the addition of the tags will help users to understand why their posts may be getting rejected!

### Relevant tickets

References [Pivotal #176421256](https://www.pivotaltracker.com/story/show/176421256).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
