### PR TITLE
Dispatch DeleteCustomerIoProfile on low priority queue

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -196,7 +196,8 @@ class UserObserver
         if ($user->wasChanged('promotions_muted_at')) {
             // And we set it, delete the Customer.io profile.
             if ($mutedPromotions) {
-                return DeleteCustomerIoProfile::dispatch($user);
+                return DeleteCustomerIoProfile::dispatch($user)
+                    ->onQueue(config('queue.names.low'));
             }
 
             // Otherwise, it's null and we need to track resubscribe.


### PR DESCRIPTION
### What's this PR do?

This pull request modifies our `UserObserver` to dispatch deleting Customer.io profiles to the low priority queue, to be consistent with where we dispatch upserting profiles.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Caught this when the `RemoveCustomerIoMobile` in production today, where we didn't expect to see so many jobs in the high priority queue.

### Relevant tickets

References [Pivotal #177168318](https://www.pivotaltracker.com/story/show/177168318).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
