### PR TITLE
Include why_participated field in test post rejection logic

### DIFF
--- a/app/Providers/ModelServiceProvider.php
+++ b/app/Providers/ModelServiceProvider.php
@@ -45,6 +45,8 @@ class ModelServiceProvider extends ServiceProvider
                 in_array($post->text, [
                     'Test runscope upload',
                     'caption_ghost_test',
+                ]) || in_array($post->why_participated, [
+                    'why_participated_ghost_test',
                 ])
             ) {
                 // The post will delay for 2 minutes before being rejected to assure tests are running normally


### PR DESCRIPTION
### What's this PR do?

This pull request is a hotfix per [this issue](https://dosomething.slack.com/archives/C09ANFQLA/p1622138986033700) highlighted where test posts are appearing in Campaign inboxes in Northstar admin.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We've removed the caption field from the website, so it might be prudent to revisit this logic (& add some tests!). I'll put a ticket in the freezer for this.

### Relevant tickets
https://dosomething.slack.com/archives/C09ANFQLA/p1622138986033700

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
