### PR TITLE
Enable serving our dev docs.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,11 @@ location / {
     try_files $uri $uri/ /index.php?$query_string;
 }
 
+# Allow our application to serve our development docs static site.
+location /dev {
+  index index.html;
+}
+
 # Allow our application to serve '.well-known' routes.
 location ^~ /.well-known/ {
     allow all;


### PR DESCRIPTION
### What's this PR do?

This pull request attempts to update the Nginx config to see if it will resolve the issues serving the static files for the docs via Heroku.

### How should this be reviewed?

👀 

### Any background context you want to provide?

While the docs are working on QA after deploying the PR to enable Docusaurus, hitting the `/dev/docs` URL results in a `403 Forbidden` error, but if you add `/dev/docs/index.html` to the URL they work. We believe this is just an issue with how Nginx is set up to serve files and just need to indicate that we want to serve `index.html` files.

### Relevant tickets

References [Pivotal #178614470](https://www.pivotaltracker.com/story/show/178614470).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.