### PR TITLE
Update listed frequency for The Boost

### DIFF
--- a/resources/views/profiles/subscriptions/edit.blade.php
+++ b/resources/views/profiles/subscriptions/edit.blade.php
@@ -54,7 +54,7 @@
                 <input type="checkbox" name="email_subscription_topics[3]" id="lifestyle" value="lifestyle" {{in_array("lifestyle", (count($errors) ? old('email_subscription_topics') : $user->email_subscription_topics) ?: []) ? "checked" : null}} />
                 <span class="option__indicator"></span>
                 <span class="font-bold field-label">The Boost</span>
-                <span class="footnote italic">Sent weekly on Thursdays.</span><br > 
+                <span class="footnote italic">Sent biweekly on Thursdays.</span><br > 
                 <p class="footnote">Our weekly cause and lifestyle newsletter. You’ll receive one article (like an inspiring story of a young changemaker or a how-to volunteering guide), plus one related action.</p>
             </label>
         </div>


### PR DESCRIPTION
### What's this PR do?

This pull request just switches "weekly" to "biweekly" in the Boost description.

Updated:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/4240292/123990276-79f2e400-d97e-11eb-9518-7f64db133872.png">


### How should this be reviewed?

Did I miss any other references to the Boost timing?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #178369775](https://www.pivotaltracker.com/n/projects/2401401/stories/178369775).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
