### PR TITLE
Add Accepted Quantity method to actions

### DIFF
--- a/app/Http/Transformers/ActionTransformer.php
+++ b/app/Http/Transformers/ActionTransformer.php
@@ -11,6 +11,13 @@ use League\Fractal\TransformerAbstract;
 class ActionTransformer extends TransformerAbstract
 {
     /**
+     * List of resources possible to include.
+     *
+     * @var array
+     */
+    protected $availableIncludes = ['accepted_quantity'];
+
+    /**
      * Transform resource data.
      *
      * @param \App\Models\Action $action
@@ -45,5 +52,19 @@ class ActionTransformer extends TransformerAbstract
             'created_at' => $action->created_at->toIso8601String(),
             'updated_at' => $action->updated_at->toIso8601String(),
         ];
+    }
+
+    /**
+     * Include accepted quantity.
+     *
+     * @param \App\Models\Action $action
+     * @return \League\Fractal\Resource\Collection
+     */
+    public function includeAcceptedQuantity(Action $action)
+    {
+        return $this->item(
+            $action->getAcceptedQuantity(),
+            new AcceptedQuantityTransformer(),
+        );
     }
 }

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -96,4 +96,16 @@ class Action extends Model
     {
         return $this->hasMany(Post::class);
     }
+
+    /**
+     * Get the quantity total associated with approved posts under this action.
+     *
+     * @return int
+     */
+    public function getAcceptedQuantity()
+    {
+        $accepted_posts = $this->posts->where('status', 'accepted');
+
+        return $accepted_posts->sum('quantity');
+    }
 }

--- a/documentation/endpoints/v3/actions.md
+++ b/documentation/endpoints/v3/actions.md
@@ -89,6 +89,12 @@ Example Response:
 
 ## Retrieve A Specific Action
 
+### Optional Query Parameters
+
+- **include** _(string)_
+  - Include additional related records in the response: `accepted_quantity`
+  - e.g. `api/v3/actions/:action_id/?include=accepted_quantity`
+
 ```
 GET /api/v3/actions/:action_id
 ```

--- a/documentation/endpoints/v3/actions.md
+++ b/documentation/endpoints/v3/actions.md
@@ -11,8 +11,13 @@ GET /api/v3/actions
 ### Optional Query Parameters
 
 - **filter[column]** _(string)_
+
   - Filter results by the given column: `id`, `campaign_id`, `callpower_campaign_id`
   - You can filter by more than one value for a column, e.g. `/actions?filter[id]=121,122`
+
+- **include** _(string)_
+  - Include additional related records in the response: `accepted_quantity`
+  - e.g. `api/v3/actions?include=accepted_quantity`
 
 Example Response:
 
@@ -38,6 +43,7 @@ Example Response:
             "anonymous": false,
             "online": false,
             "quiz": false,
+            "impact_goal": 4000,
             "noun": "votes",
             "verb": "registered",
             "created_at": "2019-01-23T21:23:42+00:00",
@@ -61,6 +67,7 @@ Example Response:
             "anonymous": false,
             "online": false,
             "quiz": false,
+            "impact_goal": 10000,
             "noun": "votes",
             "verb": "registered",
             "created_at": "2019-01-23T21:23:42+00:00",
@@ -109,6 +116,7 @@ Example Response:
   "anonymous": false,
   "online": true,
   "quiz": false,
+  "impact_goal": 250000,
   "noun": "resources",
   "verb": "shared",
   "created_at": "2019-01-23T21:23:42+00:00",


### PR DESCRIPTION
### What's this PR do?

This pull request adds a method to the actions model that calculates how many posts associated with it have an `accepted` status. We then add that using `includes` on the `ActionTransformer` so that we can optionally query for it when pulling an action or actions. If we include it in the API request it should return as an `accepted_quantity` field.

### How should this be reviewed?

I think I covered all the steps needed with the transformer but let me know if I missed something!

### Any background context you want to provide?

Need this so that we can pull this info and display on a campaign's progress bar!

### Relevant tickets

References [Pivotal #177933245](https://www.pivotaltracker.com/n/projects/2401401/stories/177933245).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
