### PR TITLE
Adding import mute promotions job

### DIFF
--- a/app/Http/Controllers/PromotionsController.php
+++ b/app/Http/Controllers/PromotionsController.php
@@ -30,6 +30,11 @@ class PromotionsController extends Controller
     /**
      * Mute promotions for the specified resource.
      *
+     * @TODO: this existing as a destroy method seems odd, since it is not directly
+     * deleting a resource but setting a property on the User model. Contextually,
+     * this will ultimately result in the deletion of the user from CustomerIO, but
+     * could be a bit clearer.
+     *
      * @param  string $id
      * @return \Illuminate\Http\Response
      */

--- a/app/Http/Controllers/Web/Admin/PromotionsController.php
+++ b/app/Http/Controllers/Web/Admin/PromotionsController.php
@@ -20,8 +20,11 @@ class PromotionsController extends Controller
 
     /**
      * Mutes promotions for user.
-     * @TODO: this existing as a destroy method seems odd, since it is not actually
-     * deleting a resource but setting a property on the User model.
+     *
+     * @TODO: this existing as a destroy method seems odd, since it is not directly
+     * deleting a resource but setting a property on the User model. Contextually,
+     * this will ultimately result in the deletion of the user from CustomerIO, but
+     * could be a bit clearer.
      *
      * @param User $user
      * @return \Illuminate\Http\Response

--- a/app/Http/Controllers/Web/Admin/PromotionsController.php
+++ b/app/Http/Controllers/Web/Admin/PromotionsController.php
@@ -20,6 +20,8 @@ class PromotionsController extends Controller
 
     /**
      * Mutes promotions for user.
+     * @TODO: this existing as a destroy method seems odd, since it is not actually
+     * deleting a resource but setting a property on the User model.
      *
      * @param User $user
      * @return \Illuminate\Http\Response

--- a/app/Jobs/Imports/ImportMutePromotions.php
+++ b/app/Jobs/Imports/ImportMutePromotions.php
@@ -7,9 +7,9 @@ use App\Models\MutePromotionsLog;
 use App\Models\User;
 use Exception;
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
 
 class ImportMutePromotions implements ShouldQueue
 {
@@ -41,9 +41,7 @@ class ImportMutePromotions implements ShouldQueue
      */
     public function handle()
     {
-        $user = User::withTrashed()->find($this->userId);
-
-        // @TODO: How to best handle if user not found?
+        $user = User::withTrashed()->findOrFail($this->userId);
 
         logger('Import job handling muting promotion', ['user' => $user->id]);
 

--- a/app/Jobs/Imports/ImportMutePromotions.php
+++ b/app/Jobs/Imports/ImportMutePromotions.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Jobs\Imports;
+
+use App\Models\ImportFile;
+use App\Models\MutePromotionsLog;
+use App\Models\User;
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class ImportMutePromotions implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /**
+     * The Northstar user ID to mute promotions for.
+     *
+     * @var string
+     */
+    protected $userId;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param array $record
+     * @param ImportFile $importFile
+     * @return void
+     */
+    public function __construct($record, ImportFile $importFile)
+    {
+        $this->userId = $record['northstar_id'];
+
+        $this->importFile = $importFile;
+    }
+
+    /**
+     * Execute the job to mute user promotions.
+     */
+    public function handle()
+    {
+        $user = User::withTrashed()->find($this->userId);
+
+        // @TODO: How to best handle if user not found?
+
+        logger('Import job handling muting promotion', ['user' => $user->id]);
+
+        $user->mutePromotions();
+
+        MutePromotionsLog::create([
+            'import_file_id' => $this->importFile->id,
+            'user_id' => $this->userId,
+        ]);
+
+        info('import.mute-promotions', [
+            'user_id' => $this->userId,
+            'promotions_muted_at' => $user->promotions_muted_at->toDateTimeString(),
+        ]);
+
+        $this->importFile->incrementImportCount();
+    }
+
+    /**
+     * Return the parameters passed to this job.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return [
+            'import_file_id' => $this->importFile->id,
+            'user_id' => $this->userId,
+        ];
+    }
+}

--- a/app/Models/ImportFile.php
+++ b/app/Models/ImportFile.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 class ImportFile extends Model
 {
     /**
+     * The database connection that should be used by the model.
+     *
+     * @var string
+     */
+    protected $connection = 'mysql';
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/app/Models/MutePromotionsLog.php
+++ b/app/Models/MutePromotionsLog.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 class MutePromotionsLog extends Model
 {
     /**
+     * The database connection that should be used by the model.
+     *
+     * @var string
+     */
+    protected $connection = 'mysql';
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/database/factories/ImportFileFactory.php
+++ b/database/factories/ImportFileFactory.php
@@ -2,8 +2,8 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use App\ImportType;
 use App\Models\ImportFile;
+use App\Types\ImportType;
 use Faker\Generator as Faker;
 
 $factory->define(ImportFile::class, function (Faker $faker) {

--- a/tests/Jobs/Imports/ImportMutePromotionsTest.php
+++ b/tests/Jobs/Imports/ImportMutePromotionsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Jobs\Imports\ImportMutePromotions;
+use App\Models\ImportFile;
+use App\Models\User;
+
+class ImportMutePromotionsTest extends TestCase
+{
+    public function testExecutesMutesPromotionsRequest()
+    {
+        $user = factory(User::class)->create();
+
+        $importFile = factory(ImportFile::class)->create();
+
+        $job = new ImportMutePromotions(
+            ['northstar_id' => $user->id],
+            $importFile,
+        );
+
+        $job->handle();
+
+        $this->assertMysqlDatabaseHas('mute_promotions_logs', [
+            'import_file_id' => $importFile->id,
+            'user_id' => $user->id,
+        ]);
+    }
+}

--- a/tests/Jobs/Imports/ImportMutePromotionsTest.php
+++ b/tests/Jobs/Imports/ImportMutePromotionsTest.php
@@ -3,10 +3,17 @@
 use App\Jobs\Imports\ImportMutePromotions;
 use App\Models\ImportFile;
 use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ImportMutePromotionsTest extends TestCase
 {
-    public function testExecutesMutesPromotionsRequest()
+    /**
+     * Test that a specified user can have promotions muted and that an event
+     * for mute promotions is added to the logs.
+     *
+     * @return void
+     */
+    public function testMutesPromotionsForUserAndLogsEvent()
     {
         $user = factory(User::class)->create();
 
@@ -23,5 +30,36 @@ class ImportMutePromotionsTest extends TestCase
             'import_file_id' => $importFile->id,
             'user_id' => $user->id,
         ]);
+    }
+
+    /**
+     * Test that an exception is thrown if a user is not found, and no event
+     * for mute promotions is added to the logs.
+     *
+     * @retuns void
+     */
+    public function testDoesNotMutePromotionsOrLogEventIfUserNotFound()
+    {
+        $user = factory(User::class)->create();
+
+        $importFile = factory(ImportFile::class)->create();
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $job = new ImportMutePromotions(
+            ['northstar_id' => 'non_existent_id'],
+            $importFile,
+        );
+
+        $job->handle();
+
+        $this->assertDatabaseMissing(
+            'mute_promotions_logs',
+            [
+                'import_file_id' => $importFile->id,
+                'user_id' => $user->id,
+            ],
+            'mysql',
+        );
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request starts to merge the Chompy queue jobs over into Northstar.

First up is the `ImportMutePromotions` job!

### How should this be reviewed?

👀 

### Any background context you want to provide?

I wasn't sure whether to include tests for the existing Northstar API/Web endpoints for `/users/{id}/promotions`. Now that the job is in Northstar directly it does not need to use these endpoints. We will need the endpoints when we transition the web UI but I suspect that means getting rid of the API endpoint and keeping the web one. We can tackle that when we tackle the UI.

### Relevant tickets

References [Pivotal #177733312](https://www.pivotaltracker.com/story/show/177733312).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
