### PR TITLE
Fix bug where users who unselect "WYD" in registration flow are still subscribed to it

### DIFF
--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -52,7 +52,13 @@ class ProfileSubscriptionsController extends Controller
 
         $currentMobile = $user->mobile;
 
-        $this->registrar->register($request->all(), $user, function (
+        // Make sure that we wipe out existing email topics if the form is submitted with none checked
+        $request = $request->all();
+        if (!array_key_exists('email_subscription_topics', $request)) {
+            $request['email_subscription_topics'] = [];
+        }
+
+        $this->registrar->register($request, $user, function (
             $user
         ) use ($currentMobile) {
             // Set the sms_status if we're adding or updating the user's mobile.

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -53,12 +53,12 @@ class ProfileSubscriptionsController extends Controller
         $currentMobile = $user->mobile;
 
         // Make sure that we wipe out existing email topics if the form is submitted with none checked
-        $request = $request->all();
-        if (!array_key_exists('email_subscription_topics', $request)) {
-            $request['email_subscription_topics'] = [];
+        $input = $request->all();
+        if (!array_key_exists('email_subscription_topics', $input)) {
+            $input['email_subscription_topics'] = [];
         }
 
-        $this->registrar->register($request, $user, function (
+        $this->registrar->register($input, $user, function (
             $user
         ) use ($currentMobile) {
             // Set the sms_status if we're adding or updating the user's mobile.

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -62,6 +62,31 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
     }
 
     /**
+     * Test that users can successfully set no newsletters.
+     */
+    public function testSelectingNoNewsletters()
+    {
+        // Create a user with the "community" topic just like in registerViaWeb
+        $user = factory(User::class)->create([
+            'sms_status' => null,
+            'mobile' => null,
+            'email_subscription_topics' => ['community']
+        ]);
+
+        // Go to the third page of the registration flow
+        $this->be($user, 'web');
+
+        $this->visit('/profile/subscriptions')
+            ->uncheck('email_subscription_topics[0]')
+            ->press('Finish');
+
+        // Make sure the user has no email topics set
+        $updatedUser = $user->fresh();
+
+        $this->assertEquals([], $updatedUser->email_subscription_topics);
+    }
+
+    /**
      * Test that users can move to the next step of registration without updating any fields.
      */
     public function testFinishButtonWithoutUpdates()

--- a/tests/Http/ProfileSubscriptionsTest.php
+++ b/tests/Http/ProfileSubscriptionsTest.php
@@ -70,7 +70,7 @@ class ProfileSubscriptionsTest extends BrowserKitTestCase
         $user = factory(User::class)->create([
             'sms_status' => null,
             'mobile' => null,
-            'email_subscription_topics' => ['community']
+            'email_subscription_topics' => ['community'],
         ]);
 
         // Go to the third page of the registration flow


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a very specific bug! When a member went through the web registration form:
1. After first page, gets subscribed to WYD (correct!)
2. On third page, if they unchecked WYD and did not check any other newletters, they would still be subscribed to WYD. (incorrect!)

The issue was that Laravel does not include in the request fields that have not been filled out. A form with four checkboxes where none are checked appears to indicate no change, but it fact signifies clearing out all email topics since we know for sure that one of those boxes was checked by default. (If an existing user happens to hit this page, they will still get the correct experience too!) So, now we check the request for `email_subscription_topics`  and if none are found, we actively set that to `[]`.

### How should this be reviewed?

See failing and then passing test as proof that this works!


### Relevant tickets

References [Pivotal #177290113](https://www.pivotaltracker.com/story/show/177290113).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.

