### PR TITLE
Subscriptions endpoint updates

### DIFF
--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -81,7 +81,14 @@ class SubscriptionController extends Controller
         }
 
         // Register new user.
-        $newUser = $this->registrar->register($request->all());
+        $newUser = $this->registrar->register(
+            $request->only([
+                'email',
+                'email_subscription_topic',
+                'source',
+                'source_detail',
+            ]),
+        );
 
         $newUser->addEmailSubscriptionTopics($topics);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1005,6 +1005,7 @@ class User extends MongoModel implements
      * Add the given topic to the user's array of topics if it is not already there.
      *
      * @param string $topic
+     * @deprecated
      */
     public function addEmailSubscriptionTopic($topic)
     {
@@ -1012,6 +1013,20 @@ class User extends MongoModel implements
         $this->email_subscription_topics = array_merge(
             $this->email_subscription_topics ?: [],
             [$topic],
+        );
+    }
+
+    /**
+     * Add one or more provided topics to the user's array of topics if not already there.
+     *
+     * @param array $topics
+     */
+    public function addEmailSubscriptionTopics($topics)
+    {
+        // Add the new topic to the existing array of topics
+        $this->email_subscription_topics = array_merge(
+            $this->email_subscription_topics ?: [],
+            $topics,
         );
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1023,7 +1023,6 @@ class User extends MongoModel implements
      */
     public function addEmailSubscriptionTopics($topics)
     {
-        // Add the new topic to the existing array of topics
         $this->email_subscription_topics = array_merge(
             $this->email_subscription_topics ?: [],
             $topics,

--- a/tests/Http/SubscriptionsTest.php
+++ b/tests/Http/SubscriptionsTest.php
@@ -30,6 +30,25 @@ class SubscriptionsTest extends TestCase
     }
 
     /**
+     * Test an empty array missing topics throws a validation error.
+     */
+    public function testEmptySubscriptionArrayIsInvalid()
+    {
+        $user = factory(User::class)->create([
+            'email_subscription_topics' => [],
+        ]);
+
+        $response = $this->json('POST', 'v2/subscriptions', [
+            'email' => $user->email,
+            'email_subscription_topic' => [],
+            'source' => 'phoenix-next',
+            'source_detail' => 'test_source_detail',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    /**
      * Test adding a subscription topic to an existing user.
      *
      * @return void


### PR DESCRIPTION
### What's this PR do?

This pull request enables passing an array of Email Newsletter subscription topics to the `/v2/subscriptions` endpoint, along with the original function of accepting just a single topic as a string.

Updating the functionality was necessary for the new Newsletter Subscription component for unauthenticated members; it lets a guest user select multiple newsletters to sign up for once they submit their email.

For new users, this will activate a password reset email so they can create a new password and the email style will depend on the first topic selected.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I added some relevant tests to ensure that the prior functionality (a single string topic) and the new functionality (an array of topics) all works as intended! 🚥 

### Relevant tickets

References [Pivotal #177168963](https://www.pivotaltracker.com/story/show/177168963).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
