### PR TITLE
Fix issue with post filters.

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Traits\FiltersActivityRequests;
 use App\Http\Controllers\Traits\FiltersRequests;
 use App\Http\Requests\PostRequest;
 use App\Http\Transformers\PostTransformer;
@@ -15,7 +16,7 @@ use Illuminate\Support\Facades\Gate;
 
 class PostsController extends ActivityApiController
 {
-    use FiltersRequests;
+    use FiltersActivityRequests;
 
     /**
      * The post manager instance.

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Traits\FiltersActivityRequests;
-use App\Http\Controllers\Traits\FiltersRequests;
 use App\Http\Requests\PostRequest;
 use App\Http\Transformers\PostTransformer;
 use App\Managers\PostManager;
@@ -16,8 +14,6 @@ use Illuminate\Support\Facades\Gate;
 
 class PostsController extends ActivityApiController
 {
-    use FiltersActivityRequests;
-
     /**
      * The post manager instance.
      *

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -849,6 +849,33 @@ class PostTest extends TestCase
      *
      * @test
      */
+    public function testFilteringPostsIndexByUserId()
+    {
+        $user = factory(User::class)->create();
+
+        factory(Post::class, 2)
+            ->states('accepted')
+            ->create([
+                'northstar_id' => $user->id,
+            ]);
+
+        factory(Post::class, 3)
+            ->states('accepted')
+            ->create();
+
+        $response = $this->getJson(
+            "api/v3/posts?filter%5Bnorthstar_id%5D={$user->id}",
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(2, 'data');
+    }
+
+    /**
+     * Guests shouldn't see user IDs on anonymous actions.
+     *
+     * @test
+     */
     public function testPostsIndexWithAnonymousPostsAsGuest()
     {
         factory(Post::class)

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -845,7 +845,7 @@ class PostTest extends TestCase
     }
 
     /**
-     * Guests shouldn't see user IDs on anonymous actions.
+     * Posts can be filtered by user ID.
      *
      * @test
      */


### PR DESCRIPTION
### What's this PR do?

This pull request includes a fix for an issue filtering the `v3/posts` endpoint, detailed in [#177311555](https://www.pivotaltracker.com/story/show/177311555).

### How should this be reviewed?

I was able to validate the problem is fixed by ff83b79 using my local Phoenix & by hitting the API via Paw, but the test in 3c95dc5 seems to be passing even without the fix applied!? I'd love a fresh set of eyes on what I could be missing here, so we can make sure we have good test coverage for this behavior!

~We might also need to apply this fix to other controllers!~ Nope, we don't!

### Any background context you want to provide?

We'd kept Rogue's `FiltersRequests` trait as the `FiltersActivityRequests` trait when merging these two applications (since it conflicted with Northstar's slightly different trait of the same name). Unfortunately, we didn't update our includes to require the renamed trait so we got the Northstar one in here by mistake!

### Relevant tickets

References [Pivotal #177311555](https://www.pivotaltracker.com/story/show/177311555).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
