### PR TITLE
Add partner-specific API endpoints from Chompy.

### DIFF
--- a/app/Http/Controllers/Partners/CallPowerController.php
+++ b/app/Http/Controllers/Partners/CallPowerController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Partners;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\Imports\ImportCallPowerRecord;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class CallPowerController extends Controller
+{
+    /**
+     * Create a controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('token:X-DS-CallPower-API-Key');
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function store(Request $request)
+    {
+        $parameters = $request->validate([
+            'mobile' => 'required',
+            'callpower_campaign_id' => 'required|integer',
+            'status' => 'required|string',
+            'call_timestamp' => 'required|date',
+            'call_duration' => 'required|integer',
+            'campaign_target_name' => 'required|string',
+            'campaign_target_title' => 'required|string',
+            'campaign_target_district' => 'nullable|string',
+            'callpower_campaign_name' => 'required|string',
+            'number_dialed_into' => 'required',
+        ]);
+
+        ImportCallPowerRecord::dispatch($parameters);
+
+        return $this->respond('Received CallPower payload.');
+    }
+}

--- a/app/Http/Controllers/Partners/SoftEdgeController.php
+++ b/app/Http/Controllers/Partners/SoftEdgeController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Partners;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\Imports\ImportSoftEdgeRecord;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class SoftEdgeController extends Controller
+{
+    /**
+     * Create a controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('token:X-DS-SoftEdge-API-Key');
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function store(Request $request)
+    {
+        $parameters = $request->validate([
+            'northstar_id' => 'required',
+            'action_id' => 'required|integer',
+            'email_timestamp' => 'required|date',
+            'campaign_target_name' => 'required|string',
+            'campaign_target_title' => 'nullable|string',
+            'campaign_target_district' => 'nullable|string',
+        ]);
+
+        ImportSoftEdgeRecord::dispatch($parameters);
+
+        return $this->respond('Received SoftEdge payload.');
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,6 +58,7 @@ class Kernel extends HttpKernel
         'role' => \App\Http\Middleware\RequireRole::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \App\Http\Middleware\ThrottleRequests::class,
+        'token' => \App\Http\Middleware\AuthenticateWithApiKey::class,
     ];
 
     /**

--- a/app/Http/Middleware/AuthenticateWithApiKey.php
+++ b/app/Http/Middleware/AuthenticateWithApiKey.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+
+class AuthenticateWithApiKey
+{
+    /**
+     * Valid API key headers & secrets.
+     *
+     * @var array
+     */
+    protected array $keys;
+
+    public function __construct()
+    {
+        $this->keys = [
+            'X-DS-CallPower-API-Key' => config('auth.partners.callpower'),
+            'X-DS-SoftEdge-API-Key' => config('auth.partners.softedge'),
+        ];
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  $headers
+     * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next, ...$headers)
+    {
+        // Check the header(s) for authorizing this route. If any match,
+        // we're good! If not, tell this request to hit the road.
+        foreach ($headers as $header) {
+            // Ensure that if we haven't set an environment variable for this
+            // environment that we throw an error rather than leave these ungated:
+            if (empty($this->keys[$header])) {
+                throw new \Exception(
+                    "The secret for '$header' cannot be empty.",
+                );
+            }
+
+            if ($request->header($header) === $this->keys[$header]) {
+                return $next($request);
+            }
+        }
+
+        throw new AuthenticationException();
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -14,6 +14,21 @@ return [
     'key' => env('APP_AUTH_KEY'),
 
     /*
+     |--------------------------------------------------------------------------
+     | CUSTOM: Partner API Keys
+     |--------------------------------------------------------------------------
+     |
+     | These secrets are used to authenticate API requests from third-party
+     | partners, like CallPower or SoftEdge.
+     |
+     */
+
+    'partners' => [
+        'callpower' => env('CALLPOWER_API_KEY'),
+        'softedge' => env('SOFTEDGE_API_KEY'),
+    ],
+
+    /*
     |--------------------------------------------------------------------------
     | Authentication Defaults
     |--------------------------------------------------------------------------

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -69,6 +69,15 @@ See [Authentication](authentication.md) for details on authorizing your requests
 | `GET .well-known/openid-configuration` | [Get OpenID Configuration](endpoints/discovery.md#get-openid-configuration) |
 | `GET v2/keys`                          | [Retrieve Public Key](endpoints/discovery.md#retrieve-public-key)           |
 
+#### Third-Party Partners
+
+We also have endpoints that our partner organizations use to integrate with our systems. These require a partner-specific API key.
+
+| Endpoint                      | Functionality                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| `POST /api/v1/callpower/call` | [CallPower: Create a post](endpoints/partners/callpower.md#create-a-callpower-post) |
+| `POST /api/v1/softedge/email` | [SoftEdge: Create a post](endpoints/partners/softedge.md#create-a-softedge-post)    |
+
 <br>
 
 ## Responses

--- a/documentation/endpoints/partners/callpower.md
+++ b/documentation/endpoints/partners/callpower.md
@@ -1,0 +1,85 @@
+## CallPower Posts
+
+## Create a CallPower Post
+
+```
+POST /api/partners/callpower/call
+```
+
+This endpoint requires the partner-specific `X-DS-CallPower-API-Key` header.
+
+**Request Parameters:**
+
+```js
+{
+  // The mobile number of the user who makes the phone call. (required)
+  mobile: String,
+
+  // The CallPower campaign_id given by the CallPower system. (required)
+  callpower_campaign_id: Int,
+
+  // The status of the call, e.g. completed, busy, failed, no answer, cancelled, unknown. (required)
+  status: String,
+
+  // The timestamp of when the call was made, in ISO-8601 format. (required)
+  call_timestamp: DateTime,
+
+  // The length of the call (required),
+  call_duration: Int,
+
+  //The name of the target the user called.
+  campaign_target_name: String,
+
+  // The title of the target the user called. (required)
+  campaign_target_title: String,
+
+  // The district of the target the user called.
+  campaign_target_district: String,
+
+  // The CallPower campaign name given in CallPower. (required)
+  callpower_campaign_name: String,
+
+  // The number the user called to connect to the target. (required)
+  number_dialed_into: String,
+}
+```
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```sh
+curl -X POST "http://northstar.test/api/partners/callpower/call" \
+     -H 'X-DS-CallPower-API-Key: ***** Hidden credentials *****' \
+     -H 'Accept: application/json' \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+      "mobile": "+15551231234",
+      "status": "completed",
+      "call_timestamp": "2017-11-07 18:54:10.829655",
+      "call_duration": 36,
+      "campaign_target_title": "Representative",
+      "campaign_target_district": "FL-7",
+      "callpower_campaign_id": 1,
+      "campaign_target_name": "Mickey Mouse",
+      "callpower_campaign_name": "DefendDreamers_Nov9_CongressCalls",
+      "number_dialed_into": "+15554441234"
+    }'
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```js
+// 200 OK
+
+{
+    "success": {
+        "code": 200,
+        "message": "Received CallPower payload."
+    }
+}
+```
+
+</details>

--- a/documentation/endpoints/partners/softedge.md
+++ b/documentation/endpoints/partners/softedge.md
@@ -1,0 +1,69 @@
+## SoftEdge Posts
+
+## Create a SoftEdge Post
+
+```
+POST /api/partners/softedge/email
+```
+
+This endpoint requires the partner-specific `X-DS-SoftEdge-API-Key` header.
+
+**Request Parameters:**
+
+```js
+{
+  // The `id` of action the post is associated to. (required)
+  action_id: Int,
+
+  // The `id` of the user who sent the email. (required)
+  northstar_id: String,
+
+  // The timestamp of when the email was sent. (required)
+  email_timestamp: DateTime,
+
+  // The name of the target the user emailed. (required)
+  campaign_target_name: String,
+
+  // The title of the target the user emailed.
+  campaign_target_title: String,
+
+  // The district of the target the user emailed.
+  campaign_target_distrct: String,
+}
+```
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```sh
+curl -X POST "http://northstar.test/api/partners/softedge/email" \
+     -H 'X-DS-SoftEdge-API-Key: ***** Hidden credentials *****' \
+     -H 'Accept: application/json' \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -d $'{
+      "action_id": 1,
+      "northstar_id": "609d4e6cc166170977230222",
+      "call_timestamp": "2017-11-07 18:54:10.829655",
+      "campaign_target_district": "FL-7",
+      "campaign_target_name": "Mickey Mouse",
+      "campaign_target_title": "Representative"
+    }'
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```js
+// 200 OK
+
+{
+    "success": {
+        "code": 200,
+        "message": "Received SoftEdge payload."
+    }
+}
+```
+
+</details>

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,7 +71,7 @@ Route::group(
     },
 );
 
-// https://profile.dosomething.org/v2/
+// https://identity.dosomething.org/v2/
 Route::group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     // Authentication
     Route::post('auth/token', 'OAuthController@createToken');
@@ -130,7 +130,7 @@ Route::group(['prefix' => 'v2', 'as' => 'v2.'], function () {
     Route::get('scopes', 'ScopeController@index');
 });
 
-// https://profile.dosomething.org/v1/
+// https://identity.dosomething.org/v1/
 Route::group(['prefix' => 'v1', 'as' => 'v1.'], function () {
     // Users
     Route::resource('users', 'Legacy\UserController', [
@@ -143,6 +143,10 @@ Route::group(['prefix' => 'v1', 'as' => 'v1.'], function () {
     // Profile (the currently authenticated user)
     Route::get('profile', 'Legacy\ProfileController@show');
     Route::post('profile', 'Legacy\ProfileController@update');
+});
+
+// https://identity.dosomething.org/api/partners/
+Route::group(['prefix' => 'api/partners'], function () {
 });
 
 // Assets

--- a/routes/api.php
+++ b/routes/api.php
@@ -147,6 +147,8 @@ Route::group(['prefix' => 'v1', 'as' => 'v1.'], function () {
 
 // https://identity.dosomething.org/api/partners/
 Route::group(['prefix' => 'api/partners'], function () {
+    // CallPower
+    Route::post('callpower/call', 'Partners\CallPowerController@store');
 });
 
 // Assets

--- a/routes/api.php
+++ b/routes/api.php
@@ -149,6 +149,9 @@ Route::group(['prefix' => 'v1', 'as' => 'v1.'], function () {
 Route::group(['prefix' => 'api/partners'], function () {
     // CallPower
     Route::post('callpower/call', 'Partners\CallPowerController@store');
+
+    // SoftEdge
+    Route::post('softedge/email', 'Partners\SoftEdgeController@store');
 });
 
 // Assets

--- a/tests/Http/Partners/CallPowerTest.php
+++ b/tests/Http/Partners/CallPowerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use App\Jobs\Imports\ImportCallPowerRecord;
+use Illuminate\Support\Facades\Bus;
+
+class CallPowerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['auth.partners.callpower' => 'CallPowerSecretToken!']);
+    }
+
+    /**
+     * It should kick off a job for a valid payload.
+     *
+     * @return void
+     */
+    public function testProcessesCalls()
+    {
+        Bus::fake();
+
+        $response = $this->postJson(
+            'api/partners/callpower/call',
+            [
+                'mobile' => '2224567891',
+                'callpower_campaign_id' => '4',
+                'status' => 'completed',
+                'call_timestamp' => '2017-11-09 06:34:01.185035',
+                'call_duration' => 50,
+                'campaign_target_name' => 'Mickey Mouse',
+                'campaign_target_title' => 'Representative',
+                'campaign_target_district' => 'FL-7',
+                'callpower_campaign_name' => 'Test',
+                'number_dialed_into' => '+12028519273',
+            ],
+            [
+                'X-DS-CallPower-API-Key' => 'CallPowerSecretToken!',
+            ],
+        );
+
+        $response->assertOk();
+
+        Bus::assertDispatched(ImportCallPowerRecord::class);
+    }
+
+    /**
+     * It should validate required keys are provided.
+     *
+     * @return void
+     */
+    public function testValidatesRequestPayload()
+    {
+        Bus::fake();
+
+        $response = $this->postJson(
+            'api/partners/callpower/call',
+            [
+                // 'mobile' => whoops we forgot this!
+                'callpower_campaign_id' => '4',
+                'status' => 'completed',
+                'call_timestamp' => '2017-11-09 06:34:01.185035',
+                // 'call_duration' => who knows?!
+                'campaign_target_name' => 'Mickey Mouse',
+                'campaign_target_title' => 'Representative',
+                'campaign_target_district' => 'FL-7',
+                'callpower_campaign_name' => 'Test',
+                'number_dialed_into' => '+12028519273',
+            ],
+            [
+                'X-DS-CallPower-API-Key' => 'CallPowerSecretToken!',
+            ],
+        );
+
+        $response->assertJsonValidationErrors(['mobile', 'call_duration']);
+
+        Bus::assertNotDispatched(ImportCallPowerRecord::class);
+    }
+
+    /**
+     * It should require an API token.
+     *
+     * @return void
+     */
+    public function testRequiresToken()
+    {
+        Bus::fake();
+
+        $response = $this->postJson('api/partners/callpower/call', [
+            'mobile' => '2224567891',
+            'callpower_campaign_id' => '4',
+            'status' => 'completed',
+            'call_timestamp' => '2017-11-09 06:34:01.185035',
+            'call_duration' => 50,
+            'campaign_target_name' => 'Mickey Mouse',
+            'campaign_target_title' => 'Representative',
+            'campaign_target_district' => 'FL-7',
+            'callpower_campaign_name' => 'Test',
+            'number_dialed_into' => '+12028519273',
+        ]);
+
+        $response->assertUnauthorized();
+
+        Bus::assertNotDispatched(ImportCallPowerRecord::class);
+    }
+
+    /**
+     * It should require the correct partner API token.
+     *
+     * @return void
+     */
+    public function testRequiresValidToken()
+    {
+        Bus::fake();
+
+        $response = $this->postJson(
+            'api/partners/callpower/call',
+            [
+                'mobile' => '2224567891',
+                'callpower_campaign_id' => '4',
+                'status' => 'completed',
+                'call_timestamp' => '2017-11-09 06:34:01.185035',
+                'call_duration' => 50,
+                'campaign_target_name' => 'Mickey Mouse',
+                'campaign_target_title' => 'Representative',
+                'campaign_target_district' => 'FL-7',
+                'callpower_campaign_name' => 'Test',
+                'number_dialed_into' => '+12028519273',
+            ],
+            [
+                'X-DS-CallPower-API-Key' => 'let-me-in!!!!', // <-- shockingly, not the token!
+            ],
+        );
+
+        $response->assertUnauthorized();
+
+        Bus::assertNotDispatched(ImportCallPowerRecord::class);
+    }
+}

--- a/tests/Http/Partners/SoftEdgeTest.php
+++ b/tests/Http/Partners/SoftEdgeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Jobs\Imports\ImportSoftEdgeRecord;
+use Illuminate\Support\Facades\Bus;
+
+class SoftEdgeTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['auth.partners.softedge' => 'SoftEdgeSecretToken!']);
+    }
+
+    /**
+     * It should kick off a job for a valid payload.
+     *
+     * @return void
+     */
+    public function testProcessesEmails()
+    {
+        Bus::fake();
+
+        $response = $this->postJson(
+            'api/partners/softedge/email',
+            [
+                'action_id' => '123',
+                'northstar_id' => '609d4e6cc166170977230222',
+                'email_timestamp' => '2017-11-07 18:54:10.829655',
+                'campaign_target_name' => 'Contact Mickey Mouse',
+                'campaign_target_title' => 'Representative',
+                'campaign_target_district' => 'FL-7',
+            ],
+            [
+                'X-DS-SoftEdge-API-Key' => 'SoftEdgeSecretToken!',
+            ],
+        );
+
+        $response->assertOk();
+
+        Bus::assertDispatched(ImportSoftEdgeRecord::class);
+    }
+
+    /**
+     * It should validate required keys are provided.
+     *
+     * @return void
+     */
+    public function testValidatesRequestPayload()
+    {
+        Bus::fake();
+
+        $response = $this->postJson(
+            'api/partners/softedge/email',
+            [
+                // 'action_id' => whoops, forgot!
+                'northstar_id' => '609d4e6cc166170977230222',
+                // 'email_timestamp' => did it even happen? we'll never know!
+                'campaign_target_name' => 'Contact Mickey Mouse',
+                'campaign_target_title' => 'Representative',
+                'campaign_target_district' => 'FL-7',
+            ],
+            [
+                'X-DS-SoftEdge-API-Key' => 'SoftEdgeSecretToken!',
+            ],
+        );
+
+        $response->assertJsonValidationErrors(['action_id', 'email_timestamp']);
+
+        Bus::assertNotDispatched(ImportSoftEdgeRecord::class);
+    }
+
+    /**
+     * It should require an API token.
+     *
+     * @return void
+     */
+    public function testRequiresToken()
+    {
+        Bus::fake();
+
+        $response = $this->postJson('api/partners/softedge/email', [
+            'action_id' => '123',
+            'northstar_id' => '609d4e6cc166170977230222',
+            'email_timestamp' => '2017-11-07 18:54:10.829655',
+            'campaign_target_name' => 'Contact Mickey Mouse',
+            'campaign_target_title' => 'Representative',
+            'campaign_target_district' => 'FL-7',
+        ]);
+
+        $response->assertUnauthorized();
+
+        Bus::assertNotDispatched(ImportSoftEdgeRecord::class);
+    }
+
+    /**
+     * It should require the correct partner API token.
+     *
+     * @return void
+     */
+    public function testRequiresValidToken()
+    {
+        Bus::fake();
+
+        $response = $this->postJson(
+            'api/partners/softedge/email',
+            [
+                'action_id' => '123',
+                'northstar_id' => '609d4e6cc166170977230222',
+                'email_timestamp' => '2017-11-07 18:54:10.829655',
+                'campaign_target_name' => 'Contact Mickey Mouse',
+                'campaign_target_title' => 'Representative',
+                'campaign_target_district' => 'FL-7',
+            ],
+            [
+                'X-DS-SoftEdge-API-Key' => 'let-me-in!!!!', // <-- shockingly, not the token!
+            ],
+        );
+
+        $response->assertUnauthorized();
+
+        Bus::assertNotDispatched(ImportSoftEdgeRecord::class);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request adds partner API endpoints for CallPower & SoftEdge (which kick off each of these import jobs, added in #1200 and #1205 respectively). These are facades used by these third-party partners to interface with our internal APIs.

### How should this be reviewed?

I separated out this work into individual commits & wrote test suites for each endpoint.

I also copied over Chompy's documentation & re-formatted to match Northstar's existing documentation (which use JS request parameter syntax & copy-pasteable cURL examples for request payload with appropriate headers).

### Any background context you want to provide?

We'll need to provide updated API endpoints to these partners when we decommission Chompy!

### Relevant tickets

References [Pivotal #177733275](https://www.pivotaltracker.com/story/show/177733275).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
