### PR TITLE
Add Algolia config vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,11 @@ GOOGLE_TAG_MANAGER_ID=
 
 SNOWPLOW_URL= # without https://
 
+# Algolia (only use if testing indexing):
+SCOUT_DRIVER=null
+ALGOLIA_APP_ID=
+ALGOLIA_SECRET=
+
 # ==============================================================================
 # Feature Flags
 # ==============================================================================


### PR DESCRIPTION
### What's this PR do?

This pull request pastes over the Algolia/Scout config variables into the .env.example [from Rogue](https://github.com/DoSomething/rogue/blob/4d43ca518ab629af0dd0297a772615f8a824350a/.env.example#L44-#L47).

### How should this be reviewed?
👀 

### Any background context you want to provide?
https://dosomething.slack.com/archives/CP2D7UGAU/p1617296309022300
