### PR TITLE
Add impact goal to Action Index Component

### DIFF
--- a/resources/assets/admin/components/Action/index.js
+++ b/resources/assets/admin/components/Action/index.js
@@ -16,6 +16,7 @@ export const ActionFragment = gql`
     }
     civicAction
     collectSchoolId
+    impactGoal
     name
     noun
     online
@@ -60,6 +61,11 @@ export const Action = ({ action, deleteAction, isPermalink }) => {
 
       <div className="container__row">
         <ul>
+          <li>
+            <h4>IMPACT GOAL</h4>
+            <p>{action.impactGoal}</p>
+          </li>
+
           <li>
             <h4>NOUN</h4>
             <p>{action.noun}</p>


### PR DESCRIPTION
### What's this PR do?

This pull request adds the impact goal to display on the Action `index.js` component!

### How should this be reviewed?

👀 

![Screen Shot 2021-05-12 at 11 11 33 AM](https://user-images.githubusercontent.com/15236023/117999884-4b0fa880-b313-11eb-89db-764de889e104.png)

![Screen Shot 2021-05-12 at 11 11 54 AM](https://user-images.githubusercontent.com/15236023/117999891-4e0a9900-b313-11eb-87db-e1b6cce82da6.png)


### Any background context you want to provide?

Now that we've added the field to graphql, we can query for it on this component!

### Relevant tickets

References [Pivotal #177933517](https://www.pivotaltracker.com/n/projects/2401401/stories/177933517).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
