### PR TITLE
Adds Four Posts Badge!

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -486,15 +486,12 @@ class Post extends Model
                 ->count();
 
             if ($userPostsWithFaveTagCount >= 3) {
-                $this->user->addBadge(BadgeType::get('ONE_STAFF_FAVE'));
-                $this->user->addBadge(BadgeType::get('TWO_STAFF_FAVES'));
                 $this->user->addBadge(BadgeType::get('THREE_STAFF_FAVES'));
             }
-            if ($userPostsWithFaveTagCount === 2) {
-                $this->user->addBadge(BadgeType::get('ONE_STAFF_FAVE'));
+            if ($userPostsWithFaveTagCount >= 2) {
                 $this->user->addBadge(BadgeType::get('TWO_STAFF_FAVES'));
             }
-            if ($userPostsWithFaveTagCount === 1) {
+            if ($userPostsWithFaveTagCount >= 1) {
                 $this->user->addBadge(BadgeType::get('ONE_STAFF_FAVE'));
             }
 
@@ -788,21 +785,15 @@ class Post extends Model
         if ($user) {
             $userPostsCount = $user->posts()->count();
             if ($userPostsCount >= 4) {
-                $user->addBadge(BadgeType::get('ONE_POST'));
-                $user->addBadge(BadgeType::get('TWO_POSTS'));
-                $user->addBadge(BadgeType::get('THREE_POSTS'));
                 $user->addBadge(BadgeType::get('FOUR_POSTS'));
             }
-            if ($userPostsCount === 3) {
-                $user->addBadge(BadgeType::get('ONE_POST'));
-                $user->addBadge(BadgeType::get('TWO_POSTS'));
+            if ($userPostsCount >= 3) {
                 $user->addBadge(BadgeType::get('THREE_POSTS'));
             }
-            if ($userPostsCount === 2) {
-                $user->addBadge(BadgeType::get('ONE_POST'));
+            if ($userPostsCount >= 2) {
                 $user->addBadge(BadgeType::get('TWO_POSTS'));
             }
-            if ($userPostsCount === 1) {
+            if ($userPostsCount >= 1) {
                 $user->addBadge(BadgeType::get('ONE_POST'));
             }
             $user->save();

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -787,7 +787,13 @@ class Post extends Model
         $user = $this->user;
         if ($user) {
             $userPostsCount = $user->posts()->count();
-            if ($userPostsCount >= 3) {
+            if ($userPostsCount >= 4) {
+                $user->addBadge(BadgeType::get('ONE_POST'));
+                $user->addBadge(BadgeType::get('TWO_POSTS'));
+                $user->addBadge(BadgeType::get('THREE_POSTS'));
+                $user->addBadge(BadgeType::get('FOUR_POSTS'));
+            }
+            if ($userPostsCount === 3) {
                 $user->addBadge(BadgeType::get('ONE_POST'));
                 $user->addBadge(BadgeType::get('TWO_POSTS'));
                 $user->addBadge(BadgeType::get('THREE_POSTS'));

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -800,6 +800,9 @@ class User extends MongoModel implements
             'three_posts_badge' => in_array('three-posts', $this->badges)
                 ? true
                 : false,
+            'four_posts_badge' => in_array('four-posts', $this->badges)
+                ? true
+                : false,
             'news_subscription_badge' => in_array(
                 'news-subscription',
                 $this->badges,

--- a/app/Types/BadgeType.php
+++ b/app/Types/BadgeType.php
@@ -8,6 +8,7 @@ class BadgeType extends Type
     private const ONE_POST = 'one-post';
     private const TWO_POSTS = 'two-posts';
     private const THREE_POSTS = 'three-posts';
+    private const FOUR_POSTS = 'four-posts';
     private const NEWS_SUBSCRIPTION = 'news-subscription';
     private const ONE_STAFF_FAVE = 'one-staff-fave';
     private const TWO_STAFF_FAVES = 'two-staff-faves';
@@ -25,6 +26,7 @@ class BadgeType extends Type
             self::ONE_POST => 'One Post Badge',
             self::TWO_POSTS => 'Two Posts Badge',
             self::THREE_POSTS => 'Three Posts Badge',
+            self::FOUR_POSTS => 'Four Posts Badge',
             self::NEWS_SUBSCRIPTION => 'News Subscription Badge',
             self::ONE_STAFF_FAVE => 'One Staff Fave Badge',
             self::TWO_STAFF_FAVES => 'Two Staff Faves Badge',

--- a/tests/Http/TagsTest.php
+++ b/tests/Http/TagsTest.php
@@ -462,6 +462,7 @@ class TagsTest extends TestCase
                 'two-staff-faves',
                 'three-posts',
                 'three-staff-faves',
+                'four-posts',
             ],
             $user->badges,
         );

--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -94,6 +94,7 @@ class UserModelTest extends TestCase
             'one_post_badge' => false,
             'two_posts_badge' => false,
             'three_posts_badge' => false,
+            'four_posts_badge' => false,
             'news_subscription_badge' => false,
             'one_staff_fave_badge' => false,
             'two_staff_faves_badge' => false,


### PR DESCRIPTION
### What's this PR do?

This pull request adds one additional badge for when a user takes a fourth action, since there should be 6 badges "visible" to users and we reference 6 badges in our communications about it.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This was meant to be added in to replace the voter registration badge but we forgot to prioritize!!

### Relevant tickets

References [Pivotal #177399018](https://www.pivotaltracker.com/story/show/177399018).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [x] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [x] If new attributes were added to users, then the data team already knows about these changes.
