### PR TITLE
Add 'CreateRockTheVoteReport' job & command.

### DIFF
--- a/app/Console/Commands/ImportRockTheVoteCommand.php
+++ b/app/Console/Commands/ImportRockTheVoteCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\Imports\CreateRockTheVoteReport;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class ImportRockTheVoteCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'northstar:rock-the-vote';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Imports Rock The Vote registrations from the past hour.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // We want all registrations in the past hour (including a 30 minute overlap to
+        // ensure that we don't lose any records to a gap between scheduled jobs):
+        $now = CarbonImmutable::now();
+        $since = $now->subHours(1)->subMinutes(30);
+
+        Log::debug('Executing import command', [
+            'since' => $since,
+            'before' => $now,
+        ]);
+
+        CreateRockTheVoteReport::dispatch(
+            $since->toDateTimeString(),
+            $now->toDateTimeString(),
+        );
+    }
+}

--- a/app/Jobs/Imports/CreateRockTheVoteReport.php
+++ b/app/Jobs/Imports/CreateRockTheVoteReport.php
@@ -15,14 +15,14 @@ class CreateRockTheVoteReport implements ShouldQueue
     /**
      * The 'since' parameter to create a Rock The Vote report with.
      *
-     * @var DateTime
+     * @var \Carbon\CarbonInterface
      */
     protected $since;
 
     /**
      * The 'before' parameter to create a Rock The Vote report with.
      *
-     * @var DateTime
+     * @var \Carbon\CarbonInterface
      */
     protected $before;
 

--- a/app/Jobs/Imports/CreateRockTheVoteReport.php
+++ b/app/Jobs/Imports/CreateRockTheVoteReport.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Jobs\Imports;
+
+use App\Models\RockTheVoteReport;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+
+class CreateRockTheVoteReport implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /**
+     * The 'since' parameter to create a Rock The Vote report with.
+     *
+     * @var DateTime
+     */
+    protected $since;
+
+    /**
+     * The 'before' parameter to create a Rock The Vote report with.
+     *
+     * @var DateTime
+     */
+    protected $before;
+
+    /**
+     * The Rock The Vote report created upon success.
+     *
+     * @var DateTime
+     */
+    protected $report;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param string $since
+     * @param string $before
+     * @return void
+     */
+    public function __construct($since, $before)
+    {
+        $this->since = $since;
+        $this->before = $before;
+    }
+
+    /**
+     * Execute the job to create a Rock The Vote report and import it after creation.
+     *
+     * @return array
+     */
+    public function handle()
+    {
+        info('Creating report', [
+            'since' => $this->since,
+            'before' => $this->before,
+        ]);
+
+        $this->report = RockTheVoteReport::createViaApi(
+            $this->since,
+            $this->before,
+        );
+
+        // TODO: We still need to make this job!! :)
+        // ImportRockTheVoteReport::dispatch(null, $this->report);
+    }
+
+    /**
+     * Returns the parameters passed to this job.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return [
+            'since' => $this->since,
+            'before' => $this->before,
+            'report' => $this->report,
+        ];
+    }
+}

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
 use App\Services\RockTheVote;
 use Illuminate\Database\Eloquent\Model;
 
@@ -56,12 +57,14 @@ class RockTheVoteReport extends Model
     /**
      * Creates a Rock The Vote Report via API request and saves to storage.
      *
-     * @param string $since
-     * @param string $before
+     * @param CarbonInterface $since
+     * @param CarbonInterface $before
      * @return RockTheVoteReport
      */
-    public static function createViaApi($since = null, $before = null)
-    {
+    public static function createViaApi(
+        CarbonInterface $since,
+        CarbonInterface $before
+    ) {
         $userId = auth()->id();
 
         if (config('services.rock_the_vote.faker')) {
@@ -79,8 +82,8 @@ class RockTheVoteReport extends Model
         }
 
         $response = app(RockTheVote::class)->createReport([
-            'since' => $since,
-            'before' => $before,
+            'since' => $since->toIso8601String(),
+            'before' => $before->toIso8601String(),
         ]);
 
         // HACK: The 'report_id' field documented for this endpoint doesn't appear in

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -77,7 +77,8 @@ class RockTheVoteReport extends Model
         ]);
 
         // Parse response to find the new Rock The Vote Report ID.
-        $statusUrlParts = explode('/', $response->status_url);
+        // TODO: Can we read 'report_id' from the response?
+        $statusUrlParts = explode('/', $response['status_url']);
         $reportId = $statusUrlParts[count($statusUrlParts) - 1];
 
         // Log our created report in the database, to keep track of reports requested.
@@ -85,7 +86,7 @@ class RockTheVoteReport extends Model
             'id' => $reportId,
             'since' => $since,
             'before' => $before,
-            'status' => $response->status,
+            'status' => $response['status'],
             'user_id' => $userId,
         ]);
     }
@@ -107,7 +108,7 @@ class RockTheVoteReport extends Model
     {
         $retryReport = self::createViaApi($this->since, $this->before);
 
-        $this->retry_report_id = $retryReport->id;
+        $this->retry_report_id = $retryReport['id'];
         $this->save();
 
         return $retryReport;

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -83,8 +83,8 @@ class RockTheVoteReport extends Model
             'before' => $before,
         ]);
 
-        // Parse response to find the new Rock The Vote Report ID.
-        // TODO: Can we read 'report_id' from the response?
+        // HACK: The 'report_id' field documented for this endpoint doesn't appear in
+        // actual API respones, so we'll parse it from the given status URL:
         $statusUrlParts = explode('/', $response['status_url']);
         $reportId = $statusUrlParts[count($statusUrlParts) - 1];
 

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -8,6 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class RockTheVoteReport extends Model
 {
     /**
+     * The database connection that should be used by the model.
+     *
+     * @var string
+     */
+    protected $connection = 'mysql';
+
+    /**
      * We use the externally created Rock the Vote ID as our primary key.
      */
     public $incrementing = false;

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Carbon\CarbonInterface;
 use App\Services\RockTheVote;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 
 class RockTheVoteReport extends Model

--- a/app/Models/RockTheVoteReport.php
+++ b/app/Models/RockTheVoteReport.php
@@ -62,7 +62,7 @@ class RockTheVoteReport extends Model
      */
     public static function createViaApi($since = null, $before = null)
     {
-        $userId = optional(auth()->user())->northstar_id;
+        $userId = auth()->id();
 
         if (config('services.rock_the_vote.faker')) {
             $reportId = self::count() + 1;

--- a/app/Services/RockTheVote.php
+++ b/app/Services/RockTheVote.php
@@ -19,10 +19,10 @@ class RockTheVote
         $config = config('services.rock_the_vote');
 
         $this->client = new \GuzzleHttp\Client([
-            'base_uri' => $config['url'] . '/api/v4/',
+            'base_uri' => $config['url'],
         ]);
 
-        $this->authQuery = [
+        $this->authParams = [
             'partner_API_key' => $config['api_key'],
             'partner_id' => $config['partner_id'],
         ];
@@ -37,8 +37,8 @@ class RockTheVote
      */
     public function createReport($params)
     {
-        $response = $this->client->post('registrant_reports', [
-            'json' => array_merge($params, $this->authQuery),
+        $response = $this->client->post('/api/v4/registrant_reports', [
+            'json' => array_merge($params, $this->authParams),
         ]);
 
         return json_decode($response->getBody()->getContents(), true);
@@ -53,8 +53,8 @@ class RockTheVote
      */
     public function getReportStatusById($id)
     {
-        $response = $this->client->get('registrant_reports/' . $id, [
-            'query' => $this->authQuery,
+        $response = $this->client->get('/api/v4/registrant_reports/' . $id, [
+            'query' => $this->authParams,
         ]);
 
         return json_decode($response->getBody()->getContents(), true);
@@ -69,7 +69,7 @@ class RockTheVote
     public function getReportByUrl($url)
     {
         $response = $this->client->get($url, [
-            'query' => $this->authQuery,
+            'query' => $this->authParams,
         ]);
 
         return $response->getBody();

--- a/app/Services/RockTheVote.php
+++ b/app/Services/RockTheVote.php
@@ -41,7 +41,7 @@ class RockTheVote
             'json' => array_merge($params, $this->authQuery),
         ]);
 
-        return json_decode($response->getBody()->getContents());
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     /**
@@ -57,7 +57,7 @@ class RockTheVote
             'query' => $this->authQuery,
         ]);
 
-        return json_decode($response->getBody()->getContents());
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     /**

--- a/tests/Console/ImportRockTheVoteCommandTest.php
+++ b/tests/Console/ImportRockTheVoteCommandTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Jobs\Imports\CreateRockTheVoteReport;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Bus;
+
+class ImportRockTheVoteCommandTest extends TestCase
+{
+    /** @test */
+    public function it_should_start_job()
+    {
+        Bus::fake();
+
+        Artisan::call('northstar:rock-the-vote');
+
+        Bus::assertDispatched(CreateRockTheVoteReport::class);
+    }
+}

--- a/tests/Jobs/Imports/CreateRockTheVoteReportTest.php
+++ b/tests/Jobs/Imports/CreateRockTheVoteReportTest.php
@@ -15,7 +15,6 @@ class CreateRockTheVoteReportTest extends TestCase
     {
         $this->rockTheVoteMock = $this->mock(\App\Services\RockTheVote::class);
         $this->rockTheVoteMock->shouldReceive('createReport')->andReturn([
-            'report_id' => 17,
             'status' => 'queued',
             'record_count' => null,
             'current_index' => null,

--- a/tests/Jobs/Imports/CreateRockTheVoteReportTest.php
+++ b/tests/Jobs/Imports/CreateRockTheVoteReportTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Jobs\Imports\CreateRockTheVoteReport;
+use App\Models\RockTheVoteReport;
+use Carbon\Carbon;
+
+class CreateRockTheVoteReportTest extends TestCase
+{
+    /**
+     * Test that this job creates a report for the given interval.
+     *
+     * @return void
+     */
+    public function testCreatesReport()
+    {
+        $this->rockTheVoteMock = $this->mock(\App\Services\RockTheVote::class);
+        $this->rockTheVoteMock->shouldReceive('createReport')->andReturn([
+            'report_id' => 17,
+            'status' => 'queued',
+            'record_count' => null,
+            'current_index' => null,
+            'status_url' =>
+                'https://register.rockthevote.com/api/v4/registrant_reports/17',
+            'download_url' => null,
+        ]);
+
+        $since = new Carbon('2021-05-26 10:07:00');
+        $before = new Carbon('2021-05-26 11:37:00');
+
+        CreateRockTheVoteReport::dispatch($since, $before);
+
+        $this->rockTheVoteMock->shouldHaveReceived('createReport')->once();
+
+        $this->assertMysqlDatabaseHas('rock_the_vote_reports', [
+            'id' => 17,
+            'status' => 'queued',
+            'since' => '2021-05-26 10:07:00',
+            'before' => '2021-05-26 11:37:00',
+        ]);
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request migrates Chompy's `CreateRockTheVoteReport` queue job & Artisan command into Northstar. These allow us to request new "reports" from Rock The Vote on an hourly schedule. (We'll then check up on & parse those reports in the `ImportRockTheVoteReport`, to be added later!)

### How should this be reviewed?

I added tests for the job & command in their respective commits. I'll drop some comments in the diff, as well.

### Any background context you want to provide?

🍽️

### Relevant tickets

References [Pivotal #178301632](https://www.pivotaltracker.com/story/show/178301632).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
