### PR TITLE
Fix SMS statuses by ID, rather than by querying database.

### DIFF
--- a/app/Console/Commands/FixSmsStatusCommand.php
+++ b/app/Console/Commands/FixSmsStatusCommand.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use App\Models\User;
 use App\Services\CustomerIo;
 use Illuminate\Console\Command;
-use Illuminate\Support\Collection;
+use League\Csv\Reader;
 
 class FixSmsStatusCommand extends Command
 {
@@ -14,14 +14,14 @@ class FixSmsStatusCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'northstar:fix-sms-status {--dry-run}';
+    protected $signature = 'northstar:fix-sms-status {--dry-run} {input=php://stdin}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Fix accounts with active sms_status but no mobile number.';
+    protected $description = 'Unset sms_status for the given accounts.';
 
     /**
      * Execute the console command.
@@ -32,36 +32,47 @@ class FixSmsStatusCommand extends Command
     {
         info('northstar:fix-sms-status - Starting up!');
 
-        // Get addressable users with a null mobile:
-        $query = User::whereIn('sms_status', [
-            'active',
-            'pending',
-            'less',
-        ])->where('mobile', 'exists', false);
+        $input = file_get_contents($this->argument('input'));
+        $csv = Reader::createFromString($input);
+        $csv->setHeaderOffset(0);
 
-        $query->chunkById(200, function (Collection $users) use ($customerIo) {
-            foreach ($users as $user) {
-                $profile = $customerIo->getAttributes($user);
+        foreach ($csv->getRecords() as $record) {
+            $user = User::find($record['id']);
 
-                throttle(600); // Customer.io Beta API is rate-limited, so keep under 10/s (600/min).
+            if (!$user) {
+                info('Could not find user', ['id' => $record['id']]);
 
-                // We want to log a little context on each user that we're fixing
-                // to help identify patterns of potentially affected accounts:
-                info('Fixing user', [
-                    'id' => $user->id,
-                    'has_profile' => !empty($profile),
-                    'phone' => data_get($profile, 'phone'),
-                    'source' => $user->source,
-                    'created_at' => $user->created_at,
-                ]);
-
-                if ($this->option('dry-run')) {
-                    continue;
-                }
-
-                $user->unset('sms_status');
+                continue;
             }
-        });
+
+            // If this user has a mobile (perhaps due to adding one after
+            // our CSV was generated), skip unsetting their SMS status:
+            if (!is_null($user->mobile)) {
+                info('Skipping user', ['id' => $user->id]);
+
+                continue;
+            }
+
+            $profile = $customerIo->getAttributes($user);
+
+            throttle(600); // Customer.io Beta API is rate-limited, so keep under 10/s (600/min).
+
+            // We want to log a little context on each user that we're fixing
+            // to help identify patterns of potentially affected accounts:
+            info('Fixing user', [
+                'id' => $user->id,
+                'has_profile' => !empty($profile),
+                'phone' => data_get($profile, 'phone'),
+                'source' => $user->source,
+                'created_at' => $user->created_at,
+            ]);
+
+            if ($this->option('dry-run')) {
+                continue;
+            }
+
+            $user->unset('sms_status');
+        }
 
         info('northstar:fix-sms-status - All done!');
     }

--- a/tests/Console/example-ids.csv
+++ b/tests/Console/example-ids.csv
@@ -1,0 +1,3 @@
+id
+5d3630a0fdce2742ff6c64d4
+5d3630a0fdce2742ff6c64d5


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `northstar:fix-sms-status` command to accept a CSV of user IDs, rather than querying the database for affected records. This should allow us to sidestep query timeouts we're running into on production.

### How should this be reviewed?

👀

### Any background context you want to provide?

This should fix an issue where some accounts may receive unwanted messaging.

### Relevant tickets

References [Pivotal #177986264](https://www.pivotaltracker.com/story/show/177986264).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
