### PR TITLE
Add a command to fix mismatched mobile/status fields.

### DIFF
--- a/app/Console/Commands/FixSmsStatusCommand.php
+++ b/app/Console/Commands/FixSmsStatusCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\CustomerIo;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class FixSmsStatusCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:fix-sms-status {--dry-run}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix accounts with active sms_status but no mobile number.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(CustomerIo $customerIo)
+    {
+        info('northstar:fix-sms-status - Starting up!');
+
+        // Get addressable users with a null mobile:
+        $query = User::whereIn('sms_status', [
+            'active',
+            'pending',
+            'less',
+        ])->where('mobile', 'exists', false);
+
+        $query->chunkById(200, function (Collection $users) use ($customerIo) {
+            foreach ($users as $user) {
+                $profile = $customerIo->getAttributes($user);
+
+                // We want to log a little context on each user that we're fixing
+                // to help identify patterns of potentially affected accounts:
+                info('Fixing user', [
+                    'id' => $user->id,
+                    'has_profile' => !empty($profile),
+                    'phone' => data_get($profile, 'phone'),
+                    'source' => $user->source,
+                    'created_at' => $user->created_at,
+                ]);
+
+                if ($this->option('dry-run')) {
+                    continue;
+                }
+
+                $user->unset('sms_status');
+            }
+        });
+
+        info('northstar:fix-sms-status - All done!');
+    }
+}

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -101,6 +101,36 @@ class CustomerIo
     }
 
     /**
+     * Read the given customer's profile in Customer.io.
+     * @see https://customer.io/docs/api/#operation/getPersonAttributes
+     *
+     * @param User $user
+     */
+    public function getAttributes(User $user)
+    {
+        if (!$this->enabled()) {
+            info('Would have read attributes from Customer.io', [
+                'id' => $user->id,
+            ]);
+
+            return null;
+        }
+
+        $response = $this->appApiClient->get(
+            "https://beta-api.customer.io/v1/api/customers/$user->id/attributes",
+        );
+
+        // For this endpoint, any status besides 200 means something is wrong:
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $json = json_decode((string) $response->getBody(), true);
+
+        return $json['customer']['attributes'];
+    }
+
+    /**
      * Create or update the given customer's profile in Customer.io.
      * @see https://customer.io/docs/api/#apitrackcustomerscustomers_update
      *

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -10,14 +10,14 @@ class CustomerIo
     /**
      * The Customer.io App API client.
      *
-     * @var Client
+     * @var \GuzzleHttp\Client
      */
     protected $appApiClient;
 
     /**
      * The Customer.io Track API client.
      *
-     * @var Client
+     * @var \GuzzleHttp\Client
      */
     protected $trackApiClient;
 

--- a/tests/Console/FixSmsStatusCommandTest.php
+++ b/tests/Console/FixSmsStatusCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+
+class FixSmsStatusCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_fix_birthdates()
+    {
+        // We should have
+        $brokenUsers = factory(User::class, 5)->create([
+            'mobile' => null,
+            'sms_status' => $this->faker->randomElement([
+                'active',
+                'less',
+                'pending',
+            ]),
+        ]);
+
+        $goodUser = factory(User::class)->create([
+            'mobile' => $this->faker->unique()->phoneNumber,
+            'sms_status' => $this->faker->randomElement([
+                'active',
+                'less',
+                'pending',
+            ]),
+        ]);
+
+        // Run the fixer command.
+        Artisan::call('northstar:fix-sms-status');
+
+        // We should have removed this field for anyone who doesn't have a mobile:
+        foreach ($brokenUsers as $user) {
+            $this->assertNull($user->fresh()->sms_status);
+        }
+
+        // And users that _should_ have SMS status should be untouched:
+        $this->assertNotEquals('stop', $goodUser->fresh()->sms_status);
+    }
+}

--- a/tests/Console/FixSmsStatusCommandTest.php
+++ b/tests/Console/FixSmsStatusCommandTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Artisan;
 class FixSmsStatusCommandTest extends TestCase
 {
     /** @test */
-    public function it_should_fix_birthdates()
+    public function it_should_fix_sms_statuses()
     {
         // We should have
         $brokenUsers = factory(User::class, 5)->create([

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -43,6 +43,7 @@ trait CreatesApplication
 
         // Configure a mock for any Customer.io API calls.
         $this->customerIoMock = $this->mock(\App\Services\CustomerIo::class);
+        $this->customerIoMock->shouldReceive('getAttributes')->andReturn(null);
         $this->customerIoMock->shouldReceive('updateCustomer')->andReturn(null);
         $this->customerIoMock->shouldReceive('trackEvent');
         $this->customerIoMock->shouldReceive('sendEmail');


### PR DESCRIPTION
### What's this PR do?

This pull request adds an Artisan command to fix accounts which have no `mobile` but still have an "addressable" `sms_status` field. In cases where a user _had_ a phone number and removed it, this bug may be causing them to continue to receive SMS messaging & be unable to opt-out by texting STOP.

### How should this be reviewed?

I added a command to fix potentially affected accounts & a test demonstrating expected behavior. This command also logs context about affected users (source, creation time, and whether or not they have a `phone` set in Customer.io).

I'll plan to run this command on QA & production – once as a "dry run", and once "for real".

### Any background context you want to provide?

You can read a full write-up on the issue that this addresses in [this Pivotal comment](https://www.pivotaltracker.com/story/show/177986264/comments/223965113).

### Relevant tickets

References [Pivotal #177986264](https://www.pivotaltracker.com/story/show/177986264).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
