### PR TITLE
Dimension Validation Message on the Post file field

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -107,4 +107,17 @@ class PostRequest extends Request
 
         return $rule;
     }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'file.dimensions' => 'Photos must be no larger than 10MB, at least :min_width x :min_height, and no larger
+          than :max_width x :max_height. Try cropping your photo.',
+        ];
+    }
 }

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -34,8 +34,6 @@ return [
     'different' => 'The :attribute and :other must be different.',
     'digits' => 'The :attribute must be :digits digits.',
     'digits_between' => 'The :attribute must be between :min and :max digits.',
-    'dimensions' => "Photos must be no larger than 10MB, at least :min_width x :min_height, and no larger
-          than :max_width x :max_height. Try cropping your photo.",
     'email' => 'The :attribute must be a valid email address.',
     'filled' => 'The :attribute field is required.',
     'exists' => 'The selected :attribute is invalid.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,8 +1,5 @@
 <?php
 
-$minImageSize = config('posts.image.min');
-$maxImageSize = config('posts.image.max');
-
 return [
     /*
     |--------------------------------------------------------------------------
@@ -37,8 +34,8 @@ return [
     'different' => 'The :attribute and :other must be different.',
     'digits' => 'The :attribute must be :digits digits.',
     'digits_between' => 'The :attribute must be between :min and :max digits.',
-    'dimensions' => "Photos must be no larger than 10MB, at least {$minImageSize['width']} x {$minImageSize['height']}, and no larger
-          than {$maxImageSize['width']} x {$maxImageSize['height']}. Try cropping your photo.",
+    'dimensions' => "Photos must be no larger than 10MB, at least :min_width x :min_height, and no larger
+          than :max_width x :max_height. Try cropping your photo.",
     'email' => 'The :attribute must be a valid email address.',
     'filled' => 'The :attribute field is required.',
     'exists' => 'The selected :attribute is invalid.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,5 +1,8 @@
 <?php
 
+$minImageSize = config('posts.image.min');
+$maxImageSize = config('posts.image.max');
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -34,6 +37,8 @@ return [
     'different' => 'The :attribute and :other must be different.',
     'digits' => 'The :attribute must be :digits digits.',
     'digits_between' => 'The :attribute must be between :min and :max digits.',
+    'dimensions' => "Photos must be no larger than 10MB, at least {$minImageSize['width']} x {$minImageSize['height']}, and no larger
+          than {$maxImageSize['width']} x {$maxImageSize['height']}. Try cropping your photo.",
     'email' => 'The :attribute must be a valid email address.',
     'filled' => 'The :attribute field is required.',
     'exists' => 'The selected :attribute is invalid.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -34,6 +34,7 @@ return [
     'different' => 'The :attribute and :other must be different.',
     'digits' => 'The :attribute must be :digits digits.',
     'digits_between' => 'The :attribute must be between :min and :max digits.',
+    'dimensions' => 'The :attribute has invalid image dimensions.',
     'email' => 'The :attribute must be a valid email address.',
     'filled' => 'The :attribute field is required.',
     'exists' => 'The selected :attribute is invalid.',


### PR DESCRIPTION
### What's this PR do?

This pull request adds a custom validation message for `dimension` errors for the Post `file` field. 

### How should this be reviewed?
👀 

### Any background context you want to provide?
We'd like to have clearer validation messaging for users reporting back on our website. We're overwriting the standard error message (which was missing from this config in the first place.)

(This is technically global, but we only enforce these dimension validations on the `file` field for Posts. If we add this for some other purpose we can configure this more locally.)

See https://github.com/DoSomething/phoenix-next/pull/2595 & https://github.com/DoSomething/phoenix-next/pull/2595#issuecomment-814218762

### Relevant tickets

References [Pivotal #177189106](https://www.pivotaltracker.com/story/show/177189106).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
