### PR TITLE
Drop 'events' table.

### DIFF
--- a/database/migrations/2021_07_07_155736_drop_events_table_again.php
+++ b/database/migrations/2021_07_07_155736_drop_events_table_again.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropEventsTableAgain extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::drop('events');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('eventable');
+            $table->text('content');
+
+            $table
+                ->string('user')
+                ->nullable()
+                ->index()
+                ->comment('Northstar ID of the user who did the action');
+
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request drops Northstar's unused `events` table (which we stopped writing to in lucky #1234).

### How should this be reviewed?

I added this as a `DropEventsTableAgain` migration in 56d7045. Why "again"? We dropped this [once before](https://github.com/DoSomething/rogue/commit/a9bc822d1783440663151aa57a3707abe7bae17f#diff-e15c325c9024bb1441437113e36a77c940307c2e3f453eb183c60be949d35b1d) in 2017!

The "down" migration recreates the (empty) table if necessary, based on current schema.

### Any background context you want to provide?

This table is _huge_ & not used anywhere. Dropping it will make our PostgreSQL migration easier!

### Relevant tickets

References [Pivotal #178201917](https://www.pivotaltracker.com/story/show/178201917).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] If new attributes were added to users, there is a corresponding PR to surface these in Aurora.
- [ ] If new attributes were added to users, then the data team already knows about these changes.
