### PR TITLE
Questionnaire Endpoint

### DIFF
--- a/app/Http/Controllers/QuestionnaireController.php
+++ b/app/Http/Controllers/QuestionnaireController.php
@@ -75,7 +75,7 @@ class QuestionnaireController extends ActivityApiController
      */
     public function store(Request $request)
     {
-        $this->validate($request, $this->rules);
+        $validated = $this->validate($request, $this->rules);
 
         $northstarId = getNorthstarId($request);
 
@@ -94,7 +94,7 @@ class QuestionnaireController extends ActivityApiController
 
             if (!$signup) {
                 $signup = $this->signups->create(
-                    $request->all(),
+                    $validated,
                     $northstarId,
                     $campaignId,
                 );
@@ -108,7 +108,7 @@ class QuestionnaireController extends ActivityApiController
 
             $shouldTrackToCustomerIo = $index === 0;
 
-            $post = $this->posts->create(array_merge($request->all(), [
+            $post = $this->posts->create(array_merge($validated, [
                 'action_id' => $actionId,
                 'text' => $question['answer'],
                 'details' => json_encode($postDetails),

--- a/app/Http/Controllers/QuestionnaireController.php
+++ b/app/Http/Controllers/QuestionnaireController.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\PostRequest;
+use App\Http\Transformers\PostTransformer;
+use App\Managers\PostManager;
+use App\Managers\SignupManager;
+use App\Models\Campaign;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+
+class QuestionnaireController extends ActivityApiController
+{
+    /**
+     * The post manager instance.
+     *
+     * @var \App\Managers\PostManager
+     */
+    protected $posts;
+
+    /**
+     * The SignupManager instance.
+     *
+     * @var \App\Managers\SignupManager
+     */
+    protected $signups;
+
+    /**
+     * @var \App\Http\Transformers\PostTransformer;
+     */
+    protected $transformer;
+
+    /**
+     * Create a controller instance.
+     *
+     * @param PostManager $posts
+     * @param SignupManager $signups
+     * @param PostTransformer $transformer
+     */
+    public function __construct(
+        PostManager $posts,
+        SignupManager $signups,
+        PostTransformer $transformer
+    ) {
+        $this->posts = $posts;
+        $this->signups = $signups;
+        $this->transformer = $transformer;
+
+        $this->middleware('auth:api');
+
+        $this->middleware('scope:activity');
+        $this->middleware('scope:write');
+
+        $this->rules = array_merge(
+            Arr::except((new PostRequest())->rules(), [
+                'action', 'action_id', 'campaign_id', 'type',
+            ]),
+            [
+                'questions' => 'required|array',
+                'questions.*.action_id' => 'required|integer|exists:mysql.actions,id',
+                'questions.*.title' => 'required|string',
+                'questions.*.answer' => 'required|string|max:500',
+                'contentful_id' => 'required|string',
+            ]
+        );
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $this->validate($request, $this->rules);
+
+        $northstarId = getNorthstarId($request);
+
+        $questions = $request->input('questions');
+
+        $posts = [];
+
+        $requestDetails = json_decode($request->input('details'), true) ?: [];
+
+        foreach ($questions as $question) {
+            $actionId = $question['action_id'];
+
+            // Get the campaign id from the request by action_id.
+            $campaignId = Campaign::fromActionId($actionId)->id;
+            $signup = $this->signups->get($northstarId, $campaignId);
+
+            if (!$signup) {
+                $signup = $this->signups->create(
+                    $request->all(),
+                    $northstarId,
+                    $campaignId,
+                );
+            }
+
+            $postDetails = array_merge($requestDetails, [
+                'questionnaire' => true,
+                'question' => $question['title'],
+                'contentful_id' => $request->input('contentful_id'),
+            ]);
+
+            $post = $this->posts->create(array_merge($request->all(), [
+                'action_id' => $actionId,
+                'text' => $question['answer'],
+                'details' => json_encode($postDetails),
+
+            ]), $signup->id);
+
+            array_push($posts, $post);
+        }
+
+        return $this->collection($posts, 201);
+    }
+}

--- a/app/Http/Controllers/QuestionnaireController.php
+++ b/app/Http/Controllers/QuestionnaireController.php
@@ -85,7 +85,7 @@ class QuestionnaireController extends ActivityApiController
 
         $requestDetails = json_decode($request->input('details'), true) ?: [];
 
-        foreach ($questions as $question) {
+        foreach ($questions as $index => $question) {
             $actionId = $question['action_id'];
 
             // Get the campaign id from the request by action_id.
@@ -106,12 +106,14 @@ class QuestionnaireController extends ActivityApiController
                 'contentful_id' => $request->input('contentful_id'),
             ]);
 
+            $shouldTrackToCustomerIo = $index === 0;
+
             $post = $this->posts->create(array_merge($request->all(), [
                 'action_id' => $actionId,
                 'text' => $question['answer'],
                 'details' => json_encode($postDetails),
 
-            ]), $signup->id);
+            ]), $signup->id, $shouldTrackToCustomerIo);
 
             array_push($posts, $post);
         }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -44,6 +44,7 @@ class PostRequest extends Request
             'text' => 'nullable|string|max:500',
             'location' => 'nullable|string',
             'postal_code' => 'nullable|max:10',
+            'group_id' => 'nullable|integer|exists:mysql.groups,id',
             'school_id' => 'nullable|string|max:255',
             'quantity' => 'nullable|integer',
             // Maximum ensures we don't exceed the default precision limit for this Decimal db column.

--- a/app/Managers/PostManager.php
+++ b/app/Managers/PostManager.php
@@ -43,22 +43,20 @@ class PostManager
      *
      * @param array $data
      * @param int $signupId
-     * @param string $authenticatedUserRole
+     * @param int $shouldSendToCustomerIo
      *
      * @return \App\Models\Post
      */
-    public function create($data, $signupId, $authenticatedUserRole = null)
+    public function create($data, $signupId, $shouldSendToCustomerIo = true)
     {
-        $post = $this->repository->create(
-            $data,
-            $signupId,
-            $authenticatedUserRole,
-        );
+        $post = $this->repository->create($data, $signupId);
 
-        // Send post event(s) to Customer.io for messaging:
-        SendPostToCustomerIo::dispatch($post);
+        if ($shouldSendToCustomerIo) {
+            // Send post event(s) to Customer.io for messaging:
+            SendPostToCustomerIo::dispatch($post);
+        }
 
-        if ($post->referrer_user_id) {
+        if ($shouldSendToCustomerIo && $post->referrer_user_id) {
             optional(User::find($post->referrer_user_id), function (
                 $referrerUser
             ) use ($post) {

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -46,15 +46,11 @@ class PostRepository
      *
      * @param  array $data
      * @param  int $signupId
-     * @param  string $authenticatedUserRole
      *
      * @return \App\Models\Post|null
      */
-    public function create(
-        array $data,
-        $signupId,
-        $authenticatedUserRole = null
-    ) {
+    public function create(array $data, $signupId)
+    {
         $signup = Signup::find($signupId);
 
         // Get the action_id either from the payload or the DB.

--- a/documentation/endpoints/questionnaires.md
+++ b/documentation/endpoints/questionnaires.md
@@ -1,0 +1,192 @@
+# Questionnaire Endpoint
+
+The `write` & `activity` scope is required for the create endpoint.
+
+## Store a user's Questionnaire submission 
+
+The **Questionnaire Action** block in Phoenix combines multiple **Text Submission Actions** into a single multi-question *Questionnaire*.
+
+Each question is configured with an individual Action ID so that we can store each questions response into an individual Post. 
+
+We store some metadata in the Post's `details` field to qualify that these Posts are via a Questionnaire block, and to tie the submission to its parent Contentful block & question title: e.g. `details: { questionnaire: true, question: [question title], contentful_id: [questionnaire Contentful ID] }`
+
+```
+POST /api/v3/questionnaires
+```
+
+**Request Parameters:**
+
+```js
+{
+  /* The list of questionnaire questions containing a few required properties listed below. */
+  questions: Array;
+
+  /* The question title. */
+  questions[title]: String;
+
+  /* The user submission. */
+  questions[answer]: String;
+
+  /* The Action ID associated with this question. */
+  questions[action_id]: Number;
+
+  /* The Contentful ID of the Questionnaire block. */
+  contentful_id: String;
+
+  /* This endpoint accepts the other standard parameters for POSTing to the `/api/v3/posts` endpoint which it will use to create the individual Posts. */
+}
+```
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```sh
+  curl -X "POST" "http://northstar.test/api/v3/questionnaires" \
+     -H 'Accept: application/json' \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+  "questions": [
+    { "action_id": 1, "title": "Who inspires you?", "answer": "My cat." },
+    { "action_id": 2, "title": "Why?", "answer": "They rock." },
+  ],
+  "contentful_id": "1a2b3c"
+}'
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```json
+// 200 OK
+
+{
+    "data": [
+        {
+            "id": 1,
+            "signup_id": 2,
+            "type": "text",
+            "action": "Quia Reprehenderit Aut",
+            "action_id": 1,
+            "campaign_id": "1",
+            "media": {
+                "url": null,
+                "original_image_url": null,
+                "text": "My cat."
+            },
+            "quantity": null,
+            "hours_spent": null,
+            "reactions": {
+                "reacted": false,
+                "total": null
+            },
+            "status": "pending",
+            "location": null,
+            "location_name": null,
+            "created_at": "2021-03-16T20:24:29+00:00",
+            "updated_at": "2021-03-16T20:24:29+00:00",
+            "cursor": "MTY2OA==",
+            "northstar_id": "123",
+            "tags": [],
+            "source": "dev-oauth",
+            "source_details": null,
+            "remote_addr": "0.0.0.0",
+            "details": "{\"questionnaire\":true,\"question\":\"Who inspires you?\",\"contentful_id\":\"1a2b3c\"}",
+            "referrer_user_id": null,
+            "group_id": null,
+            "school_id": null,
+            "club_id": null,
+            "action_details": {
+                "data": {
+                    "id": 2,
+                    "name": "Quia Reprehenderit Aut",
+                    "campaign_id": 1,
+                    "post_type": "text",
+                    "post_label": "Text Post",
+                    "action_type": "share-something",
+                    "action_label": "Share Something",
+                    "time_commitment": "<0.083",
+                    "time_commitment_label": "< 5 minutes",
+                    "callpower_campaign_id": null,
+                    "reportback": true,
+                    "civic_action": true,
+                    "scholarship_entry": true,
+                    "collect_school_id": true,
+                    "volunteer_credit": false,
+                    "anonymous": false,
+                    "online": false,
+                    "quiz": false,
+                    "noun": "things",
+                    "verb": "done",
+                    "created_at": "2021-03-16T16:03:49+00:00",
+                    "updated_at": "2021-03-16T16:03:49+00:00"
+                }
+            }
+        },
+        {
+            "id": 2,
+            "signup_id": 2,
+            "type": "text",
+            "action": "Quia Reprehenderit Aut",
+            "action_id": 1,
+            "campaign_id": "1",
+            "media": {
+                "url": null,
+                "original_image_url": null,
+                "text": "They rock."
+            },
+            "quantity": null,
+            "hours_spent": null,
+            "reactions": {
+                "reacted": false,
+                "total": null
+            },
+            "status": "pending",
+            "location": null,
+            "location_name": null,
+            "created_at": "2021-03-16T20:24:29+00:00",
+            "updated_at": "2021-03-16T20:24:29+00:00",
+            "cursor": "MTY2OA==",
+            "northstar_id": "123",
+            "tags": [],
+            "source": "dev-oauth",
+            "source_details": null,
+            "remote_addr": "0.0.0.0",
+            "details": "{\"questionnaire\":true,\"question\":\"Why?\",\"contentful_id\":\"1a2b3c\"}",
+            "referrer_user_id": null,
+            "group_id": null,
+            "school_id": null,
+            "club_id": null,
+            "action_details": {
+                "data": {
+                    "id": 3,
+                    "name": "Quia Reprehenderit Aut Two",
+                    "campaign_id": 1,
+                    "post_type": "text",
+                    "post_label": "Text Post",
+                    "action_type": "share-something",
+                    "action_label": "Share Something",
+                    "time_commitment": "<0.083",
+                    "time_commitment_label": "< 5 minutes",
+                    "callpower_campaign_id": null,
+                    "reportback": true,
+                    "civic_action": true,
+                    "scholarship_entry": true,
+                    "collect_school_id": true,
+                    "volunteer_credit": false,
+                    "anonymous": false,
+                    "online": false,
+                    "quiz": false,
+                    "noun": "things",
+                    "verb": "done",
+                    "created_at": "2021-03-16T16:03:49+00:00",
+                    "updated_at": "2021-03-16T16:03:49+00:00"
+                }
+            }
+        }
+    ]
+}
+```
+
+</details>

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,9 @@ Route::group(
         Route::get('signups/{signup}', 'SignupsController@show');
         Route::patch('signups/{signup}', 'SignupsController@update');
         Route::delete('signups/{signup}', 'SignupsController@destroy');
+
+        // Questionnaires
+        Route::post('questionnaires', 'QuestionnaireController@store');
     },
 );
 

--- a/tests/Http/QuestionnaireTest.php
+++ b/tests/Http/QuestionnaireTest.php
@@ -2,16 +2,10 @@
 
 use App\Models\Action;
 use App\Models\Campaign;
-use App\Models\Club;
 use App\Models\Group;
 use App\Models\Post;
-use App\Models\Reaction;
 use App\Models\Signup;
 use App\Models\User;
-use App\Services\CustomerIo;
-use App\Services\Fastly;
-use App\Services\GraphQL;
-use Illuminate\Http\UploadedFile;
 
 class QuestionnaireTest extends TestCase
 {

--- a/tests/Http/QuestionnaireTest.php
+++ b/tests/Http/QuestionnaireTest.php
@@ -6,6 +6,7 @@ use App\Models\Group;
 use App\Models\Post;
 use App\Models\Signup;
 use App\Models\User;
+use App\Services\CustomerIo;
 
 class QuestionnaireTest extends TestCase
 {
@@ -142,6 +143,9 @@ class QuestionnaireTest extends TestCase
             'referrer_user_id' => $referrerUser->id,
             'group_id' => $groupId,
         ]);
+
+        // We only want to trigger one customer.io event per questionnaire submission (even though we store two posts).
+        $this->assertCustomerIoEvent($user, 'campaign_signup_post')->once();
     }
 
     /**

--- a/tests/Http/QuestionnaireTest.php
+++ b/tests/Http/QuestionnaireTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use App\Models\Action;
+use App\Models\Campaign;
+use App\Models\Club;
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\Reaction;
+use App\Models\Signup;
+use App\Models\User;
+use App\Services\CustomerIo;
+use App\Services\Fastly;
+use App\Services\GraphQL;
+use Illuminate\Http\UploadedFile;
+
+class QuestionnaireTest extends TestCase
+{
+    /**
+     * Helper function to assert post structure.
+     */
+    public function assertPostStructure($response)
+    {
+        return $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'signup_id',
+                'northstar_id',
+                'type',
+                'action',
+                'media' => ['url', 'original_image_url', 'text'],
+                'quantity',
+                'hours_spent',
+                'tags' => [],
+                'reactions' => ['reacted', 'total'],
+                'status',
+                'details',
+                'location',
+                'school_id',
+                'club_id',
+                'source',
+                'remote_addr',
+                'created_at',
+                'updated_at',
+            ],
+        ]);
+    }
+
+    /**
+     * Test that a POST request to /posts creates a new
+     * post and signup, if it doesn't already exist.
+     *
+     * @return void
+     */
+    public function testCreatingQuestionnairePostsAndSignups()
+    {
+        $user = factory(User::class)->create();
+        $referrerUser = factory(User::class)->create();
+
+        $campaignId = factory(Campaign::class)->create()->id;
+        $location = 'US-' . $this->faker->stateAbbr();
+        $school_id = $this->faker->word;
+        $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
+        $groupId = factory(Group::class)->create()->id;
+
+        $contentfulId = '123';
+
+        $actionOne = factory(Action::class)->create([
+            'campaign_id' => $campaignId,
+            'post_type' => 'text',
+        ]);
+
+        $questionOne = ['title' => 'Question one.', 'answer' => 'Answer one.', 'action_id' =>  $actionOne->id];
+
+        $actionTwo = factory(Action::class)->create([
+            'campaign_id' => $campaignId,
+            'post_type' => 'text',
+        ]);
+
+        $questionTwo = ['title' => 'Question two.', 'answer' => 'Answer two.', 'action_id' =>  $actionTwo->id];
+
+        $response = $this->asUser($user)->json('POST', 'api/v3/questionnaires', [
+            'questions' => [$questionOne, $questionTwo],
+            'contentful_id' => $contentfulId,
+            'location' => $location,
+            'school_id' => $school_id,
+            'details' => json_encode($details),
+            'referrer_user_id' => $referrerUser->id,
+            'group_id' => $groupId,
+        ]);
+
+        $response->assertStatus(201)->assertJson([
+            'data' => [
+                [
+                    'action_id' => $questionOne['action_id'],
+                    'media' => ['text' => $questionOne['answer']],
+                ],
+                [
+                    'action_id' => $questionTwo['action_id'],
+                    'media' => ['text' => $questionTwo['answer']],
+                ],
+            ],
+        ]);
+
+        // Make sure the signup is persisted to the database.
+        $this->assertMysqlDatabaseHas('signups', [
+            'campaign_id' => $campaignId,
+            'northstar_id' => $user->id,
+            'referrer_user_id' => $referrerUser->id,
+            'group_id' => $groupId,
+        ]);
+
+        // Make sure two posts are persisted to the database.
+        $this->assertMysqlDatabaseHas('posts',
+        [
+            'northstar_id' => $user->id,
+            'campaign_id' => $campaignId,
+            'type' => 'text',
+            'action' => $actionOne->name,
+            'action_id' => $actionOne->id,
+            'text' => $questionOne['answer'],
+            'status' => 'pending',
+            'location' => $location,
+            'school_id' => $school_id,
+            'details' => json_encode(array_merge($details, [
+                'questionnaire' => true,
+                'question' => $questionOne['title'],
+                'contentful_id' => $contentfulId,
+            ])),
+            'referrer_user_id' => $referrerUser->id,
+            'group_id' => $groupId,
+        ]);
+
+        $this->assertMysqlDatabaseHas('posts', [
+            'northstar_id' => $user->id,
+            'campaign_id' => $campaignId,
+            'type' => 'text',
+            'action' => $actionTwo->name,
+            'action_id' => $actionTwo->id,
+            'text' => $questionTwo['answer'],
+            'status' => 'pending',
+            'location' => $location,
+            'school_id' => $school_id,
+            'details' => json_encode(array_merge($details, [
+                'questionnaire' => true,
+                'question' => $questionTwo['title'],
+                'contentful_id' => $contentfulId,
+            ])),
+            'referrer_user_id' => $referrerUser->id,
+            'group_id' => $groupId,
+        ]);
+    }
+
+    /**
+     * Test validation for creating a post.
+     *
+     * POST /api/v3/posts
+     * @return void
+     */
+    public function testCreatingAQuestionnaireWithValidationErrors()
+    {
+        $user = factory(User::class)->create();
+        $action = factory(Action::class)->create([
+            'post_type' => 'text',
+        ]);
+
+        $response = $this->asUser($user)->postJson('api/v3/questionnaires', [
+            'action_id' => $action->id,
+            'type' => 'text',
+            'questions' => [
+                [
+                    // Should be a valid Action ID:
+                    'action_id' => null,
+                    // Should both be Strings:
+                    'title' => 1,
+                    'answer' => 2,
+                ],
+            ],
+            // and we've omitted the required 'contentful_id' field!
+        ]);
+
+        $response->assertJsonValidationErrors([
+            'contentful_id',
+            'questions.0.action_id',
+            'questions.0.title',
+            'questions.0.answer',
+        ]);
+    }
+
+    /**
+     * Test that non-authenticated user's/apps can't create a questionnaire.
+     *
+     * @return void
+     */
+    public function testUnauthenticatedUserCreatingAQuestionnaire()
+    {
+        $response = $this->postJson('api/v3/posts', []);
+
+        $response->assertUnauthorized();
+    }
+}

--- a/tests/Http/QuestionnaireTest.php
+++ b/tests/Http/QuestionnaireTest.php
@@ -11,36 +11,6 @@ use App\Services\CustomerIo;
 class QuestionnaireTest extends TestCase
 {
     /**
-     * Helper function to assert post structure.
-     */
-    public function assertPostStructure($response)
-    {
-        return $response->assertJsonStructure([
-            'data' => [
-                'id',
-                'signup_id',
-                'northstar_id',
-                'type',
-                'action',
-                'media' => ['url', 'original_image_url', 'text'],
-                'quantity',
-                'hours_spent',
-                'tags' => [],
-                'reactions' => ['reacted', 'total'],
-                'status',
-                'details',
-                'location',
-                'school_id',
-                'club_id',
-                'source',
-                'remote_addr',
-                'created_at',
-                'updated_at',
-            ],
-        ]);
-    }
-
-    /**
      * Test that a POST request to /posts creates a new
      * post and signup, if it doesn't already exist.
      *

--- a/tests/Http/QuestionnaireTest.php
+++ b/tests/Http/QuestionnaireTest.php
@@ -23,7 +23,7 @@ class QuestionnaireTest extends TestCase
 
         $campaignId = factory(Campaign::class)->create()->id;
         $location = 'US-' . $this->faker->stateAbbr();
-        $school_id = $this->faker->word;
+        $schoolId = $this->faker->school_id;
         $details = ['source-detail' => 'broadcast-123', 'other' => 'other'];
         $groupId = factory(Group::class)->create()->id;
 
@@ -47,7 +47,7 @@ class QuestionnaireTest extends TestCase
             'questions' => [$questionOne, $questionTwo],
             'contentful_id' => $contentfulId,
             'location' => $location,
-            'school_id' => $school_id,
+            'school_id' => $schoolId,
             'details' => json_encode($details),
             'referrer_user_id' => $referrerUser->id,
             'group_id' => $groupId,
@@ -85,7 +85,7 @@ class QuestionnaireTest extends TestCase
             'text' => $questionOne['answer'],
             'status' => 'pending',
             'location' => $location,
-            'school_id' => $school_id,
+            'school_id' => $schoolId,
             'details' => json_encode(array_merge($details, [
                 'questionnaire' => true,
                 'question' => $questionOne['title'],
@@ -104,7 +104,7 @@ class QuestionnaireTest extends TestCase
             'text' => $questionTwo['answer'],
             'status' => 'pending',
             'location' => $location,
-            'school_id' => $school_id,
+            'school_id' => $schoolId,
             'details' => json_encode(array_merge($details, [
                 'questionnaire' => true,
                 'question' => $questionTwo['title'],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,7 +107,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         });
 
         // We should have tracked this event for the provided user:
-        $this->customerIoMock
+        return $this->customerIoMock
             ->shouldHaveReceived('trackEvent')
             ->with($userMatcher, $eventName, Mockery::any());
     }


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `/api/v3/questionnaires` endpoint to enable POSTing user submissions for the new **Questionnaire Action** from Phoenix (https://github.com/DoSomething/phoenix-next/pull/2571).

### How should this be reviewed?
commit-by-commit if preferred.

Do you think this implementation is sound?

### Any background context you want to provide?
A Questionnaire is composed of multiple questions, each tied to a separate Action ID. Our goal is to store individual Posts per question submission.

The Questionnaire endpoint enables us to accept specific questionnaire parameters which we use to create the individual Posts (& corresponding signups), and decorate the `details` with some questionnaire-specific information.

Additionally, we only want to track _one_ customer.io event per groups of Questionnaire posts, which is tackled in https://github.com/DoSomething/northstar/commit/28a6421ecf61d38a8ec619fb1ceb148b862bf5b8 via a new parameter to the `PostManager->create` method to specify tracking the customer.io event for created posts.

### Relevant tickets

References [Pivotal #177321999](https://www.pivotaltracker.com/story/show/177321999).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
