### PR TITLE
Fix issues with Slack tag notifications.

### DIFF
--- a/app/Notifications/PostTagged.php
+++ b/app/Notifications/PostTagged.php
@@ -35,7 +35,7 @@ class PostTagged extends Notification implements ShouldQueue
     public $admin;
 
     /*
-     * OLD: The ID of the amdin who tagged this post.
+     * OLD: The ID of the admin who tagged this post.
      *
      * @var string
      */

--- a/app/Notifications/PostTagged.php
+++ b/app/Notifications/PostTagged.php
@@ -106,11 +106,7 @@ class PostTagged extends Notification implements ShouldQueue
                     '":',
             )
             ->attachment(function ($attachment) use ($userName) {
-                $permalink = route(
-                    'signups.show',
-                    [$this->post->signup_id],
-                    true,
-                );
+                $permalink = url("/admin/posts/{$this->post->id}");
                 $image = $this->post->getMediaUrl();
 
                 $attachment

--- a/app/Notifications/PostTagged.php
+++ b/app/Notifications/PostTagged.php
@@ -91,7 +91,8 @@ class PostTagged extends Notification implements ShouldQueue
         $adminName = $this->admin->display_name;
 
         return (new SlackMessage())
-            ->from('Rogue', ':tonguecat:')
+            ->from('DoSomething.org')
+            ->image(url('apple-touch-icon-precomposed.png'))
             ->content(
                 $adminName .
                     ' just tagged this post as "' .


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue that was preventing us from sending Slack notifications when a post is tagged as "Good Submission", "Good Quote", et cetera. I've also updated this job to read user information directly from the database, rather than querying via GraphQL & done a little extra tidying up. 🍃 

### How should this be reviewed?

I'd recommend reviewing commit-by-commit. The last commit is a grab-bag to reformat for readability!

### Any background context you want to provide?

💬

### Relevant tickets

References [Pivotal #177437948](https://www.pivotaltracker.com/story/show/177437948).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
