### PR TITLE
UserObserver cleanup

### DIFF
--- a/tests/Models/UserModelTest.php
+++ b/tests/Models/UserModelTest.php
@@ -386,7 +386,8 @@ class UserModelTest extends TestCase
             $clubLeader->email,
         );
 
-        $user->update(['club_id' => $newClubId]);
+        $user->club_id = $newClubId;
+        $user->save();
 
         $this->assertCustomerIoEvent($user, 'club_id_updated');
     }
@@ -408,7 +409,8 @@ class UserModelTest extends TestCase
         // The Customer.io event shoud not be dispatched.
         $this->customerIoMock->shouldNotReceive('trackEvent');
 
-        $user->update(['club_id' => 123]);
+        $user->club_id = 123;
+        $user->save();
     }
 
     /** @test */


### PR DESCRIPTION
### What's this PR do?

This pull request moves the end of the code in the UserObserver's `updating` hook into the `updated` hook -- where we're no longer modifying model attributes we before save. Refs https://github.com/DoSomething/northstar/pull/1127#discussion_r580352288

### How should this be reviewed?

👀 

### Any background context you want to provide?

♻️ 

### Relevant tickets

References [Pivotal #176771234](https://www.pivotaltracker.com/n/projects/2328687/stories/176771234).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
