### PR TITLE
Add Backfill Method for Badges

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -478,25 +478,7 @@ class Post extends Model
             }
         }
 
-        if ($this->user) {
-            $userPostsWithFaveTagCount = $this->user
-                ->posts()
-                ->withTag('good-submission')
-                ->take(3)
-                ->count();
-
-            if ($userPostsWithFaveTagCount >= 3) {
-                $this->user->addBadge(BadgeType::get('THREE_STAFF_FAVES'));
-            }
-            if ($userPostsWithFaveTagCount >= 2) {
-                $this->user->addBadge(BadgeType::get('TWO_STAFF_FAVES'));
-            }
-            if ($userPostsWithFaveTagCount >= 1) {
-                $this->user->addBadge(BadgeType::get('ONE_STAFF_FAVE'));
-            }
-
-            $this->user->save();
-        }
+        $this->calculateStaffFaveTagBadges();
 
         return $this;
     }
@@ -796,6 +778,33 @@ class Post extends Model
             if ($userPostsCount >= 1) {
                 $user->addBadge(BadgeType::get('ONE_POST'));
             }
+            $user->save();
+        }
+    }
+
+    /**
+     * Checks whether a user should be given a badge based on their post.
+     */
+    public function calculateStaffFaveTagBadges()
+    {
+        $user = $this->user;
+        if ($user) {
+            $userPostsWithFaveTagCount = $user
+                ->posts()
+                ->withTag('good-submission')
+                ->take(3)
+                ->count();
+
+            if ($userPostsWithFaveTagCount >= 3) {
+                $user->addBadge(BadgeType::get('THREE_STAFF_FAVES'));
+            }
+            if ($userPostsWithFaveTagCount >= 2) {
+                $user->addBadge(BadgeType::get('TWO_STAFF_FAVES'));
+            }
+            if ($userPostsWithFaveTagCount >= 1) {
+                $user->addBadge(BadgeType::get('ONE_STAFF_FAVE'));
+            }
+
             $user->save();
         }
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -783,7 +783,8 @@ class Post extends Model
     }
 
     /**
-     * Checks whether a user should be given a badge based on their post.
+     * Checks whether a user should be given a badge based on if their post has been tagged
+     * a good-submission by staff.
      */
     public function calculateStaffFaveTagBadges()
     {

--- a/app/Models/Signup.php
+++ b/app/Models/Signup.php
@@ -304,8 +304,8 @@ class Signup extends Model
     {
         $user = $this->user;
         if ($user) {
-            $userSignups = $user->signups();
-            if ($userSignups->count() === 1) {
+            $userSignups = $user->signups()->count();
+            if ($userSignups > 0) {
                 $user->addBadge(BadgeType::get('SIGNUP'));
                 $user->save();
             }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,6 @@ use App\Types\BadgeType;
 use App\Types\PasswordResetType;
 use Carbon\Carbon;
 use Email\Parse as EmailParser;
-use Facade\Ignition\DumpRecorder\Dump;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1325,7 +1325,7 @@ class User extends MongoModel implements
     }
 
     /**
-     * Runs our badges calculators to be sure active users have the correct badges earned
+     * Runs our badges calculators to be sure active users have the correct badges earned.
      */
     public function backfillBadges()
     {

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -186,11 +186,8 @@ class UserObserver
             ]);
         }
 
-        /*
-         * Handle any changes to the user's subscriptions/promotions.
-         */
-
-        $user->calculateUserSubscriptionBadges();
+        // Handle any changes to the user's subscriptions/promotions.
+        $user->backfillBadges();
 
         $mutedPromotions = isset($user->promotions_muted_at);
         $shouldTrackPromotionsResubscribe = false;
@@ -199,8 +196,9 @@ class UserObserver
         if ($user->wasChanged('promotions_muted_at')) {
             // And we set it, delete the Customer.io profile.
             if ($mutedPromotions) {
-                return DeleteCustomerIoProfile::dispatch($user)
-                    ->onQueue(config('queue.names.low'));
+                return DeleteCustomerIoProfile::dispatch($user)->onQueue(
+                    config('queue.names.low'),
+                );
             }
 
             // Otherwise, it's null and we need to track resubscribe.

--- a/tests/BrowserKitTestCase.php
+++ b/tests/BrowserKitTestCase.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert;
 use Tests\CreatesApplication;
@@ -8,7 +9,7 @@ use Tests\WithMocks;
 
 abstract class BrowserKitTestCase extends Laravel\BrowserKitTesting\TestCase
 {
-    use CreatesApplication, WithMocks, WithAuthentication;
+    use CreatesApplication, WithMocks, WithAuthentication, RefreshDatabase;
 
     /**
      * The base URL to use while testing the application.

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1264,7 +1264,7 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test that the correct badges are added to a user even when based on historical action
+     * Test that the correct badges are added to a user even when based on historical action.
      *
      * @return void
      */

--- a/tests/Http/UserTest.php
+++ b/tests/Http/UserTest.php
@@ -1262,4 +1262,48 @@ class UserTest extends TestCase
             'badges' => ['news-subscription'],
         ]);
     }
+
+    /**
+     * Test that the correct badges are added to a user even when based on historical action
+     *
+     * @return void
+     */
+    public function testBadgesBackfillForActiveUsers()
+    {
+        $activeUser = factory(User::class)
+            ->states('email-subscribed-news')
+            ->create();
+        $campaignId = $this->faker->randomNumber(4);
+
+        $response = $this->asUser($activeUser)->postJson('api/v3/signups', [
+            'campaign_id' => $campaignId,
+            'details' => 'badge-testing',
+        ]);
+
+        // Make sure we get the 201 Created response
+        $response->assertStatus(201);
+
+        $this->assertMongoDatabaseHas('users', [
+            '_id' => $activeUser->id,
+            'badges' => ['news-subscription', 'signup'],
+        ]);
+
+        $secondResponse = $this->asAdminUser()->json(
+            'PUT',
+            'v2/users/' . $activeUser->id,
+            [
+                'badges' => [],
+            ],
+        );
+        // simulating a "updated user"
+        $activeUser->touch();
+
+        $secondResponse->assertStatus(200);
+
+        //check that the badges have been re added
+        $this->assertMongoDatabaseHas('users', [
+            '_id' => $activeUser->id,
+            'badges' => ['signup', 'news-subscription'],
+        ]);
+    }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request creates a method for users that have recently been updated to double check they have all the correct badges assigned to them based on activity. It also adds a test to make sure this works as expected.

### How should this be reviewed?

Any other cases that seem necessary for tests?

### Any background context you want to provide?

This is our solution to make sure all existing and active users have their accounts updated properly with badges they've earned for past activity.

### Relevant tickets

References [Pivotal #177327500](https://www.pivotaltracker.com/story/show/177327500).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
