### PR TITLE
Don't throw on 404s from the Customer.io API.

### DIFF
--- a/app/Services/CustomerIo.php
+++ b/app/Services/CustomerIo.php
@@ -151,7 +151,12 @@ class CustomerIo
 
         $response = $this->trackApiClient->put('customers/' . $user->id, [
             'json' => $payload,
+            'http_errors' => false,
         ]);
+
+        if ($response->getStatusCode() === 404) {
+            return null;
+        }
 
         // For this endpoint, any status besides 200 means something is wrong:
         if ($response->getStatusCode() !== 200) {


### PR DESCRIPTION
### What's this PR do?

This pull request prevents the `northstar:fix-sms-status` command from throwing an exception if a request 404's.

We'll expect a subset of these users won't exist in Customer.io because their promotions have been muted & that shouldn't "fail" the script. For example, here's an error that halted the script when testing on QA earlier:

```
In RequestException.php line 113:

  Client error: `GET https://beta-api.customer.io/v1/api/customers/5d02cdd646e68f00e96de186/attributes` resulted in a `404 Not Found` response:
  {"errors":[{"detail":"not found (reference 01F4Z5B1MDK8FFTM2D2C5QM9GQ)","status":"404"}]}
```

### How should this be reviewed?

Here's documentation on the Guzzle [http_errors](https://docs.guzzlephp.org/en/stable/request-options.html#http-errors) option.

This more closely mirrors how we handle requests in our Gateway library (where 404's also return `null`).

### Any background context you want to provide?

I always forget that this is the default behavior with Guzzle! 

### Relevant tickets

References [Pivotal #177986264](https://www.pivotaltracker.com/story/show/177986264).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
