### PR TITLE
Fixes dots in registration flow so they aren't giant in Firefox and Chrome

### DIFF
--- a/resources/views/profiles/about/edit.blade.php
+++ b/resources/views/profiles/about/edit.blade.php
@@ -108,7 +108,7 @@
 
         <div class="flex pt-4">
             <div class="w-1/3 flex justify-start">
-                <img src="/images/about-form-icon.svg" />
+                <img class="w-1/3" src="/images/about-form-icon.svg" />
             </div>
             <div class="w-2/3 flex justify-around md:justify-end p-2">
                 <div class="m-1">

--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -61,7 +61,7 @@
 
         <div class="flex pt-4">
             <div class="w-1/3 flex justify-start">
-                <img src="/images/subscription-form-icon.svg" />
+                <img class="w-1/3" src="/images/subscription-form-icon.svg" />
             </div>
             <div class="w-2/3 flex justify-around sm:justify-end p-2">
                 <div class="m-1">


### PR DESCRIPTION
### What's this PR do?

These dots are to indicate which page of the process members are on. At some point, they started showing up HUGE on Chrome and Firefox, but stayed normal in Safari.

Chrome before:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/4240292/117860204-e128cd80-b244-11eb-88ea-eba8a3ad31c1.png">

Firefox before:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/4240292/117860174-d79f6580-b244-11eb-9ed3-310ede02f2e1.png">

Safari before:
<img width="611" alt="image" src="https://user-images.githubusercontent.com/4240292/117860231-e9810880-b244-11eb-93e4-bccbdb0e9733.png">

I did some digging to see what was different between Safari and Firefox. In Safari, the dot image was taking up a third of its container, which was in turn taking up a third of the full width of that area:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/4240292/117860703-7330d600-b245-11eb-9d2f-dc3c140e9d77.png">
In Firefox however, the dot image was taking up the full width of its container, which was also correctly taking up a third of the full width of that area:
<img width="302" alt="image" src="https://user-images.githubusercontent.com/4240292/117860846-9ce9fd00-b245-11eb-9b05-e6bd0e8fb281.png">

One of the things I tried was giving the image tag the `class="w-1/3"` that its container has. That seemed to fix the big dot issue in Firefox/Chrome and only very slightly change the appearance in Safari so that's the solution in this PR.

I can't explain why this was happening and perhaps there is a better way to fix it which I would love to hear about!

Chrome after:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/4240292/117861397-3e714e80-b246-11eb-8c3a-1ed386f9bcae.png">

Firefox after:
<img width="677" alt="image" src="https://user-images.githubusercontent.com/4240292/117861465-51841e80-b246-11eb-96a0-cc4276f6c70b.png">

Safari before AND after (for easy comparison to see the slight change):
<img width="611" alt="image" src="https://user-images.githubusercontent.com/4240292/117860231-e9810880-b244-11eb-93e4-bccbdb0e9733.png">

<img width="631" alt="image" src="https://user-images.githubusercontent.com/4240292/117861504-5b0d8680-b246-11eb-949f-56d6bc7fb148.png">


### How should this be reviewed?

Should other approaches be considered?

### Any background context you want to provide?

All in the ticket!

### Relevant tickets

References [Pivotal #177463282](https://www.pivotaltracker.com/story/show/177463282).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
