### PR TITLE
Impact goal for actions

### DIFF
--- a/app/Console/Commands/RemoveCustomerIoMobile.php
+++ b/app/Console/Commands/RemoveCustomerIoMobile.php
@@ -47,8 +47,9 @@ class RemoveCustomerIoMobile extends Command
                 }
 
                 // Otherwise update their profile to remove the mobile number.
-                dispatch(new UpsertCustomerIoProfile($user))
-                    ->onQueue(config('queue.names.low'));
+                dispatch(new UpsertCustomerIoProfile($user))->onQueue(
+                    config('queue.names.low'),
+                );
             });
         });
 

--- a/app/Http/Controllers/QuestionnaireController.php
+++ b/app/Http/Controllers/QuestionnaireController.php
@@ -55,15 +55,19 @@ class QuestionnaireController extends ActivityApiController
 
         $this->rules = array_merge(
             Arr::except((new PostRequest())->rules(), [
-                'action', 'action_id', 'campaign_id', 'type',
+                'action',
+                'action_id',
+                'campaign_id',
+                'type',
             ]),
             [
                 'questions' => 'required|array',
-                'questions.*.action_id' => 'required|integer|exists:mysql.actions,id',
+                'questions.*.action_id' =>
+                    'required|integer|exists:mysql.actions,id',
                 'questions.*.title' => 'required|string',
                 'questions.*.answer' => 'required|string|max:500',
                 'contentful_id' => 'required|string',
-            ]
+            ],
         );
     }
 
@@ -108,12 +112,15 @@ class QuestionnaireController extends ActivityApiController
 
             $shouldTrackToCustomerIo = $index === 0;
 
-            $post = $this->posts->create(array_merge($validated, [
-                'action_id' => $actionId,
-                'text' => $question['answer'],
-                'details' => json_encode($postDetails),
-
-            ]), $signup->id, $shouldTrackToCustomerIo);
+            $post = $this->posts->create(
+                array_merge($validated, [
+                    'action_id' => $actionId,
+                    'text' => $question['answer'],
+                    'details' => json_encode($postDetails),
+                ]),
+                $signup->id,
+                $shouldTrackToCustomerIo,
+            );
 
             array_push($posts, $post);
         }

--- a/app/Http/Controllers/Web/Admin/ActionsController.php
+++ b/app/Http/Controllers/Web/Admin/ActionsController.php
@@ -40,6 +40,7 @@ class ActionsController extends Controller
             ],
             'noun' => ['required', 'string'],
             'verb' => ['required', 'string'],
+            'impact_goal' => ['nullable', 'integer'],
         ];
     }
 

--- a/app/Http/Controllers/Web/ProfileSubscriptionsController.php
+++ b/app/Http/Controllers/Web/ProfileSubscriptionsController.php
@@ -58,9 +58,9 @@ class ProfileSubscriptionsController extends Controller
             $input['email_subscription_topics'] = [];
         }
 
-        $this->registrar->register($input, $user, function (
-            $user
-        ) use ($currentMobile) {
+        $this->registrar->register($input, $user, function ($user) use (
+            $currentMobile
+        ) {
             // Set the sms_status if we're adding or updating the user's mobile.
             if ($user->mobile && $user->mobile !== $currentMobile) {
                 if ($user->sms_status !== 'less') {

--- a/app/Http/Transformers/ActionTransformer.php
+++ b/app/Http/Transformers/ActionTransformer.php
@@ -39,6 +39,7 @@ class ActionTransformer extends TransformerAbstract
             'anonymous' => $action->anonymous,
             'online' => $action->online,
             'quiz' => $action->quiz,
+            'impact_goal' => $action->impact_goal,
             'noun' => $action->noun,
             'verb' => $action->verb,
             'created_at' => $action->created_at->toIso8601String(),

--- a/app/Imports/RockTheVoteRecord.php
+++ b/app/Imports/RockTheVoteRecord.php
@@ -174,12 +174,12 @@ class RockTheVoteRecord
                 $userId = $value[1];
             } elseif ($key === 'group_id') {
                 $result['group_id'] = (int) $value[1];
-            /*
-             * If referral parameter is set to true, the user parameter belongs to the referring
-             * user, not the user that should be associated with this voter registration record.
-             *
-             * Expected key: "referral"
-             */
+                /*
+                 * If referral parameter is set to true, the user parameter belongs to the referring
+                 * user, not the user that should be associated with this voter registration record.
+                 *
+                 * Expected key: "referral"
+                 */
             } elseif (
                 ($key === 'referral' || $key === 'refferal') &&
                 str_to_boolean($value[1])

--- a/app/Imports/RockTheVoteRecord.php
+++ b/app/Imports/RockTheVoteRecord.php
@@ -174,12 +174,12 @@ class RockTheVoteRecord
                 $userId = $value[1];
             } elseif ($key === 'group_id') {
                 $result['group_id'] = (int) $value[1];
-                /*
-                 * If referral parameter is set to true, the user parameter belongs to the referring
-                 * user, not the user that should be associated with this voter registration record.
-                 *
-                 * Expected key: "referral"
-                 */
+            /*
+             * If referral parameter is set to true, the user parameter belongs to the referring
+             * user, not the user that should be associated with this voter registration record.
+             *
+             * Expected key: "referral"
+             */
             } elseif (
                 ($key === 'referral' || $key === 'refferal') &&
                 str_to_boolean($value[1])

--- a/app/Listeners/ReportPasswordUpdated.php
+++ b/app/Listeners/ReportPasswordUpdated.php
@@ -33,7 +33,7 @@ class ReportPasswordUpdated
                 'password_updated',
                 [
                     'updated_via' => $passwordResetType,
-                ]
+                ],
             );
         }
 

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -47,6 +47,7 @@ class Action extends Model
         'anonymous',
         'online',
         'quiz',
+        'impact_goal',
         'noun',
         'verb',
         'collect_school_id',

--- a/app/Models/MongoModel.php
+++ b/app/Models/MongoModel.php
@@ -79,15 +79,19 @@ class MongoModel extends BaseModel
      */
     public function removeNullAttributes()
     {
-        $this->attributes = array_filter($this->attributes, function ($value, $key) {
-            /*
-             * We need to save null values for promotions_muted_at to determine whether a user
-             * profile should be recreated in Customer.io.
-             * @see UserObserver@updated
-             * @see https://github.com/DoSomething/northstar/pull/1127#discussion_r579494892
-             */
-            return $key === 'promotions_muted_at' ? true : !is_null($value);
-        }, ARRAY_FILTER_USE_BOTH);
+        $this->attributes = array_filter(
+            $this->attributes,
+            function ($value, $key) {
+                /*
+                 * We need to save null values for promotions_muted_at to determine whether a user
+                 * profile should be recreated in Customer.io.
+                 * @see UserObserver@updated
+                 * @see https://github.com/DoSomething/northstar/pull/1127#discussion_r579494892
+                 */
+                return $key === 'promotions_muted_at' ? true : !is_null($value);
+            },
+            ARRAY_FILTER_USE_BOTH,
+        );
     }
 
     /**

--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -84,7 +84,7 @@ class CustomerIo
 
         $response = $this->trackApiClient->post(
             'customers/' . $user->id . '/events',
-            ['json' => $payload]
+            ['json' => $payload],
         );
 
         // For this endpoint, any status besides 200 means something is wrong:
@@ -192,7 +192,9 @@ class CustomerIo
 
         logger('Suppressing Customer.io profile', ['user_id' => $id]);
 
-        return $this->trackApiClient->post('customers/' . $id . '/suppress', ['json' => []]);
+        return $this->trackApiClient->post('customers/' . $id . '/suppress', [
+            'json' => [],
+        ]);
     }
 
     /**
@@ -203,15 +205,21 @@ class CustomerIo
      * @param int $transactionalMessageId
      * @param array $messageData
      */
-    public function sendEmail(User $user, $transactionalMessageId, $messageData = [])
-    {
+    public function sendEmail(
+        User $user,
+        $transactionalMessageId,
+        $messageData = []
+    ) {
         $logInfo = [
             'transactional_message_id' => $transactionalMessageId,
             'data' => $messageData,
         ];
 
         if (!$this->enabled()) {
-            info('Transactional email would have been sent from Customer.io', $logInfo);
+            info(
+                'Transactional email would have been sent from Customer.io',
+                $logInfo,
+            );
 
             return;
         }
@@ -230,7 +238,9 @@ class CustomerIo
 
         logger('Sending Customer.io email', $logInfo);
 
-        $response = $this->appApiClient->post('send/email', ['json' => $payload]);
+        $response = $this->appApiClient->post('send/email', [
+            'json' => $payload,
+        ]);
     }
 
     /**

--- a/app/Types/PasswordResetType.php
+++ b/app/Types/PasswordResetType.php
@@ -11,10 +11,14 @@ class PasswordResetType extends Type
 
     // Password reset types
     private const FORGOT_PASSWORD = 'forgot-password';
-    private const BOOST_ACTIVATE_ACCOUNT = 'boost-' . self::ACTIVATE_ACCOUNT_KEY;
-    private const BREAKDOWN_ACTIVATE_ACCOUNT = 'breakdown-' . self::ACTIVATE_ACCOUNT_KEY;
-    private const PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT = 'pays-to-do-good-' . self::ACTIVATE_ACCOUNT_KEY;
-    private const ROCK_THE_VOTE_ACTIVATE_ACCOUNT = 'rock-the-vote-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const BOOST_ACTIVATE_ACCOUNT =
+        'boost-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const BREAKDOWN_ACTIVATE_ACCOUNT =
+        'breakdown-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT =
+        'pays-to-do-good-' . self::ACTIVATE_ACCOUNT_KEY;
+    private const ROCK_THE_VOTE_ACTIVATE_ACCOUNT =
+        'rock-the-vote-' . self::ACTIVATE_ACCOUNT_KEY;
     private const WYD_ACTIVATE_ACCOUNT = 'wyd-' . self::ACTIVATE_ACCOUNT_KEY;
 
     /**
@@ -26,10 +30,12 @@ class PasswordResetType extends Type
     {
         return [
             self::FORGOT_PASSWORD => 'Forgot Password',
-            self::ROCK_THE_VOTE_ACTIVATE_ACCOUNT => 'Rock The Vote Activate Account',
+            self::ROCK_THE_VOTE_ACTIVATE_ACCOUNT =>
+                'Rock The Vote Activate Account',
             self::BOOST_ACTIVATE_ACCOUNT => 'Boost Activate Account',
             self::BREAKDOWN_ACTIVATE_ACCOUNT => 'Breakdown Activate Account',
-            self::PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT => 'Pays To Do Good Activate Account',
+            self::PAYS_TO_DO_GOOD_ACTIVATE_ACCOUNT =>
+                'Pays To Do Good Activate Account',
             self::WYD_ACTIVATE_ACCOUNT => 'WYD Activate Account',
         ];
     }
@@ -42,6 +48,9 @@ class PasswordResetType extends Type
      */
     public static function isActivateAccount(string $passwordResetTypeValue)
     {
-        return Str::contains($passwordResetTypeValue, self::ACTIVATE_ACCOUNT_KEY);
+        return Str::contains(
+            $passwordResetTypeValue,
+            self::ACTIVATE_ACCOUNT_KEY,
+        );
     }
 }

--- a/database/migrations-mongodb/2021_03_10_000000_add_index_to_mobile_promotions_muted_at_sms_status_fields.php
+++ b/database/migrations-mongodb/2021_03_10_000000_add_index_to_mobile_promotions_muted_at_sms_status_fields.php
@@ -35,7 +35,9 @@ class AddIndexToMobilePromotionsMutedAtSmsStatusFields extends Migration
         Schema::connection('mongodb')->table('users', function (
             Blueprint $collection
         ) {
-            $collection->dropIndex('mobile_1_promotions_muted_at_1_sms_status_1');
+            $collection->dropIndex(
+                'mobile_1_promotions_muted_at_1_sms_status_1',
+            );
         });
     }
 }

--- a/database/migrations/2021_05_04_185150_add_impact_goal_to_actions.php
+++ b/database/migrations/2021_05_04_185150_add_impact_goal_to_actions.php
@@ -15,7 +15,7 @@ class AddImpactGoalToActions extends Migration
     {
         Schema::table('actions', function (Blueprint $table) {
             $table
-                ->string('impact_goal')
+                ->unsignedInteger('impact_goal')
                 ->after('quiz')
                 ->nullable()
                 ->comment('The impact goal associated with this action.');

--- a/database/migrations/2021_05_04_185150_add_impact_goal_to_actions.php
+++ b/database/migrations/2021_05_04_185150_add_impact_goal_to_actions.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddImpactGoalToActions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table
+                ->string('impact_goal')
+                ->after('quiz')
+                ->nullable()
+                ->comment('The impact goal associated with this action.');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('actions', function (Blueprint $table) {
+            $table->dropColumn('impact_goal');
+        });
+    }
+}

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -16,6 +16,6 @@ cat ../northstar-updates.csv | php artisan northstar:update --field=email_subscr
 
 In this example, we run the console command with a `northstar-updates.csv` file, which we'd expect to contain the following fields:
 
-* `northstar_id` (required)
-* `email_subscription_status`
-* `sms_status`
+- `northstar_id` (required)
+- `email_subscription_status`
+- `sms_status`

--- a/documentation/customer-io.md
+++ b/documentation/customer-io.md
@@ -10,30 +10,30 @@ When a user's `email_subscription_status` boolean field is set to `true`, they a
 
 The current `email_subscription_topics` a user can subscribe to are:
 
-* `community`
-* `lifestyle`
-* `news`
-* `scholarships`
+- `community`
+- `lifestyle`
+- `news`
+- `scholarships`
 
 ### SMS subscribers
 
 The user's `sms_status` field determines their SMS subscription status (a heavy TODO is to rename it as `sms_subscription_status` for consistency with email):
 
-* `active` - receives weekly promotional SMS broadcasts
-* `less` - receives monthly promotional SMS broadcasts
-* `stop` - has unsubscribed from all SMS messaging
-* `pending` - has received a re-permissioning SMS broadcast (a.k.a. an [`askSubscriptionStatusBroadcast`](https://github.com/DoSomething/gambit-admin/wiki/Broadcasts#asksubscriptionstatus)), prompting them to answer with `active`, `less`, or `stop`
-* `undeliverable` - we set this internally if Twilio cannot successfully deliver a SMS broadcast to the user's mobile number 
+- `active` - receives weekly promotional SMS broadcasts
+- `less` - receives monthly promotional SMS broadcasts
+- `stop` - has unsubscribed from all SMS messaging
+- `pending` - has received a re-permissioning SMS broadcast (a.k.a. an [`askSubscriptionStatusBroadcast`](https://github.com/DoSomething/gambit-admin/wiki/Broadcasts#asksubscriptionstatus)), prompting them to answer with `active`, `less`, or `stop`
+- `undeliverable` - we set this internally if Twilio cannot successfully deliver a SMS broadcast to the user's mobile number
 
-The current `sms_subscription_topics` are `general` and `voting`. By default, users are opted into both topics when they subscribe, unless the user is being imported from Rock The Vote (see [details](https://github.com/DoSomething/chompy/tree/master/docs/imports#sms-subscription)). 
+The current `sms_subscription_topics` are `general` and `voting`. By default, users are opted into both topics when they subscribe, unless the user is being imported from Rock The Vote (see [details](https://github.com/DoSomething/chompy/tree/master/docs/imports#sms-subscription)).
 
 ### Subscription updates
 
-* When a new account is created (via web or SMS), the member is subscribed for promotions by default, and a Customer.io profile is created for them.
+- When a new account is created (via web or SMS), the member is subscribed for promotions by default, and a Customer.io profile is created for them.
 
-* If a member unsubscribes from both SMS and email promotions, their `promotions_muted_at` field will be set to the datetime they've unsubscribed. This will trigger their Customer.io profile deletion.
+- If a member unsubscribes from both SMS and email promotions, their `promotions_muted_at` field will be set to the datetime they've unsubscribed. This will trigger their Customer.io profile deletion.
 
-* If a member whose promotions have been muted resubscribes to either email and/or SMS, their `promotions_muted_at` field will be set to null. This will trigger their Customer.io profile to be re-created, and additionally track a `promotions_resubscribe` Customer.io event.
+- If a member whose promotions have been muted resubscribes to either email and/or SMS, their `promotions_muted_at` field will be set to null. This will trigger their Customer.io profile to be re-created, and additionally track a `promotions_resubscribe` Customer.io event.
 
 ### Mute Promotions import
 

--- a/documentation/endpoints/questionnaires.md
+++ b/documentation/endpoints/questionnaires.md
@@ -2,11 +2,11 @@
 
 The `write` & `activity` scope is required for the create endpoint.
 
-## Store a user's Questionnaire submission 
+## Store a user's Questionnaire submission
 
-The **Questionnaire Action** block in Phoenix combines multiple **Text Submission Actions** into a single multi-question *Questionnaire*.
+The **Questionnaire Action** block in Phoenix combines multiple **Text Submission Actions** into a single multi-question _Questionnaire_.
 
-Each question is configured with an individual Action ID so that we can store each questions response into an individual Post. 
+Each question is configured with an individual Action ID so that we can store each questions response into an individual Post.
 
 We store some metadata in the Post's `details` field to qualify that these Posts are via a Questionnaire block, and to tie the submission to its parent Contentful block & question title: e.g. `details: { questionnaire: true, question: [question title], contentful_id: [questionnaire Contentful ID] }`
 
@@ -62,130 +62,130 @@ POST /api/v3/questionnaires
 // 200 OK
 
 {
-    "data": [
-        {
-            "id": 1,
-            "signup_id": 2,
-            "type": "text",
-            "action": "Quia Reprehenderit Aut",
-            "action_id": 1,
-            "campaign_id": "1",
-            "media": {
-                "url": null,
-                "original_image_url": null,
-                "text": "My cat."
-            },
-            "quantity": null,
-            "hours_spent": null,
-            "reactions": {
-                "reacted": false,
-                "total": null
-            },
-            "status": "pending",
-            "location": null,
-            "location_name": null,
-            "created_at": "2021-03-16T20:24:29+00:00",
-            "updated_at": "2021-03-16T20:24:29+00:00",
-            "cursor": "MTY2OA==",
-            "northstar_id": "123",
-            "tags": [],
-            "source": "dev-oauth",
-            "source_details": null,
-            "remote_addr": "0.0.0.0",
-            "details": "{\"questionnaire\":true,\"question\":\"Who inspires you?\",\"contentful_id\":\"1a2b3c\"}",
-            "referrer_user_id": null,
-            "group_id": null,
-            "school_id": null,
-            "club_id": null,
-            "action_details": {
-                "data": {
-                    "id": 2,
-                    "name": "Quia Reprehenderit Aut",
-                    "campaign_id": 1,
-                    "post_type": "text",
-                    "post_label": "Text Post",
-                    "action_type": "share-something",
-                    "action_label": "Share Something",
-                    "time_commitment": "<0.083",
-                    "time_commitment_label": "< 5 minutes",
-                    "callpower_campaign_id": null,
-                    "reportback": true,
-                    "civic_action": true,
-                    "scholarship_entry": true,
-                    "collect_school_id": true,
-                    "volunteer_credit": false,
-                    "anonymous": false,
-                    "online": false,
-                    "quiz": false,
-                    "noun": "things",
-                    "verb": "done",
-                    "created_at": "2021-03-16T16:03:49+00:00",
-                    "updated_at": "2021-03-16T16:03:49+00:00"
-                }
-            }
-        },
-        {
-            "id": 2,
-            "signup_id": 2,
-            "type": "text",
-            "action": "Quia Reprehenderit Aut",
-            "action_id": 1,
-            "campaign_id": "1",
-            "media": {
-                "url": null,
-                "original_image_url": null,
-                "text": "They rock."
-            },
-            "quantity": null,
-            "hours_spent": null,
-            "reactions": {
-                "reacted": false,
-                "total": null
-            },
-            "status": "pending",
-            "location": null,
-            "location_name": null,
-            "created_at": "2021-03-16T20:24:29+00:00",
-            "updated_at": "2021-03-16T20:24:29+00:00",
-            "cursor": "MTY2OA==",
-            "northstar_id": "123",
-            "tags": [],
-            "source": "dev-oauth",
-            "source_details": null,
-            "remote_addr": "0.0.0.0",
-            "details": "{\"questionnaire\":true,\"question\":\"Why?\",\"contentful_id\":\"1a2b3c\"}",
-            "referrer_user_id": null,
-            "group_id": null,
-            "school_id": null,
-            "club_id": null,
-            "action_details": {
-                "data": {
-                    "id": 3,
-                    "name": "Quia Reprehenderit Aut Two",
-                    "campaign_id": 1,
-                    "post_type": "text",
-                    "post_label": "Text Post",
-                    "action_type": "share-something",
-                    "action_label": "Share Something",
-                    "time_commitment": "<0.083",
-                    "time_commitment_label": "< 5 minutes",
-                    "callpower_campaign_id": null,
-                    "reportback": true,
-                    "civic_action": true,
-                    "scholarship_entry": true,
-                    "collect_school_id": true,
-                    "volunteer_credit": false,
-                    "anonymous": false,
-                    "online": false,
-                    "quiz": false,
-                    "noun": "things",
-                    "verb": "done",
-                    "created_at": "2021-03-16T16:03:49+00:00",
-                    "updated_at": "2021-03-16T16:03:49+00:00"
-                }
-            }
+  "data": [
+    {
+      "id": 1,
+      "signup_id": 2,
+      "type": "text",
+      "action": "Quia Reprehenderit Aut",
+      "action_id": 1,
+      "campaign_id": "1",
+      "media": {
+        "url": null,
+        "original_image_url": null,
+        "text": "My cat."
+      },
+      "quantity": null,
+      "hours_spent": null,
+      "reactions": {
+        "reacted": false,
+        "total": null
+      },
+      "status": "pending",
+      "location": null,
+      "location_name": null,
+      "created_at": "2021-03-16T20:24:29+00:00",
+      "updated_at": "2021-03-16T20:24:29+00:00",
+      "cursor": "MTY2OA==",
+      "northstar_id": "123",
+      "tags": [],
+      "source": "dev-oauth",
+      "source_details": null,
+      "remote_addr": "0.0.0.0",
+      "details": "{\"questionnaire\":true,\"question\":\"Who inspires you?\",\"contentful_id\":\"1a2b3c\"}",
+      "referrer_user_id": null,
+      "group_id": null,
+      "school_id": null,
+      "club_id": null,
+      "action_details": {
+        "data": {
+          "id": 2,
+          "name": "Quia Reprehenderit Aut",
+          "campaign_id": 1,
+          "post_type": "text",
+          "post_label": "Text Post",
+          "action_type": "share-something",
+          "action_label": "Share Something",
+          "time_commitment": "<0.083",
+          "time_commitment_label": "< 5 minutes",
+          "callpower_campaign_id": null,
+          "reportback": true,
+          "civic_action": true,
+          "scholarship_entry": true,
+          "collect_school_id": true,
+          "volunteer_credit": false,
+          "anonymous": false,
+          "online": false,
+          "quiz": false,
+          "noun": "things",
+          "verb": "done",
+          "created_at": "2021-03-16T16:03:49+00:00",
+          "updated_at": "2021-03-16T16:03:49+00:00"
         }
-    ]
+      }
+    },
+    {
+      "id": 2,
+      "signup_id": 2,
+      "type": "text",
+      "action": "Quia Reprehenderit Aut",
+      "action_id": 1,
+      "campaign_id": "1",
+      "media": {
+        "url": null,
+        "original_image_url": null,
+        "text": "They rock."
+      },
+      "quantity": null,
+      "hours_spent": null,
+      "reactions": {
+        "reacted": false,
+        "total": null
+      },
+      "status": "pending",
+      "location": null,
+      "location_name": null,
+      "created_at": "2021-03-16T20:24:29+00:00",
+      "updated_at": "2021-03-16T20:24:29+00:00",
+      "cursor": "MTY2OA==",
+      "northstar_id": "123",
+      "tags": [],
+      "source": "dev-oauth",
+      "source_details": null,
+      "remote_addr": "0.0.0.0",
+      "details": "{\"questionnaire\":true,\"question\":\"Why?\",\"contentful_id\":\"1a2b3c\"}",
+      "referrer_user_id": null,
+      "group_id": null,
+      "school_id": null,
+      "club_id": null,
+      "action_details": {
+        "data": {
+          "id": 3,
+          "name": "Quia Reprehenderit Aut Two",
+          "campaign_id": 1,
+          "post_type": "text",
+          "post_label": "Text Post",
+          "action_type": "share-something",
+          "action_label": "Share Something",
+          "time_commitment": "<0.083",
+          "time_commitment_label": "< 5 minutes",
+          "callpower_campaign_id": null,
+          "reportback": true,
+          "civic_action": true,
+          "scholarship_entry": true,
+          "collect_school_id": true,
+          "volunteer_credit": false,
+          "anonymous": false,
+          "online": false,
+          "quiz": false,
+          "noun": "things",
+          "verb": "done",
+          "created_at": "2021-03-16T16:03:49+00:00",
+          "updated_at": "2021-03-16T16:03:49+00:00"
+        }
+      }
+    }
+  ]
 }
 ```
 

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -93,7 +93,8 @@ return [
 
     'custom' => [
         'sms_status' => [
-            'required_with_all' => 'Please select how often you wish to receive texts.',
+            'required_with_all' =>
+                'Please select how often you wish to receive texts.',
         ],
     ],
 

--- a/resources/views/admin/actions/create.blade.php
+++ b/resources/views/admin/actions/create.blade.php
@@ -39,6 +39,11 @@
                     </div>
 
                     <div class="form-item -third">
+                        <label class="field-label">Impact Goal</label>
+                        @include('admin.forms.text', ['name' => 'impact_goal', 'placeholder' => 'e.g. 4000 (optional)'])
+                    </div>
+
+                    <div class="form-item -third">
                         <label class="field-label">Action Noun</label>
                         @include('admin.forms.text', ['name' => 'noun', 'placeholder' => 'e.g. Jeans'])
                     </div>

--- a/resources/views/admin/actions/edit.blade.php
+++ b/resources/views/admin/actions/edit.blade.php
@@ -38,6 +38,11 @@
                     </div>
 
                     <div class="form-item -third">
+                        <label class="field-label">Impact Goal</label>
+                        @include('admin.forms.text', ['name' => 'impact_goal', 'placeholder' => 'e.g. 4000 (optional)', 'value' => $action->impact_goal])
+                    </div>
+
+                    <div class="form-item -third">
                         <label class="field-label">Action Noun</label>
                         @include('admin.forms.text', ['name' => 'noun', 'placeholder' => 'e.g. Jeans', 'value' => $action->noun])
                     </div>

--- a/tests/Console/RemoveCustomerIoMobileTest.php
+++ b/tests/Console/RemoveCustomerIoMobileTest.php
@@ -8,11 +8,19 @@ class RemoveCustomerIoMobileTest extends BrowserKitTestCase
     /** @test */
     public function testExpectedApiCalls()
     {
-        factory(User::class, 5)->states('email-subscribed', 'sms-subscribed')->create();
+        factory(User::class, 5)
+            ->states('email-subscribed', 'sms-subscribed')
+            ->create();
 
-        $nullSmsStatusUsers = factory(User::class, 3)->states('email-unsubscribed')->create(['sms_status' => null]);
-        $unsubscribedToSmsUsers = factory(User::class, 3)->states('email-subscribed', 'sms-unsubscribed')->create();
-        $unsubscribedToAllUsers = factory(User::class, 7)->states('email-unsubscribed', 'sms-unsubscribed')->create();
+        $nullSmsStatusUsers = factory(User::class, 3)
+            ->states('email-unsubscribed')
+            ->create(['sms_status' => null]);
+        $unsubscribedToSmsUsers = factory(User::class, 3)
+            ->states('email-subscribed', 'sms-unsubscribed')
+            ->create();
+        $unsubscribedToAllUsers = factory(User::class, 7)
+            ->states('email-unsubscribed', 'sms-unsubscribed')
+            ->create();
 
         Artisan::call('northstar:cio-remove-mobile');
 

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -46,7 +46,7 @@ class ActionTest extends TestCase
      */
     public function testCreatingAnActionWithAnImpactGoal()
     {
-        $action = factory(Action::class)->create(['impact_goal' => '3000']);
+        $action = factory(Action::class)->create(['impact_goal' => 3000]);
 
         $response = $this->getJson('api/v3/actions/' . $action->id);
 

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -38,4 +38,25 @@ class ActionTest extends TestCase
         $response->assertOk();
         $response->assertJsonPath('data.id', $action->id);
     }
+
+    /**
+     * Test that when an action is created with an impact goal it saves properly
+     *
+     * @return void
+     */
+    public function testCreatingAnActionWithAnImpactGoal()
+    {
+        $action = factory(Action::class)->create(['impact_goal' => '3000']);
+
+        $response = $this->getJson('api/v3/actions/' . $action->id);
+
+        $response->assertOk();
+
+        $this->assertMysqlDatabaseHas('actions', [
+            'post_type' => $action->post_type,
+            'name' => $action->name,
+            'id' => $action->id,
+            'impact_goal' => $action->impact_goal,
+        ]);
+    }
 }

--- a/tests/Http/ActionTest.php
+++ b/tests/Http/ActionTest.php
@@ -40,23 +40,17 @@ class ActionTest extends TestCase
     }
 
     /**
-     * Test that when an action is created with an impact goal it saves properly
+     * Test that when an action is created with an impact goal it saves properly.
      *
      * @return void
      */
-    public function testCreatingAnActionWithAnImpactGoal()
+    public function testDisplayingActionWithAnImpactGoal()
     {
         $action = factory(Action::class)->create(['impact_goal' => 3000]);
 
         $response = $this->getJson('api/v3/actions/' . $action->id);
 
         $response->assertOk();
-
-        $this->assertMysqlDatabaseHas('actions', [
-            'post_type' => $action->post_type,
-            'name' => $action->name,
-            'id' => $action->id,
-            'impact_goal' => $action->impact_goal,
-        ]);
+        $response->assertJsonPath('data.impact_goal', $action->impact_goal);
     }
 }

--- a/tests/Http/PostTest.php
+++ b/tests/Http/PostTest.php
@@ -328,7 +328,11 @@ class PostTest extends TestCase
         $response = $this->asUser($signup->user)->postJson('api/v3/posts', [
             'type' => 'photo',
             'action_id' => $action->id,
-            'file' => UploadedFile::fake()->image('photo.jpg', $minImageSize['height'] - 1, $minImageSize['height'] - 1), // less than the minimum size!
+            'file' => UploadedFile::fake()->image(
+                'photo.jpg',
+                $minImageSize['height'] - 1,
+                $minImageSize['height'] - 1,
+            ), // less than the minimum size!
         ]);
 
         $response->assertJsonValidationErrors(['file' => $validationMessage]);
@@ -336,7 +340,11 @@ class PostTest extends TestCase
         $response = $this->asUser($signup->user)->postJson('api/v3/posts', [
             'type' => 'photo',
             'action_id' => $action->id,
-            'file' => UploadedFile::fake()->image('photo.jpg', $maxImageSize['height'] + 1, $maxImageSize['height'] + 1), // more than the maximum size!
+            'file' => UploadedFile::fake()->image(
+                'photo.jpg',
+                $maxImageSize['height'] + 1,
+                $maxImageSize['height'] + 1,
+            ), // more than the maximum size!
         ]);
 
         $response->assertJsonValidationErrors(['file' => $validationMessage]);
@@ -374,7 +382,7 @@ class PostTest extends TestCase
         $response = $this->asUser($signup->user)->postJson('api/v3/posts', [
             'type' => 'photo',
             'action_id' => $action->id,
-            'hours_spent' => 0.00, // This should be a minimum of 0.01.
+            'hours_spent' => 0.0, // This should be a minimum of 0.01.
         ]);
 
         $response->assertJsonValidationErrors(['hours_spent']);

--- a/tests/Http/PromotionsTest.php
+++ b/tests/Http/PromotionsTest.php
@@ -13,9 +13,7 @@ class PromotionsTest extends BrowserKitTestCase
     {
         $user = factory(User::class)->create();
 
-        $this->asAdminUser()->delete(
-            'v2/users/' . $user->id . '/promotions',
-        );
+        $this->asAdminUser()->delete('v2/users/' . $user->id . '/promotions');
 
         $this->assertResponseStatus(200);
         $this->assertNotNull($user->fresh()->promotions_muted_at);
@@ -49,9 +47,7 @@ class PromotionsTest extends BrowserKitTestCase
 
         $user->delete();
 
-        $this->asAdminUser()->delete(
-            'v2/users/' . $user->id . '/promotions',
-        );
+        $this->asAdminUser()->delete('v2/users/' . $user->id . '/promotions');
 
         $this->assertResponseStatus(200);
         $this->assertNotNull($user->fresh()->promotions_muted_at);

--- a/tests/Http/QuestionnaireTest.php
+++ b/tests/Http/QuestionnaireTest.php
@@ -34,24 +34,36 @@ class QuestionnaireTest extends TestCase
             'post_type' => 'text',
         ]);
 
-        $questionOne = ['title' => 'Question one.', 'answer' => 'Answer one.', 'action_id' =>  $actionOne->id];
+        $questionOne = [
+            'title' => 'Question one.',
+            'answer' => 'Answer one.',
+            'action_id' => $actionOne->id,
+        ];
 
         $actionTwo = factory(Action::class)->create([
             'campaign_id' => $campaignId,
             'post_type' => 'text',
         ]);
 
-        $questionTwo = ['title' => 'Question two.', 'answer' => 'Answer two.', 'action_id' =>  $actionTwo->id];
+        $questionTwo = [
+            'title' => 'Question two.',
+            'answer' => 'Answer two.',
+            'action_id' => $actionTwo->id,
+        ];
 
-        $response = $this->asUser($user)->json('POST', 'api/v3/questionnaires', [
-            'questions' => [$questionOne, $questionTwo],
-            'contentful_id' => $contentfulId,
-            'location' => $location,
-            'school_id' => $schoolId,
-            'details' => json_encode($details),
-            'referrer_user_id' => $referrerUser->id,
-            'group_id' => $groupId,
-        ]);
+        $response = $this->asUser($user)->json(
+            'POST',
+            'api/v3/questionnaires',
+            [
+                'questions' => [$questionOne, $questionTwo],
+                'contentful_id' => $contentfulId,
+                'location' => $location,
+                'school_id' => $schoolId,
+                'details' => json_encode($details),
+                'referrer_user_id' => $referrerUser->id,
+                'group_id' => $groupId,
+            ],
+        );
 
         $response->assertStatus(201)->assertJson([
             'data' => [
@@ -75,8 +87,7 @@ class QuestionnaireTest extends TestCase
         ]);
 
         // Make sure two posts are persisted to the database.
-        $this->assertMysqlDatabaseHas('posts',
-        [
+        $this->assertMysqlDatabaseHas('posts', [
             'northstar_id' => $user->id,
             'campaign_id' => $campaignId,
             'type' => 'text',
@@ -86,11 +97,13 @@ class QuestionnaireTest extends TestCase
             'status' => 'pending',
             'location' => $location,
             'school_id' => $schoolId,
-            'details' => json_encode(array_merge($details, [
-                'questionnaire' => true,
-                'question' => $questionOne['title'],
-                'contentful_id' => $contentfulId,
-            ])),
+            'details' => json_encode(
+                array_merge($details, [
+                    'questionnaire' => true,
+                    'question' => $questionOne['title'],
+                    'contentful_id' => $contentfulId,
+                ]),
+            ),
             'referrer_user_id' => $referrerUser->id,
             'group_id' => $groupId,
         ]);
@@ -105,11 +118,13 @@ class QuestionnaireTest extends TestCase
             'status' => 'pending',
             'location' => $location,
             'school_id' => $schoolId,
-            'details' => json_encode(array_merge($details, [
-                'questionnaire' => true,
-                'question' => $questionTwo['title'],
-                'contentful_id' => $contentfulId,
-            ])),
+            'details' => json_encode(
+                array_merge($details, [
+                    'questionnaire' => true,
+                    'question' => $questionTwo['title'],
+                    'contentful_id' => $contentfulId,
+                ]),
+            ),
             'referrer_user_id' => $referrerUser->id,
             'group_id' => $groupId,
         ]);

--- a/tests/Http/Web/PasswordResetTest.php
+++ b/tests/Http/Web/PasswordResetTest.php
@@ -210,7 +210,10 @@ class PasswordResetTest extends TestCase
             $params = $job->getParams();
 
             $this->assertEquals($params['user']->id, $user->id);
-            $this->assertEquals($params['eventData']['updated_via'], 'rock-the-vote-activate-account');
+            $this->assertEquals(
+                $params['eventData']['updated_via'],
+                'rock-the-vote-activate-account',
+            );
 
             return true;
         });

--- a/tests/Http/Web/WebActionTest.php
+++ b/tests/Http/Web/WebActionTest.php
@@ -31,6 +31,7 @@ class WebActionTest extends TestCase
             'scholarship_entry' => true,
             'volunteer_credit' => false,
             'anonymous' => false,
+            'impact_goal' => 2000,
             'noun' => 'things',
             'verb' => 'done',
         ]);
@@ -144,5 +145,40 @@ class WebActionTest extends TestCase
         $response = $this->getJson('api/v3/actions/' . $action->id);
 
         $response->assertNotFound();
+    }
+
+    /**
+     * Test that a POST request to /actions with invalid data types is not successful.
+     *
+     * POST /admin/actions
+     * @return void
+     */
+    public function testCannotCreateActionWithInvalidInput()
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        $actionName = $this->faker->sentence;
+
+        $admin = factory(User::class, 'admin')->create();
+
+        $response = $this->actingAs($admin, 'web')->post('/admin/actions', [
+            'name' => $actionName,
+            'campaign_id' => $campaign->id,
+            'post_type' => 'photo',
+            'action_type' => 'make-something',
+            'time_commitment' => '0.5-1.0',
+            'reportback' => true,
+            'civic_action' => false,
+            'scholarship_entry' => true,
+            'volunteer_credit' => false,
+            'anonymous' => false,
+            'impact_goal' => 'dog', //should be an integer
+            'noun' => 'things',
+            'verb' => 'done',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'impact_goal' => 'The impact goal must be an integer.',
+        ]);
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new field to an action called the `impact_goal`. This field is for editors to define the impact goal for a campaign that involves collecting items etc. This goal amount will be used to populate the progress bar displayed on that campaign!

### How should this be reviewed?

Let me know if any other test cases make sense here. I would like to add one to test an invalid data format when an action is created, but I was having trouble finding a good way to do that. Advice would be welcomed!

<img width="817" alt="Screen Shot 2021-05-05 at 4 23 08 PM" src="https://user-images.githubusercontent.com/15236023/117204686-a6471580-adbe-11eb-957e-961e7bc6bbb0.png">


### Any background context you want to provide?

I added the field to the create/edit forms for an action, but I can't yet add it to the react components that display actions because we are using a graphql query there to grab the data and I haven't added this field to graphql yet. Tricky, tricky!

### Relevant tickets

References [Pivotal #177933241](https://www.pivotaltracker.com/story/show/177933241).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
