### PR TITLE
Extract recounts into a queued job.

### DIFF
--- a/app/Jobs/RefreshCampaignPostCounts.php
+++ b/app/Jobs/RefreshCampaignPostCounts.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Campaign;
+use App\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class RefreshCampaignPostCounts implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The campaign we're refreshing.
+     *
+     * @var Campaign
+     */
+    protected $campaign;
+
+    /**
+     * When was this job dispatched?
+     *
+     * @var \Carbon\Carbon
+     */
+    protected $dispatchedAt;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Campaign $campaign)
+    {
+        $this->campaign = $campaign;
+        $this->dispatchedAt = now();
+
+        $this->onQueue(config('queue.names.low'));
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // If we've already updated this campaign after this job was dispatched,
+        // we can probably skip recounting to reduce unnecessary database load:
+        if ($this->campaign->updated_at > $this->dispatchedAt) {
+            return;
+        }
+
+        $accepted_count = Post::getPostCount($this->campaign, 'accepted');
+        $pending_count = Post::getPostCount($this->campaign, 'pending');
+
+        $this->campaign->pending_count = $pending_count;
+        $this->campaign->accepted_count = $accepted_count;
+
+        info('Recalculated post counts', [
+            'campaign_id' => $this->campaign->id,
+            'accepted_count' => $accepted_count,
+            'pending_count' => $pending_count,
+        ]);
+
+        $this->campaign->save();
+    }
+}

--- a/app/Jobs/RefreshCampaignPostCounts.php
+++ b/app/Jobs/RefreshCampaignPostCounts.php
@@ -4,16 +4,9 @@ namespace App\Jobs;
 
 use App\Models\Campaign;
 use App\Models\Post;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 
-class RefreshCampaignPostCounts implements ShouldQueue
+class RefreshCampaignPostCounts extends Job
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
      * The campaign we're refreshing.
      *

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -101,17 +101,6 @@ class Campaign extends Model
     }
 
     /**
-     * Run a quick 'COUNT(*)' query to get the count of pending and accepted
-     * posts for this campaign (so we can use this efficiently later).
-     */
-    public function refreshCounts()
-    {
-        $this->pending_count = Post::getPostCount($this, 'pending');
-        $this->accepted_count = Post::getPostCount($this, 'accepted');
-        $this->save();
-    }
-
-    /**
      * Scope a query to only include "open" campaigns.
      */
     public function scopeWhereOpen($query)

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories;
 
 use App\Auth\Scope;
+use App\Jobs\RefreshCampaignPostCounts;
 use App\Models\Action;
 use App\Models\Post;
 use App\Models\Review;
@@ -216,7 +217,7 @@ class PostRepository
         $post->save();
 
         // Update the "counter cache" on the Post Campaign:
-        $post->campaign->refreshCounts();
+        RefreshCampaignPostCounts::dispatch($post->campaign);
 
         return $post;
     }


### PR DESCRIPTION
### What's this PR do?

This pull request extracts the database query to recount accepted/pending posts into a queue job. This takes this hefty query off of the main web thread & attempts to reduce "over-calculating" this when we don't need to.

### How should this be reviewed?

I'll add some notes in the diff!

### Any background context you want to provide?

Ideally, we'll also want to find how we can make this query less intensive (likely by adding a more appropriate index than the one the query planner is currently going with). However, that's proving to be tricker than I'd thought it would be & this gets us a quick fix! We'll revisit the query itself once we've migrated over to PostgreSQL.

### Relevant tickets

References [Pivotal #178612113](https://www.pivotaltracker.com/story/show/178612113).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
