### PR TITLE
Adds console command to remove phone from Customer.io profiles if not subscribed to SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ Northstar! :sparkles:
 
 Northstar currently uses two database connections: its original MongoDB connection, and the MySQL connection originally owned by [Rogue](https://github.com/DoSomething/rogue).
 
-To run a migration, specify the desired DB connection and path:
+To run a database migration, it's easiest to use our custom Artisan command:
 ```
-php artisan migrate --path="database/migrations-mongodb/" --database="mongodb"
-php artisan migrate --path="database/migrations/" --database="mysql"
+php artisan migrate:all
 ```
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Northstar [![wercker status](https://app.wercker.com/status/109bce734be9a06703562876265f5bd9/s/dev "wercker status")](https://app.wercker.com/project/byKey/109bce734be9a06703562876265f5bd9) [![StyleCI](https://styleci.io/repos/26884886/shield?style=flat-rounded)](https://styleci.io/repos/26884886)
+# Northstar
 
 This is **Northstar**, the DoSomething.org user & identity service. It's our single "source of truth" for member information.
 Northstar is built using [Laravel 6.0](https://laravel.com/docs/6.x), [OAuth 2.0 Server](https://oauth2.thephpleague.com), and [MongoDB](https://www.mongodb.com).
@@ -7,6 +7,16 @@ Northstar is built using [Laravel 6.0](https://laravel.com/docs/6.x), [OAuth 2.0
 
 Check out the [API Documentation](https://github.com/DoSomething/northstar/blob/master/documentation/README.md) to start using
 Northstar! :sparkles:
+
+### Migrations
+
+Northstar currently uses two database connections: its original MongoDB connection, and the MySQL connection originally owned by [Rogue](https://github.com/DoSomething/rogue).
+
+To run a migration, specify the desired DB connection and path:
+```
+php artisan migrate --path="database/migrations-mongodb/" --database="mongodb"
+php artisan migrate --path="database/migrations/" --database="mysql"
+```
 
 ### Contributing
 

--- a/app/Console/Commands/RemoveCustomerIoMobile.php
+++ b/app/Console/Commands/RemoveCustomerIoMobile.php
@@ -30,10 +30,9 @@ class RemoveCustomerIoMobile extends Command
      */
     public function handle()
     {
-        // Find all SMS unsubscribed users where promotions have not been muted.
-        $query = (new User())->newQuery()
-            ->whereNull('promotions_muted_at')
-            ->whereIn('sms_status', ['stop', 'undeliverable']);
+        $query = User::whereNull('promotions_muted_at')
+            ->whereNotNull('mobile')
+            ->whereIn('sms_status', [null, 'stop', 'undeliverable']);
 
         $progress = $this->output->createProgressBar($query->count());
 

--- a/app/Console/Commands/RemoveCustomerIoMobile.php
+++ b/app/Console/Commands/RemoveCustomerIoMobile.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\DeleteCustomerIoProfile;
+use App\Jobs\UpsertCustomerIoProfile;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class RemoveCustomerIoMobile extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:remove-cio-mobile';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Removes mobile from all unsubscribed profiles in Customer.io.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Find all SMS unsubscribed users where promotions have not been muted.
+        $query = (new User())->newQuery()
+            ->whereNull('promotions_muted_at')
+            ->whereNotNull('mobile')
+            ->whereIn('sms_status', ['stop', 'undeliverable']);
+
+        $progress = $this->output->createProgressBar($query->count());
+
+        $query->chunkById(200, function (Collection $users) use ($progress) {
+            $users->each(function (User $user) use ($progress) {
+                // If the user is subscribed to email:
+                $job = $user->email_subscription_status ?
+                    // Execute an update to remove mobile from their profile.
+                    new UpsertCustomerIoProfile($user) :
+                    // Otherwise delete the profile entirely.
+                    new DeleteCustomerIoProfile($user);
+
+                dispatch($job)->onQueue(config('queue.names.low'));
+                $progress->advance();
+            });
+        });
+
+        $this->info(' Done!');
+    }
+}

--- a/app/Console/Commands/RemoveCustomerIoMobile.php
+++ b/app/Console/Commands/RemoveCustomerIoMobile.php
@@ -15,7 +15,7 @@ class RemoveCustomerIoMobile extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:remove-cio-mobile';
+    protected $signature = 'northstar:cio-remove-mobile';
 
     /**
      * The console command description.

--- a/app/Console/Commands/RemoveCustomerIoMobile.php
+++ b/app/Console/Commands/RemoveCustomerIoMobile.php
@@ -34,7 +34,6 @@ class RemoveCustomerIoMobile extends Command
         // Find all SMS unsubscribed users where promotions have not been muted.
         $query = (new User())->newQuery()
             ->whereNull('promotions_muted_at')
-            ->whereNotNull('mobile')
             ->whereIn('sms_status', ['stop', 'undeliverable']);
 
         $progress = $this->output->createProgressBar($query->count());
@@ -53,6 +52,6 @@ class RemoveCustomerIoMobile extends Command
             });
         });
 
-        $this->info(' Done!');
+        $this->info('Done!');
     }
 }

--- a/app/Console/Commands/RemoveCustomerIoMobile.php
+++ b/app/Console/Commands/RemoveCustomerIoMobile.php
@@ -41,8 +41,7 @@ class RemoveCustomerIoMobile extends Command
                 // If the user is not subscribed to email:
                 if (!$user->email_subscription_status) {
                     // Delete their profile entirely by muting promotions.
-                    $user->promotions_muted_at = now();
-                    $user->save();
+                    $user->mutePromotions();
                 } else {
                     // Otherwise update their profile to remove the mobile number.
                     dispatch(new UpsertCustomerIoProfile($user))

--- a/app/Http/Controllers/PromotionsController.php
+++ b/app/Http/Controllers/PromotionsController.php
@@ -42,8 +42,7 @@ class PromotionsController extends Controller
             throw new ModelNotFoundException();
         }
 
-        $user->promotions_muted_at = now();
-        $user->save();
+        $user->mutePromotions();
 
         info('mute_promotions_request', ['id' => $user->id]);
 

--- a/app/Http/Controllers/Web/Admin/PromotionsController.php
+++ b/app/Http/Controllers/Web/Admin/PromotionsController.php
@@ -30,8 +30,7 @@ class PromotionsController extends Controller
 
         logger('Muting promotions', ['user' => $user->id]);
 
-        $user->promotions_muted_at = Carbon::now();
-        $user->save();
+        $user->mutePromotions();
 
         return redirect()
             ->route('admin.users.show', $user->id)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1114,6 +1114,16 @@ class User extends MongoModel implements
     }
 
     /**
+     * Sets the promotions_muted_at and saves to delete Customer.io profile.
+     * @see UserObserver@updated
+     */
+    public function mutePromotions()
+    {
+        $this->promotions_muted_at = now();
+        $this->save();
+    }
+
+    /**
      * Accessor for the `causes` attribute.
      *
      * @param  mixed value

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -49,13 +49,17 @@ class UserObserver
      */
     public function created(User $user)
     {
-        // Send payload to Blink for Customer.io profile.
+        // Send metrics to StatHat.
+        Log::info('user_created', ['source' => $user->source]);
+
+        // If user is not subscribed to any platform -- do not create a Customer.io profile.
+        if (!($user->email_subscription_status || $user->isSmsSubscribed())) {
+            return;
+        }
+
         $queueLevel = config('queue.jobs.users');
         $queue = config('queue.names.' . $queueLevel);
         UpsertCustomerIoProfile::dispatch($user)->onQueue($queue);
-
-        // Send metrics to StatHat.
-        Log::info('user_created', ['source' => $user->source]);
     }
 
     /**

--- a/database/migrations-mongodb/2021_03_09_000000_add_index_to_promotions_muted_at_and_sms_status_fields.php
+++ b/database/migrations-mongodb/2021_03_09_000000_add_index_to_promotions_muted_at_and_sms_status_fields.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexToPromotionsMutedAtAndSmsStatusFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mongodb')->table('users', function (
+            Blueprint $collection
+        ) {
+            $collection->index(
+                ['promotions_muted_at', 'sms_status'],
+                null,
+                null,
+                ['sparse' => true],
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('mongodb')->table('users', function (
+            Blueprint $collection
+        ) {
+            $collection->dropIndex('promotions_muted_at_1_sms_status_1');
+        });
+    }
+}

--- a/database/migrations-mongodb/2021_03_10_000000_add_index_to_mobile_promotions_muted_at_sms_status_fields.php
+++ b/database/migrations-mongodb/2021_03_10_000000_add_index_to_mobile_promotions_muted_at_sms_status_fields.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddIndexToPromotionsMutedAtAndSmsStatusFields extends Migration
+class AddIndexToMobilePromotionsMutedAtSmsStatusFields extends Migration
 {
     /**
      * Run the migrations.
@@ -17,7 +17,7 @@ class AddIndexToPromotionsMutedAtAndSmsStatusFields extends Migration
             Blueprint $collection
         ) {
             $collection->index(
-                ['promotions_muted_at', 'sms_status'],
+                ['mobile', 'promotions_muted_at', 'sms_status'],
                 null,
                 null,
                 ['sparse' => true],
@@ -35,7 +35,7 @@ class AddIndexToPromotionsMutedAtAndSmsStatusFields extends Migration
         Schema::connection('mongodb')->table('users', function (
             Blueprint $collection
         ) {
-            $collection->dropIndex('promotions_muted_at_1_sms_status_1');
+            $collection->dropIndex('mobile_1_promotions_muted_at_1_sms_status_1');
         });
     }
 }

--- a/tests/Console/RemoveCustomerIoMobileTest.php
+++ b/tests/Console/RemoveCustomerIoMobileTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+
+class RemoveCustomerIoMobileTest extends BrowserKitTestCase
+{
+    /** @test */
+    public function testExpectedApiCalls()
+    {
+        factory(User::class, 5)->states('email-subscribed', 'sms-subscribed')->create();
+        factory(User::class, 3)->states('email-subscribed', 'sms-unsubscribed')->create();
+        factory(User::class, 7)->states('email-unsubscribed', 'sms-unsubscribed')->create();
+
+        Artisan::call('northstar:cio-remove-mobile');
+
+        // Called 8 times for creating a subscribed user, another 3 when console command executed.
+        $this->customerIoMock->shouldHaveReceived('updateCustomer')->times(11);
+        $this->customerIoMock->shouldHaveReceived('deleteCustomer')->times(7);
+    }
+}

--- a/tests/Console/RemoveCustomerIoMobileTest.php
+++ b/tests/Console/RemoveCustomerIoMobileTest.php
@@ -9,13 +9,22 @@ class RemoveCustomerIoMobileTest extends BrowserKitTestCase
     public function testExpectedApiCalls()
     {
         factory(User::class, 5)->states('email-subscribed', 'sms-subscribed')->create();
-        factory(User::class, 3)->states('email-subscribed', 'sms-unsubscribed')->create();
-        factory(User::class, 7)->states('email-unsubscribed', 'sms-unsubscribed')->create();
+        $removeMobiles = factory(User::class, 3)->states('email-subscribed', 'sms-unsubscribed')->create();
+        $deleteProfiles = factory(User::class, 7)->states('email-unsubscribed', 'sms-unsubscribed')->create();
 
         Artisan::call('northstar:cio-remove-mobile');
 
         // Called 8 times for creating a subscribed user, another 3 when console command executed.
         $this->customerIoMock->shouldHaveReceived('updateCustomer')->times(11);
         $this->customerIoMock->shouldHaveReceived('deleteCustomer')->times(7);
+
+        foreach ($removeMobiles as $user) {
+            $this->assertNull($user->promotions_muted_at);
+        }
+
+        foreach ($deleteProfiles as $user) {
+            // TODO: Why is this failling?
+          //$this->assertNotNull($user->promotions_muted_at);
+        }
     }
 }

--- a/tests/Console/RemoveCustomerIoMobileTest.php
+++ b/tests/Console/RemoveCustomerIoMobileTest.php
@@ -19,12 +19,11 @@ class RemoveCustomerIoMobileTest extends BrowserKitTestCase
         $this->customerIoMock->shouldHaveReceived('deleteCustomer')->times(7);
 
         foreach ($removeMobiles as $user) {
-            $this->assertNull($user->promotions_muted_at);
+            $this->assertNull($user->fresh()->promotions_muted_at);
         }
 
         foreach ($deleteProfiles as $user) {
-            // TODO: Why is this failling?
-          //$this->assertNotNull($user->promotions_muted_at);
+            $this->assertNotNull($user->fresh()->promotions_muted_at);
         }
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `northstar:cio-remove-mobile` Artisan command that finds all users that have not had promotions muted, have a mobile set, and a null or unsubscribed SMS status. Then, for each user found:

* if they are subscribed to email, update their Customer.io profile (which will remove their `phone` attribute per #1142)
* if they are not subscribed, set their `promotions_muted_at` attribute to trigger deleting their Customer.io profile (per #1124) 

This PR also adds a migration to create a compound index to the `mobile`, `promotions_muted_at`, and  `sms_status` fields on our users MongoDB collection to optimize finding the ~1M out of ~11-12M documents we want to update. Because of this migration -- **this should not be merged until we're in a good spot to put Northstar into maintenance mode for a deploy.**


### How should this be reviewed?

👀 

### Any background context you want to provide?

* I left a TODO for fixing the test that asserts muting promotions for each still-subscribed-to-email user for now, not sure why this is falling. When I've tested locally, I've verified the `promotions_muted_at` field is set correctly.

* I think we may want to delete the `BackfillCustomerIo` job entirely -- as it makes it somewhat easy to accidentally re-add profiles we spent a weekend deleting if someone ran it on production. Left out that deletion for now, but any objections?
 
### Relevant tickets

References [Pivotal #177168318](https://www.pivotaltracker.com/story/show/177168318).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
