### PR TITLE
Adds documentation on user optional fields

### DIFF
--- a/documentation/endpoints/v2/users.md
+++ b/documentation/endpoints/v2/users.md
@@ -232,13 +232,17 @@ Fetching a user requires either the `admin` scope, or an "admin" or "staff" role
 GET /v2/users/:user_id
 ```
 
+**Additional Query Parameters:**
+
+- `includes`: A list of [optional fields](../../features/user-optional-fields.md) to include in the response. e.g. `/v2/users/123?include=email,mobile`.
+
 <details>
 <summary><strong>Example Request</strong></summary>
 ```sh
 curl -X GET \
   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Accept: application/json"
-  https://northstar.dosomething.org/v2/users/5430e850dt8hbc541c37tt3d
+  https://northstar.dosomething.org/v2/users/5430e850dt8hbc541c37tt3d?include=email,mobile,last_name,addr_street1,addr_street2,birthdate
 ```
 </details>
 

--- a/documentation/features/user-optional-fields.md
+++ b/documentation/features/user-optional-fields.md
@@ -1,0 +1,15 @@
+# User - Optional Fields
+
+## Overview
+
+Following an [Access Control & Auditing](https://docs.google.com/document/d/1OclKWYEtjo0LTI9DzKaVG1dEBY6kfAEEgYZVRzSlD7s/edit) audit, [we implemented](https://github.com/DoSomething/northstar/pull/907) a security feature on the `GET` `v2/users/:id` endpoint to ensure that any fields marked as "sensitive" (fields containing personally identifiable information) would need to be explicitly queried so that we can log the request.
+
+Fields are marked as "sensitive" via the `$sensitive` property on the User model.
+
+## Usage
+
+To include such fields in the response, the request should include an `include` query parameter with a list of optional fields to include.
+
+For example, if we wanted to query for the user's street address, we might request:
+
+`v2/users/5571f4f5a59dbf3c7a8b4569?include=addr_street1,addr_street2`


### PR DESCRIPTION
### What's this PR do?

This pull request adds some documentation on the "optional fields" feature on the `/v2/users/:id` endpoint.

### How should this be reviewed?
👁️ 

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #174405268](https://www.pivotaltracker.com/story/show/174405268).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
