### PR TITLE
Reverting test.

### DIFF
--- a/tests/Jobs/Imports/ImportMutePromotionsTest.php
+++ b/tests/Jobs/Imports/ImportMutePromotionsTest.php
@@ -44,20 +44,18 @@ class ImportMutePromotionsTest extends TestCase
 
         $this->expectException(ModelNotFoundException::class);
 
-        try {
-            ImportMutePromotions::dispatch(
-                ['northstar_id' => 'non_existent_id'],
-                $importFile,
-            );
-        } finally {
-            $this->assertDatabaseMissing(
-                'mute_promotions_logs',
-                [
-                    'import_file_id' => $importFile->id,
-                    'user_id' => $user->id,
-                ],
-                'mysql',
-            );
-        }
+        ImportMutePromotions::dispatch(
+            ['northstar_id' => 'non_existent_id'],
+            $importFile,
+        );
+
+        $this->assertDatabaseMissing(
+            'mute_promotions_logs',
+            [
+                'import_file_id' => $importFile->id,
+                'user_id' => $user->id,
+            ],
+            'mysql',
+        );
     }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request simply removes the `try { ... } finally { ... }` from `testDoesNotMutePromotionsOrLogEventIfUserNotFound()` test. It was added to see if it resolved the flakey "database lock" test bugs, but now that @DFurnes figured out the real reason for the flakey tests in #1194 it is no longer needed.

### How should this be reviewed?

👀 
