### PR TITLE
Register admin post route with Laravel.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -160,6 +160,9 @@ if (config('features.admin')) {
             Route::view('groups/{id}', 'admin.app');
             Route::view('groups/{id}/posts', 'admin.app');
 
+            // Posts
+            Route::view('posts/{id}', 'admin.app');
+
             // Signups
             Route::view('signups', 'admin.app');
             Route::view('signups/{id}', 'admin.app');


### PR DESCRIPTION
### What's this PR do?

This pull request registers the `/admin/posts/:id` route with Laravel so that it knows to route that to our client-side admin application when it gets incoming requests. (This was previously working when clicking around in-app on the admin UI, but wouldn't work if you were following an external link to get there).

### How should this be reviewed?

👁️

### Any background context you want to provide?

This is the only remaining issue I ran into when testing this out on QA!🦞 

### Relevant tickets

References [Pivotal #176911792](https://www.pivotaltracker.com/story/show/176911792).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
