### PR TITLE
Update hours_spent field validated minimum value

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -48,7 +48,7 @@ class PostRequest extends Request
             'school_id' => 'nullable|string|max:255',
             'quantity' => 'nullable|integer',
             // Maximum ensures we don't exceed the default precision limit for this Decimal db column.
-            'hours_spent' => 'nullable|numeric|min:0.1|max:999999.99',
+            'hours_spent' => 'nullable|numeric|min:0.01|max:999999.99',
             'file' =>
                 'image|dimensions:min_width=' .
                 $minImageSize['width'] .

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -374,7 +374,7 @@ class PostTest extends TestCase
         $response = $this->asUser($signup->user)->postJson('api/v3/posts', [
             'type' => 'photo',
             'action_id' => $action->id,
-            'hours_spent' => 0, // This should be a minimum of 0.1.
+            'hours_spent' => 0.00, // This should be a minimum of 0.01.
         ]);
 
         $response->assertJsonValidationErrors(['hours_spent']);


### PR DESCRIPTION
### What's this PR do?

This pull request updates the validation on the `hours_spent` Post field to `0.01`

### How should this be reviewed?
👀 

### Any background context you want to provide?
Now that we accept minutes explicitly (https://github.com/DoSomething/phoenix-next/pull/2606), it's possible to receive a value under `0.1` (anything under 5 minutes).

### Relevant tickets
https://dosomething.slack.com/archives/C09ANFQLA/p1618427752064900?thread_ts=1618365713.056500&cid=C09ANFQLA

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
