### PR TITLE
ImportFileFactory updates

### DIFF
--- a/database/factories/ImportFileFactory.php
+++ b/database/factories/ImportFileFactory.php
@@ -7,14 +7,21 @@ use App\Types\ImportType;
 use Faker\Generator as Faker;
 
 $factory->define(ImportFile::class, function (Faker $faker) {
+    $rowCount = $faker->numberBetween(10, 1250);
+    $importCount = $faker->numberBetween(1, $rowCount);
+
     return [
-        'filepath' => $faker->imageUrl,
+        'user_id' => null,
         'import_type' => $faker->randomElement([
             ImportType::$emailSubscription,
             ImportType::$mutePromotions,
             ImportType::$rockTheVote,
         ]),
-        'row_count' => $faker->numberBetween(10, 1250),
+        'options' => null,
+        'filepath' => $faker->imageUrl,
+        'row_count' => $rowCount,
+        'import_count' => $importCount,
+        'skip_count' => $rowCount - $importCount,
     ];
 });
 
@@ -23,9 +30,9 @@ $factory->state(ImportFile::class, 'email_subscription', [
 ]);
 
 $factory->state(ImportFile::class, 'mute_promotions', [
-    'import_type' => ImportType::$emailSubscription,
+    'import_type' => ImportType::$mutePromotions,
 ]);
 
 $factory->state(ImportFile::class, 'rock_the_vote', [
-    'import_type' => ImportType::$emailSubscription,
+    'import_type' => ImportType::$rockTheVote,
 ]);

--- a/tests/Jobs/Imports/ImportEmailSubscriptionsTest.php
+++ b/tests/Jobs/Imports/ImportEmailSubscriptionsTest.php
@@ -7,6 +7,19 @@ use App\Models\User;
 class ImportEmailSubscriptionsTest extends TestCase
 {
     /**
+     * Make a fake unprocessed import file with no completed or skipped imports.
+     */
+    public function makeFakeUnprocessedImportFile()
+    {
+        return factory(ImportFile::class)
+            ->states('email_subscription')
+            ->create([
+                'import_count' => 0,
+                'skip_count' => 0,
+            ]);
+    }
+
+    /**
      * Test that an existing user record can have email subcriptions updated
      * when importing records.
      */
@@ -14,9 +27,7 @@ class ImportEmailSubscriptionsTest extends TestCase
     {
         $user = factory(User::class)->create();
 
-        $importFile = factory(ImportFile::class)
-            ->states('email_subscription')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportEmailSubscriptions::dispatch(
             ['email' => $user->email, 'first_name' => $user->first_name],
@@ -44,9 +55,7 @@ class ImportEmailSubscriptionsTest extends TestCase
      */
     public function testAddsSubcriptionForNewUser()
     {
-        $importFile = factory(ImportFile::class)
-            ->states('email_subscription')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportEmailSubscriptions::dispatch(
             [
@@ -82,9 +91,7 @@ class ImportEmailSubscriptionsTest extends TestCase
             ->states('email-subscribed-community')
             ->create();
 
-        $importFile = factory(ImportFile::class)
-            ->states('email_subscription')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportEmailSubscriptions::dispatch(
             ['email' => $user->email, 'first_name' => $user->first_name],
@@ -111,9 +118,7 @@ class ImportEmailSubscriptionsTest extends TestCase
      */
     public function testImportTriggersPasswordResetForNewUser()
     {
-        $importFile = factory(ImportFile::class)
-            ->states('email_subscription')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportEmailSubscriptions::dispatch(
             [

--- a/tests/Jobs/Imports/ImportRockTheVoteRecordTest.php
+++ b/tests/Jobs/Imports/ImportRockTheVoteRecordTest.php
@@ -75,6 +75,19 @@ class ImportRockTheVoteRecordTest extends TestCase
     }
 
     /**
+     * Make a fake unprocessed import file with no completed or skipped imports.
+     */
+    public function makeFakeUnprocessedImportFile()
+    {
+        return factory(ImportFile::class)
+            ->states('rock_the_vote')
+            ->create([
+                'import_count' => 0,
+                'skip_count' => 0,
+            ]);
+    }
+
+    /**
      * Make a fake voter registration post action.
      *
      * @return \App\Models\Action
@@ -112,9 +125,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $this->makeFakeVoterRegistrationPostAction();
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -151,9 +162,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $this->makeFakeVoterRegistrationPostAction();
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -184,9 +193,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $this->makeFakeVoterRegistrationPostAction();
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -212,9 +219,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'user_id' => $user->id,
         ]);
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -243,9 +248,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             RockTheVoteRecord::$startedRegistrationFieldName => '555-555-5555',
         ]);
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -283,9 +286,7 @@ class ImportRockTheVoteRecordTest extends TestCase
                 ]),
             ]);
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -335,9 +336,7 @@ class ImportRockTheVoteRecordTest extends TestCase
             'Status' => 'Complete',
         ]);
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 
@@ -368,9 +367,7 @@ class ImportRockTheVoteRecordTest extends TestCase
 
         $this->makeFakeVoterRegistrationPostAction();
 
-        $importFile = factory(ImportFile::class)
-            ->states('rock_the_vote')
-            ->create();
+        $importFile = $this->makeFakeUnprocessedImportFile();
 
         ImportRockTheVoteRecord::dispatch($payload, $importFile);
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `ImportFileFactory` to ensure all fields are included in the factory file to help with seeding records into the database. It also updates the prior tests that utilized the `ImportFileFactory` to ensure that expected values are used to ensure the tests pass.

### How should this be reviewed?

👀 

### Any background context you want to provide?

While working on moving over the Chompy UI I needed to seed a bunch of import file records into the database but only a few of the fields were included in the factory. I added the rest of the fields and ensure they utilize random values that are appropriate for the fields.

However, after having done so, some tests broke, because they expected specific values (for example a `skip_count` of `1`, etc), so I added some helper methods to the test files to allow making an Import File with appropriate values for the tests.

### Relevant tickets

References [Pivotal #177733168](https://www.pivotaltracker.com/story/show/177733168).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
