### PR TITLE
Ensure correct source is set for imported records.

### DIFF
--- a/app/Jobs/Imports/ImportCallPowerRecord.php
+++ b/app/Jobs/Imports/ImportCallPowerRecord.php
@@ -91,7 +91,6 @@ class ImportCallPowerRecord implements ShouldQueue
             'action_id' => $action->id,
             'type' => 'phone-call',
             'quantity' => 1,
-            'source' => 'importer-client', // @TODO: We should type this.
             'source_details' => 'CallPower',
             'details' => $details,
         ];
@@ -105,6 +104,8 @@ class ImportCallPowerRecord implements ShouldQueue
         $post = $posts->create($payload, $signup->id);
 
         if ($post) {
+            // Set fields that repository does not allow mass-assigning:
+            $post->source = 'importer-client'; // @TODO: We should type this.
             $post->status = $status === 'completed' ? 'accepted' : 'incomplete';
             $post->save();
 

--- a/app/Jobs/Imports/ImportSoftEdgeRecord.php
+++ b/app/Jobs/Imports/ImportSoftEdgeRecord.php
@@ -77,6 +77,8 @@ class ImportSoftEdgeRecord implements ShouldQueue
         $post = $posts->create($payload, $signup->id);
 
         if ($post) {
+            // Set fields that repository does not allow mass-assigning:
+            $post->source = 'importer-client'; // @TODO: We should type this.
             $post->status = 'accepted';
             $post->save();
 

--- a/tests/Jobs/Imports/ImportCallPowerRecordTest.php
+++ b/tests/Jobs/Imports/ImportCallPowerRecordTest.php
@@ -40,6 +40,8 @@ class ImportCallPowerRecordTest extends TestCase
         $this->assertMysqlDatabaseHas('posts', [
             'action_id' => $action->id,
             'status' => 'accepted',
+            'source' => 'importer-client',
+            'source_details' => 'CallPower',
         ]);
     }
 

--- a/tests/Jobs/Imports/ImportSoftEdgeRecordTest.php
+++ b/tests/Jobs/Imports/ImportSoftEdgeRecordTest.php
@@ -34,6 +34,8 @@ class ImportSoftEdgeRecordTest extends TestCase
             'action_id' => $action->id,
             'northstar_id' => $user->id,
             'status' => 'accepted',
+            'source' => 'importer-client',
+            'source_details' => 'SoftEdge',
         ]);
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request ensures that imported records (via SoftEdge or CallPower) continue to be marked with the `importer-client` source when created via Northstar's local importer jobs. This ensures we can continue to attribute these correctly in our admin panels & data warehouse.

### How should this be reviewed?

I added a (failing) test for this in 39c828f & fixed the issue in 835de21.

### Any background context you want to provide?

We actually _do_ allow mass-assigning `source` [on the Post](https://github.com/DoSomething/northstar/blob/b28242793bee2af1270557b5bc32de4c09813b07/app/Models/Post.php#L72), so you'd think this would have worked! I forgot, however, that we also only read/set specific fields [in the PostRepository](https://github.com/DoSomething/northstar/blob/b28242793bee2af1270557b5bc32de4c09813b07/app/Repositories/PostRepository.php#L91-L121) so this field is discarded before Eloquent ever gets to see it.

### Relevant tickets

References [Pivotal #177733275](https://www.pivotaltracker.com/story/show/177733275).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
