### PR TITLE
More efficient user creation in factory setup.

### DIFF
--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -15,6 +15,9 @@ $factory->define(Post::class, function (Faker $faker) {
     $faker->addProvider(new FakerSchoolId($faker));
 
     return [
+        'northstar_id' => function () {
+            return factory(User::class)->create()->id;
+        },
         'campaign_id' => function () {
             return factory(Campaign::class)->create()->id;
         },
@@ -29,9 +32,6 @@ $factory->define(Post::class, function (Faker $faker) {
             return factory(Action::class)->create([
                 'campaign_id' => $attributes['campaign_id'],
             ])->id;
-        },
-        'northstar_id' => function () {
-            factory(User::class)->create()->id;
         },
         'text' => $faker->sentence(),
         'location' => 'US-' . $faker->stateAbbr(),

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -30,7 +30,9 @@ $factory->define(Post::class, function (Faker $faker) {
                 'campaign_id' => $attributes['campaign_id'],
             ])->id;
         },
-        'northstar_id' => factory(User::class)->create(),
+        'northstar_id' => function () {
+            factory(User::class)->create()->id;
+        },
         'text' => $faker->sentence(),
         'location' => 'US-' . $faker->stateAbbr(),
         'source' => 'phpunit',

--- a/database/factories/RockTheVoteLogFactory.php
+++ b/database/factories/RockTheVoteLogFactory.php
@@ -15,6 +15,8 @@ $factory->define(RockTheVoteLog::class, function (Faker $faker) {
         'started_registration' => Carbon::now()->format('Y-m-d H:i:s O'),
         'status' => 'Step 1',
         'tracking_source' => 'ads',
-        'user_id' => factory(User::class)->create(),
+        'user_id' => function () {
+            return factory(User::class)->create()->id;
+        },
     ];
 });

--- a/tests/Http/TagsTest.php
+++ b/tests/Http/TagsTest.php
@@ -186,6 +186,7 @@ class TagsTest extends TestCase
         $this->assertContains('Good Submission', $post->tagNames());
 
         $user = $user->fresh();
+
         $this->assertEquals(
             ['signup', 'one-post', 'one-staff-fave'],
             $user->badges,


### PR DESCRIPTION
### What's this PR do?

This pull request updates how users are created in factories and improves it by wrapping it in a closure which is only executed if not value for the `user_id` field is provided.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Great suggestion by @DFurnes in [previous PR](https://github.com/DoSomething/northstar/pull/1182/files/2f33b64122c55a3ab20c54d08f72aaff6c69af88#diff-0f9d790228ea7bad6f8d105f9db55ecb83def4973ecf4cef290f996d1d37b1b2).

### Relevant tickets

References [Pivotal #177733225](https://www.pivotaltracker.com/story/show/177733225).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
