### PR TITLE
Fix typo'd 'rock_the_vote_reports' column.

### DIFF
--- a/database/migrations/2021_06_02_145900_rename_current_index_column_typo.php
+++ b/database/migrations/2021_06_02_145900_rename_current_index_column_typo.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameCurrentIndexColumnTypo extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rock_the_vote_reports', function (Blueprint $table) {
+            $table->renameColumn('curent_index', 'current_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rock_the_vote_reports', function (Blueprint $table) {
+            $table->renameColumn('current_index', 'curent_index');
+        });
+    }
+}


### PR DESCRIPTION
### What's this PR do?

While working on tests for the `ImportRockTheVoteReport` job, I noticed errors complaining of a missing column:

```
PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'current_index' in 'field list'
```

But when I checked the migration setting up this table, it's right there! Wait… hmm… 🔍 

https://github.com/DoSomething/northstar/blob/01129a9c7812958722e4c50be4d4fe4b8af3d315/database/migrations/2021_04_15_000001_create_rock_the_vote_reports_table.php#L22

### How should this be reviewed?

Did we spell the word "current" correctly this time? 🙈

### Any background context you want to provide?

📝

### Relevant tickets

References [Pivotal #178301643](https://www.pivotaltracker.com/story/show/178301643).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
