### PR TITLE
Throttle Customer.io API requests from this console command.

### DIFF
--- a/app/Console/Commands/FixSmsStatusCommand.php
+++ b/app/Console/Commands/FixSmsStatusCommand.php
@@ -43,6 +43,8 @@ class FixSmsStatusCommand extends Command
             foreach ($users as $user) {
                 $profile = $customerIo->getAttributes($user);
 
+                throttle(600); // Customer.io Beta API is rate-limited, so keep under 10/s (600/min).
+
                 // We want to log a little context on each user that we're fixing
                 // to help identify patterns of potentially affected accounts:
                 info('Fixing user', [


### PR DESCRIPTION
### What's this PR do?

This pull request throttles the `northstar:fix-sms-status` Artisan command to 10 requests/second, in order to keep us well under the rate-limit for the Customer.io "get attributes" endpoint that it relies on for logging user details:

```
[2021-05-05 19:25:59] qa.ERROR: Client error: `GET https://beta-api.customer.io/v1/api/customers/56e96b3b469c64d8578b608b/attributes` resulted in a `429 Too Many Requests` response:
{"errors":[{"detail":"rate limited to 10 requests per 1s (reference 01F4YZWZX7NRJTKSN2BVW2ECY8)","status":"429"}]}
 {"exception":"[object] (GuzzleHttp\\Exception\\ClientException(code: 429): Client error: `GET https://beta-api.customer.io/v1/api/customers/56e96b3b469c64d8578b608b/attributes` resulted in a `429 Too Many Requests` response:
{\"errors\":[{\"detail\":\"rate limited to 10 requests per 1s (reference 01F4YZWZX7NRJTKSN2BVW2ECY8)\",\"status\":\"429\"}]}
```

### How should this be reviewed?

👀

### Any background context you want to provide?

A potentially more robust option would be to create a queued job that we kick off from this command, and then rate-limit that job to our "global" Customer.io throughput [there](https://github.com/DoSomething/northstar/blob/b17afff299ed5c4429f5e25ec27147b5ccc0ae7a/app/Jobs/Middleware/CustomerIoRateLimit.php#L18-L22). However, this "beta" API has it's own _separate_ (much lower) rate limit, so we'd also need a separate `BetaCustomerIoRateLimit` middleware... and that just seems like a lot for a one-off script!

### Relevant tickets

References [Pivotal #177986264](https://www.pivotaltracker.com/story/show/177986264).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
