### PR TITLE
Don't delete Customer.io profiles for pending SMS status

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1042,7 +1042,7 @@ class User extends MongoModel implements
      */
     public static function isSubscribedSmsStatus($smsStatusValue)
     {
-        return in_array($smsStatusValue, ['active', 'less']);
+        return in_array($smsStatusValue, ['active', 'less', 'pending']);
     }
 
     /**

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -4,6 +4,29 @@ We integrate with [Customer.io](https://customer.io/) to send transactional and 
 
 We maintain Customer.io profiles for active members who are subscribed to receive email and/or SMS promotional messaging.
 
+### Email subscribers
+
+When a user's `email_subscription_status` boolean field is set to `true`, they are subscribed to email promotions.
+
+The current `email_subscription_topics` a user can subscribe to are:
+
+* `community`
+* `lifestyle`
+* `news`
+* `scholarships`
+
+### SMS subscribers
+
+The user's `sms_status` field determines their SMS subscription status (a heavy TODO is to rename it as `sms_subscription_status` for consistency with email):
+
+* `active` - receives weekly promotional SMS broadcasts
+* `less` - receives monthly promotional SMS broadcasts
+* `stop` - has unsubscribed from all SMS messaging
+* `pending` - has received a re-permissioning SMS broadcast (a.k.a. an [`askSubscriptionStatusBroadcast`](https://github.com/DoSomething/gambit-admin/wiki/Broadcasts#asksubscriptionstatus)), prompting them to answer with `active`, `less`, or `stop`
+* `undeliverable` - we set this internally if Twilio cannot successfully deliver a SMS broadcast to the user's mobile number 
+
+The current `sms_subscription_topics` are `general` and `voting`. By default, users are opted into both topics when they subscribe, unless the user is being imported from Rock The Vote (see [details](https://github.com/DoSomething/chompy/tree/master/docs/imports#sms-subscription)). 
+
 ### Subscription updates
 
 * When a new account is created (via web or SMS), the member is subscribed for promotions by default, and a Customer.io profile is created for them.

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -219,6 +219,16 @@ class UserModelTest extends TestCase
     }
 
     /** @test */
+    public function testIsSmsSubscribedisTrueIfSmsStatusIsPending()
+    {
+        $user = factory(User::class)->create([
+            'sms_status' => 'pending',
+        ]);
+
+        $this->assertTrue($user->isSmsSubscribed());
+    }
+
+    /** @test */
     public function testIsSmsSubscribedisFalseIfSmsStatusIsNull()
     {
         $user = factory(User::class)->create([


### PR DESCRIPTION
### What's this PR do?

This pull request adds `pending` to the list of subscribed SMS statuses, to avoid deleting a user's Customer.io profile. A user's SMS status is set to `pending` when we send a re-permissioning broadcast, and are waiting for them to reply to determine whether they still want to remain subscribed (so, we'll still consider them subscribed until we hear back).

### How should this be reviewed?

👀 

### Any background context you want to provide?

There's a handful of users who have mobile numbers set but a null `sms_status` value, because there was a bug in the user profile that didn't set the user's `sms_status` if they add their mobile number. Now that the bug is fixed in #1144, we can send a new re-permissioning broadcast to these users to ensure all users with a mobile value set will have a non-null `sms_status` value.

### Relevant tickets

References [Pivotal #177168236](https://www.pivotaltracker.com/story/show/177168236).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
