### PR TITLE
Updating Rock The Vote ID column to be non-incrementing.

### DIFF
--- a/database/migrations/2021_04_16_000000_change_rock_the_vote_to_use_nonincrementing_ids.php
+++ b/database/migrations/2021_04_16_000000_change_rock_the_vote_to_use_nonincrementing_ids.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeRockTheVoteToUseNonincrementingIds extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rock_the_vote_reports', function (Blueprint $table) {
+            $table->integer('id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rock_the_vote_reports', function (Blueprint $table) {
+            $table->increments('id')->change();
+        });
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration to modify the `id` column in the `rock_the_vote_reports` table to match what existed in Chompy. In #1180 we mistakenly made this column auto-increment and realized while reviewing the models that the ID is based off of a Rock The Vote record ID and should not auto-increment.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Say no to counting.

### Relevant tickets

References [Pivotal #177733137](https://www.pivotaltracker.com/story/show/177733137).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
